### PR TITLE
XmlFileLoader overload refactor

### DIFF
--- a/Routing/Loader/RestXmlCollectionLoader.php
+++ b/Routing/Loader/RestXmlCollectionLoader.php
@@ -16,7 +16,6 @@ use FOS\RestBundle\Routing\RestRouteCollection;
  * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
  * (c) Konstantin Kudryashov <ever.zet@gmail.com>
  * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
- * (c) Donald Tyler <chekote69@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
@@ -24,6 +23,8 @@ use FOS\RestBundle\Routing\RestRouteCollection;
 
 /**
  * RestXmlCollectionLoader XML file collections loader.
+ *
+ * @author Donald Tyler <chekote69@gmail.com>
  */
 class RestXmlCollectionLoader extends XmlFileLoader
 {


### PR DESCRIPTION
Refactored RestXMLCollectionLoader to reduce code duplication. This pull is dependent on symfony/symfony#912 being accepted
