### PR TITLE
fixed codeStyle: docblock comment indentation

### DIFF
--- a/EventListener/FormatListener.php
+++ b/EventListener/FormatListener.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent,
 use FOS\Rest\Util\Codes,
     FOS\Rest\Util\FormatNegotiatorInterface;
 
-    /**
+/**
  * This listener handles Accept header format negotiations.
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>


### PR DESCRIPTION
tiny fix of last @lsmith77 [commit](https://github.com/FriendsOfSymfony/FOSRestBundle/commit/c4817fa0d94a48d1df7ec0760fa8107317a06077#L0R21)
