### PR TITLE
Annotation Listener test confirming $vars is an array.

### DIFF
--- a/View/AnnotationTemplateListener.php
+++ b/View/AnnotationTemplateListener.php
@@ -50,8 +50,10 @@ class AnnotationTemplateListener extends BaseAnnotationTemplateListener
             }
 
             $parameters = array();
-            foreach ($vars as $var) {
-                $parameters[$var] = $request->attributes->get($var);
+            if (is_array($vars)) {
+                foreach ($vars as $var) {
+                    $parameters[$var] = $request->attributes->get($var);
+                }
             }
 
             $view->setParameters($parameters);


### PR DESCRIPTION
Just discovered a time when $vars might not be an array which throws a notice.
