### PR TITLE
[BodyListener] No 'Content-Type' header then fallback to request '_format'

### DIFF
--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -52,9 +52,11 @@ class BodyListener
         if (0 == count($request->request->all())
             && in_array($request->getMethod(), array('POST', 'PUT', 'PATCH', 'DELETE'))
         ) {
-            $format = $request->getFormat($request->headers->get('Content-Type'));
+            $mimeType = $request->headers->get('Content-Type') ?: $request->getMimeType($request->getRequestFormat());
+
+            $format = $request->getFormat($mimeType);
             if (null === $format) {
-                $format = $request->getRequestFormat();
+                return;
             }
 
             if (!$this->serializer->supportsDecoding($format)) {

--- a/Tests/EventListener/RequestListenerTest.php
+++ b/Tests/EventListener/RequestListenerTest.php
@@ -68,7 +68,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
            'Empty GET request' => array(new Request(array(), array(), array(), array(), array(), array(), 'foo'), 'GET', 'application/json', array()),
            'POST request with parameters' => array(new Request(array(), array('bar'), array(), array(), array(), array(), 'foo'), 'POST', 'application/json', array('bar')),
            'POST request with unallowed format' => array(new Request(array(), array(), array(), array(), array(), array(), 'foo'), 'POST', 'application/fooformat', array()),
+           'POST request with no Content-Type' => array(new Request(array(), array(), array('_format' => 'json'), array(), array(), array(), 'foo'), 'POST', null, array('foo')),
         );
     }
-    
 }


### PR DESCRIPTION
See https://github.com/FriendsOfSymfony/RestBundle/issues/86
