### PR TITLE
Formvalidation

### DIFF
--- a/View/View.php
+++ b/View/View.php
@@ -256,9 +256,11 @@ class View implements ContainerAwareInterface
                 }
             }
         }
-
-        $form = $parameters[$this->formKey];
-
+        
+        if(isset($this->formKey)){
+            $form = $parameters[$this->formKey];
+        }
+        
         //Check if the form is valid, return an appropriate response code
         if (isset($form) && $form->isBound() && !$form->isValid()) {
             return $this->failedValidation;


### PR DESCRIPTION
We were getting a 400 http code on our 'new' and 'show' pages (when using `failed_validation: HTTP_BAD_REQUEST` option).  We figured that this was is because the `View::getStatusCodeFromParameters` is checking the validity of an unbound form (which will always fail).

Also did a bit of refactoring of the function.
