### PR TITLE
Updated autoload instructions for 0.6

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -56,7 +56,8 @@ Add the `FOS` namespace to your autoloader:
 
 $loader->registerNamespaces(array(
     // ...
-    'FOS' => array(__DIR__.'/../vendor/bundles', __DIR__.'/../vendor/fos'),
+    'FOS\\Rest'        => __DIR__.'/../vendor/fos',
+    'FOS'              => __DIR__.'/../vendor/bundles',
 ));
 ```
 


### PR DESCRIPTION
I updated the "Configure the autoloader" section for 0.6 instalation, to make it work with Symfony 2.0.x.

Before:

``` php
<?php
// app/autoload.php

$loader->registerNamespaces(array(
    // ...
    'FOS' => array(__DIR__.'/../vendor/bundles', __DIR__.'/../vendor/fos'),
));
```

After:

``` php
<?php
// app/autoload.php

$loader->registerNamespaces(array(
    // ...
    'FOS\\Rest'        => __DIR__.'/../vendor/fos',
    'FOS'              => __DIR__.'/../vendor/bundles',
));
```

Without the changes I was getting this error:

Fatal error: Class 'FOS\Rest\Util\Codes' not found in .../vendor/bundles/FOS/RestBundle/DependencyInjection/Configuration.php on line 101
