### PR TITLE
renamed 'HATEOAS Actions' to 'Conventional Actions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,10 +316,10 @@ of resources (e.g. apply batch modifications to subset of resources). Shown as `
 This action also accepts *PATCH* requests to the url */resources/{id}* and is supposed to partially modify the resource. 
 Shown as `UsersController::patchUserAction()` above.
 
-### HATEOAS Actions
+### Conventional Actions
 
 HATEOAS, or Hypermedia as the Engine of Application State, is an aspect of REST which allows clients to interact with the
-REST service through hypertext - most commonly through an HTML page. There are 3 HATEOAS actions routings that are
+REST service with hypertext - most commonly through an HTML page. There are 3 Conventional Action routings that are
 supported by this bundle:
 
 * **new** - A hypermedia representation that acts as the engine to *POST*. Typically this is a form that allows the client
@@ -327,7 +327,7 @@ to *POST* a new resource. Shown as `UsersController::newUsersAction()` above.
 * **edit** - A hypermedia representation that acts as the engine to *PUT*. Typically this is a form that allows the client
 to *PUT*, or update, an existing resource. Shown as `UsersController::editUserAction()` above.
 * **remove** - A hypermedia representation that acts as the engine to *DELETE*. Typically this is a form that allows the
-client to *DELETE* an existing resource. Commonly a confirmation form. Shown as `UsersController::deleteUserAction()` above.
+client to *DELETE* an existing resource. Commonly a confirmation form. Shown as `UsersController::removeUserAction()` above.
 
 ### Custom PUT Actions
 

--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -35,7 +35,7 @@ class RestRouteLoader implements LoaderInterface
     protected $container;
     protected $parser;
     protected $availableHTTPMethods;
-    protected $availableHateoasActions;
+    protected $availableConventionalActions;
     protected $annotationClasses;
     protected $parents = array();
     protected $prefix;
@@ -64,7 +64,7 @@ class RestRouteLoader implements LoaderInterface
         $this->reader               = $reader;
         $this->defaultFormat        = $defaultFormat;
         $this->availableHTTPMethods = array('get', 'post', 'put', 'patch', 'delete', 'head');
-        $this->availableHateaosActions = array('new', 'edit', 'remove');
+        $this->availableConventionalActions = array('new', 'edit', 'remove');
         $this->annotationClasses    = array(
             'FOS\RestBundle\Controller\Annotations\Route',
             'FOS\RestBundle\Controller\Annotations\Get',
@@ -253,7 +253,8 @@ class RestRouteLoader implements LoaderInterface
                     $urlParts[] = $httpMethod;
 
                     // allow hypertext as the engine of application state
-                    if (in_array($httpMethod, $this->availableHateaosActions)) {
+                    // through conventional GET actions
+                    if (in_array($httpMethod, $this->availableConventionalActions)) {
                         $httpMethod = 'get';
                     } else {
                         //custom object

--- a/Tests/Fixtures/Controller/UserTopicCommentsController.php
+++ b/Tests/Fixtures/Controller/UserTopicCommentsController.php
@@ -24,7 +24,7 @@ class UserTopicCommentsController extends Controller
     public function banCommentAction($slug, $title, $id)
     {} // [PUT] /users/{slug}/topics/{title}/comments/{id}/ban
 
-    // HATEOAS actions below
+    // conventional HATEOAS actions below
 
     public function newCommentsAction($slug, $title)
     {} // [GET] /users/{slug}/topics/{title}/comments/new

--- a/Tests/Fixtures/Controller/UserTopicsController.php
+++ b/Tests/Fixtures/Controller/UserTopicsController.php
@@ -27,7 +27,7 @@ class UserTopicsController extends Controller
     public function hideTopicAction($slug, $title)
     {} // [PUT] /users/{slug}/topics/{title}/hide
 
-    // HATEOAS actions below
+    // conventional HATEOAS actions below
 
     public function newTopicsAction($slug)
     {} // [GET] /users/{slug}/topics/new

--- a/Tests/Fixtures/Controller/UsersController.php
+++ b/Tests/Fixtures/Controller/UsersController.php
@@ -58,7 +58,7 @@ class UsersController extends Controller
     public function check_usernameUsersAction()
     {} // [GET] /users/check_username
 
-    // HATEOAS actions below
+    // conventional HATEOAS actions below
 
     public function newUsersAction()
     {

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -84,11 +84,11 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
-     * Test that HATEOAS controllers exist and are registered as GET methods
+     * Test that conventional actions exist and are registered as GET methods
      * 
      * @see https://github.com/FriendsOfSymfony/RestBundle/issues/67
      */
-    public function testHateoasActions()
+    public function testConventionalActions()
     {
         $expectedMethod = 'GET';
         $collection = $this->loadFromControllerFixture('UsersController');


### PR DESCRIPTION
HATEOAS actions were confusing in the readme for Rest die-hards & noobs because simply having a few conventionalized GET actions does not fully encapsulate the meaning of HATEOAS. Rather, a large chunk has to do with providing `<link>` tags therein. Simplified by calling them **Conventional Actions** instead.

see: https://github.com/FriendsOfSymfony/RestBundle/issues/76
