### PR TITLE
LoaderResolverInterface -> LoaderResolver

### DIFF
--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -14,7 +14,7 @@ namespace FOS\RestBundle\Routing\Loader;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser,
     Symfony\Component\DependencyInjection\ContainerInterface,
     Symfony\Component\Config\Loader\LoaderInterface,
-    Symfony\Component\Config\Loader\LoaderResolverInterface,
+    Symfony\Component\Config\Loader\LoaderResolver,
     Symfony\Component\HttpFoundation\Request;
 
 use FOS\RestBundle\Routing\Loader\Reader\RestControllerReader;
@@ -97,7 +97,7 @@ class RestRouteLoader implements LoaderInterface
     /**
      * Gets the loader resolver.
      *
-     * @return LoaderResolverInterface A LoaderResolver instance
+     * @return LoaderResolver A LoaderResolver instance
      */
     public function getResolver()
     {
@@ -106,9 +106,9 @@ class RestRouteLoader implements LoaderInterface
     /**
      * Sets the loader resolver.
      *
-     * @param LoaderResolverInterface $resolver A LoaderResolver instance
+     * @param LoaderResolver $resolver A LoaderResolver instance
      */
-    public function setResolver(LoaderResolverInterface $resolver)
+    public function setResolver(LoaderResolver $resolver)
     {
     }
 


### PR DESCRIPTION
PHP Fatal error:  Declaration of FOS\RestBundle\Routing\Loader\RestRouteLoader::setResolver() must be compatible with that of Symfony\Component\Config\Loader\LoaderInterface::setResolver() in /var/www/vhosts/encoding-dev.escapestudios.com/encoding/vendor/bundles/FOS/RestBundle/Routing/Loader/RestRouteLoader.php on line 29

Make use of LoaderResolver rather than LoaderResolverInterface
