### PR TITLE
Fixed #42 in the first instance.

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -19,12 +19,7 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="controller_name_converter" />
             <argument type="service">
-                <service class="Doctrine\Common\Annotations\AnnotationReader">
-                    <call method="setAnnotationNamespaceAlias">
-                        <argument>%fos_rest.routing.loader.controller.annotations_namespace%</argument>
-                        <argument>rest</argument>
-                    </call>
-                </service>
+                <service class="Doctrine\Common\Annotations\AnnotationReader" />
             </argument>
             <tag name="routing.loader" />
         </service>


### PR DESCRIPTION
As commented in the issue itself, removing the parameters lets RestBundle work again.
