### PR TITLE
Fixed small warning-generating omission

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -266,7 +266,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
         $data = $view->getData();
 
         if (!is_array($data) || array_key_exists(0, $data)) {
-            if (array_key_exists(0, $data)) {
+            if (is_array($data) && array_key_exists(0, $data)) {
                 $data = reset($data);
             }
 


### PR DESCRIPTION
array_key_exists was used without first checking that the variable was an array
