### PR TITLE
Fix call to non-existent method

### DIFF
--- a/Routing/Loader/RestRouteProcessor.php
+++ b/Routing/Loader/RestRouteProcessor.php
@@ -50,7 +50,7 @@ class RestRouteProcessor
         $loader = $loader->resolve($resource, $type);
 
         if ($loader instanceof FileLoader && null !== $currentDir) {
-            $resource = $this->getAbsolutePath($resource, $currentDir);
+            $resource = $loader->getLocator()->locate($resource, $currentDir);
         } elseif ($loader instanceof RestRouteLoader) {
             $loader->getControllerReader()->getActionReader()->setParents($parents);
             $loader->getControllerReader()->getActionReader()->setRoutePrefix($routePrefix);


### PR DESCRIPTION
I'm fairly certain this is an appropriate fix for this; I was getting `Fatal error: Call to undefined method FOS\RestBundle\Routing\Loader\RestRouteProcessor::getAbsolutePath()` when attempting to import a bundle's routing.yml file from `app/config/routing.yml` with `type:rest`

This change causes it to work as expected.
