### PR TITLE
syntax error in submodule add for JMS\SerializerBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Note: Temporarily please use this fork https://github.com/lsmith77/SerializerBun
 
 This requires adding the JMSSerializerBundle to you vendors:
 
-    $ git submodule add git://github.com/schmittjoh/SerializerBundle.git vendor/bundles/JMS/JMSSerializerBundle
+    $ git submodule add git://github.com/schmittjoh/SerializerBundle.git vendor/bundles/JMS/SerializerBundle
 
 Finally enable the JMSSerializerBundle support in the RestBundle:
 


### PR DESCRIPTION
should be `JMS\SerializerBundle` not `JMS\JMSSerializerBundle`.
