### PR TITLE
Added checking if format template before adding default vars

### DIFF
--- a/EventListener/ViewResponseListener.php
+++ b/EventListener/ViewResponseListener.php
@@ -90,24 +90,24 @@ class ViewResponseListener extends TemplateListener
             $vars = $request->attributes->get('_template_default_vars');
         }
 
-        if (!empty($vars)) {
-            $parameters = $view->getData();
-            if (null !== $parameters && !is_array($parameters)) {
-                throw new \RuntimeException('View data must be an array if using a templating aware format.');
-            }
-
-            $parameters = (array)$parameters;
-            foreach ($vars as $var) {
-                if (!array_key_exists($var, $parameters)) {
-                    $parameters[$var] = $request->attributes->get($var);
-                }
-            }
-            $view->setData($parameters);
-        }
-
         $viewHandler = $this->container->get('fos_rest.view_handler');
 
         if ($viewHandler->isFormatTemplating($view->getFormat())) {
+            if (!empty($vars)) {
+                $parameters = $view->getData();
+                if (null !== $parameters && !is_array($parameters)) {
+                    throw new \RuntimeException('View data must be an array if using a templating aware format.');
+                }
+
+                $parameters = (array)$parameters;
+                foreach ($vars as $var) {
+                    if (!array_key_exists($var, $parameters)) {
+                        $parameters[$var] = $request->attributes->get($var);
+                    }
+                }
+                $view->setData($parameters);
+            }
+
             $template = $request->attributes->get('_template');
             if ($template) {
                 if ($template instanceof TemplateReference) {

--- a/Tests/EventListener/ViewResponseListenerTest.php
+++ b/Tests/EventListener/ViewResponseListenerTest.php
@@ -144,7 +144,18 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('_template_vars', true);
         $request->attributes->set('_template_default_vars', array('foo', 'halli'));
 
+        $viewHandler = $this->getMock('\FOS\RestBundle\View\ViewHandlerInterface');
+        $viewHandler->expects($this->once())
+            ->method('isFormatTemplating')
+            ->with('html')
+            ->will($this->returnValue(true));
+
         $container = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Container')->disableOriginalConstructor()->getMock();
+        $container->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('fos_rest.view_handler'))
+            ->will($this->returnValue($viewHandler));
+
         $container->expects($this->once())
             ->method('getParameter')
             ->with('fos_rest.view_response_listener.force_view')


### PR DESCRIPTION
Using the view listener was throwing an exception to say that an array was required for a templating aware format, whenever there are arguments for the controller action, regardless of whether the format was templating aware or not.
