### PR TITLE
Add media as uncountable

### DIFF
--- a/Util/Pluralization.php
+++ b/Util/Pluralization.php
@@ -49,7 +49,7 @@ class Pluralization
             '/$/'                       => 's'
         );
         $uncountables = array(
-            'equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep'
+            'equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep', 'media'
         );
         $irregulars = array(
             'person'  => 'people',
@@ -118,7 +118,7 @@ class Pluralization
             '/s$/i'                 => '',
         );
         $uncountables = array(
-            'equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep'
+            'equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep', 'media'
         );
         $irregulars = array(
             'person'  => 'people',


### PR DESCRIPTION
I'm working on an API that deals with media such as videos and commercials. Thus, I need the word "media" to be handled as an uncountable.

It could be argued that media is the plural form of medium, but I believe that is a less common usage these days, while my case and "social media" as an uncountable is more common.
