### PR TITLE
Make getSerializer public

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -156,7 +156,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
      *
      * @return JMS\SerializerBundle\Serializer\SerializerInterface
      */
-    protected function getSerializer()
+    public function getSerializer()
     {
         return $this->container->get('fos_rest.serializer');
     }


### PR DESCRIPTION
With the increasing features and complexity of the serializer, it's important that one has direct access to it. 

This PR makes therefore getSerializer public. I don't see a reason, why not to do this.
