### PR TITLE
use interface method instate of monolog method

### DIFF
--- a/Resources/doc/examples/RssHandler.php
+++ b/Resources/doc/examples/RssHandler.php
@@ -58,7 +58,7 @@ class RssHandler
             $code = Codes::HTTP_OK;
         } catch (\Exception $e) {
             if ($this->logger) {
-                $this->logger->addError($e);
+                $this->logger->err($e);
             }
 
             $content = sprintf("%s:<br/><pre>%s</pre>", $e->getMessage(), $e->getTraceAsString());


### PR DESCRIPTION
The Symfony\Component\HttpKernel\Log\LoggerInterface defines only err method not a addError method.
