### PR TITLE
Enabled 'edit' and 'remove' as additional HATEOAS GET controllers in addition to 'new'

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,10 +306,10 @@ Shown as `UsersController::putUserAction()` above.
 * **delete** - this action accepts *DELETE* requests to the url */resources/{id}* and deltes a single resource for this
 type. Shown as `UsersController::deleteUserAction()` above.
 
-### HATEOS Actions
+### HATEOAS Actions
 
-HATEOS, or Hypermedia as the Engine of Application State, is an aspect of REST which allows clients to interact with the
-REST service through hypertext - most commonly through an HTML page. There are 3 HATEOS actions routings that are
+HATEOAS, or Hypermedia as the Engine of Application State, is an aspect of REST which allows clients to interact with the
+REST service through hypertext - most commonly through an HTML page. There are 3 HATEOAS actions routings that are
 supported by this bundle:
 
 * **new** - A hypermedia representation that acts as the engine to *POST*. Typically this is a form that allows the client

--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -35,7 +35,7 @@ class RestRouteLoader implements LoaderInterface
     protected $container;
     protected $parser;
     protected $availableHTTPMethods;
-    protected $availableHateosActions; 
+    protected $availableHateoasActions;
     protected $annotationClasses;
     protected $parents = array();
     protected $prefix;
@@ -64,7 +64,7 @@ class RestRouteLoader implements LoaderInterface
         $this->reader               = $reader;
         $this->defaultFormat        = $defaultFormat;
         $this->availableHTTPMethods = array('get', 'post', 'put', 'patch', 'delete', 'head');
-        $this->availableHateosActions = array('new', 'edit', 'remove');
+        $this->availableHateaosActions = array('new', 'edit', 'remove');
         $this->annotationClasses    = array(
             'FOS\RestBundle\Controller\Annotations\Route',
             'FOS\RestBundle\Controller\Annotations\Get',
@@ -253,7 +253,7 @@ class RestRouteLoader implements LoaderInterface
                     $urlParts[] = $httpMethod;
 
                     // allow hypertext as the engine of application state
-                    if (in_array($httpMethod, $this->availableHateosActions)) {
+                    if (in_array($httpMethod, $this->availableHateaosActions)) {
                         $httpMethod = 'get';
                     } else {
                         //custom object

--- a/Tests/Fixtures/Controller/UserTopicCommentsController.php
+++ b/Tests/Fixtures/Controller/UserTopicCommentsController.php
@@ -24,7 +24,7 @@ class UserTopicCommentsController extends Controller
     public function banCommentAction($slug, $title, $id)
     {} // [PUT] /users/{slug}/topics/{title}/comments/{id}/ban
 
-    // HATEOS controllers below
+    // HATEOAS actions below
 
     public function newCommentsAction($slug, $title)
     {} // [GET] /users/{slug}/topics/{title}/comments/new

--- a/Tests/Fixtures/Controller/UserTopicsController.php
+++ b/Tests/Fixtures/Controller/UserTopicsController.php
@@ -27,7 +27,7 @@ class UserTopicsController extends Controller
     public function hideTopicAction($slug, $title)
     {} // [PUT] /users/{slug}/topics/{title}/hide
 
-    // HATEOS controllers below
+    // HATEOAS actions below
 
     public function newTopicsAction($slug)
     {} // [GET] /users/{slug}/topics/new

--- a/Tests/Fixtures/Controller/UsersController.php
+++ b/Tests/Fixtures/Controller/UsersController.php
@@ -58,7 +58,7 @@ class UsersController extends Controller
     public function check_usernameUsersAction()
     {} // [GET] /users/check_username
 
-    // HATEOS controllers below
+    // HATEOAS actions below
 
     public function newUsersAction()
     {

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -84,11 +84,11 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
-     * Test that HATEOS controllers exist and are registered as GET methods
+     * Test that HATEOAS controllers exist and are registered as GET methods
      * 
      * @see https://github.com/FriendsOfSymfony/RestBundle/issues/67
      */
-    public function testHateosActions()
+    public function testHateoasActions()
     {
         $expectedMethod = 'GET';
         $collection = $this->loadFromControllerFixture('UsersController');


### PR DESCRIPTION
Added based on http://framework.zend.com/wiki/display/ZFPROP/Zend_Controller_Router_Route_Rest+-+Luke+Crouch?focusedCommentId=8947336#comment-8947336 and other research I've done on modern REST and experience from the trenches. 

All tests passing. Custom PUT objects and Resource Collections still working.

@see https://github.com/FriendsOfSymfony/RestBundle/issues/67
