### PR TITLE
Allow to use POST instead of PATCH for custom methods

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -51,6 +51,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('default_format')->defaultNull()->end()
+                        ->booleanNode('use_patch')->defaultTrue()->end()
                     ->end()
                 ->end()
                 ->arrayNode('service')

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -90,6 +90,7 @@ class FOSRestExtension extends Extension
         }
 
         $container->setParameter($this->getAlias().'.routing.loader.default_format', $config['routing_loader']['default_format']);
+        $container->setParameter($this->getAlias().'.routing.loader.use_patch', $config['routing_loader']['use_patch']);
 
         foreach ($config['exception']['codes'] as $exception => $code) {
             if (!is_numeric($code)) {
@@ -143,7 +144,7 @@ class FOSRestExtension extends Extension
      * Check if an exception is loadable.
      *
      * @param string $exception class to test
-     * @throws InvalidArgumentException if the class was not found.
+     * @throws \InvalidArgumentException if the class was not found.
      */
     private function testExceptionExists($exception)
     {

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -48,6 +48,7 @@
         <service id="fos_rest.routing.loader.reader.action" class="%fos_rest.routing.loader.reader.action.class%">
             <argument type="service" id="annotation_reader" />
             <argument type="service" id="fos_rest.request.query_fetcher.reader.query_param" />
+            <argument>%fos_rest.routing.loader.use_patch%</argument>
         </service>
 
     </services>

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.md
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.md
@@ -123,7 +123,7 @@ Shown as ``UsersController::putUserAction()`` above.
 type. Shown as ``UsersController::deleteUserAction()`` above.
 * **patch** - this action accepts *PATCH* requests to the url */resources* and is supposed to partially modify collection
 of resources (e.g. apply batch modifications to subset of resources). Shown as ``UsersController::patchUsersAction()`` above.
-This action also accepts *PATCH* requests to the url */resources/{id}* and is supposed to partially modify the resource. 
+This action also accepts *PATCH* requests to the url */resources/{id}* and is supposed to partially modify the resource.
 Shown as ``UsersController::patchUserAction()`` above.
 
 ### Conventional Actions
@@ -142,18 +142,26 @@ client to *DELETE* an existing resource. Commonly a confirmation form. Shown as 
 ### Custom PATCH Actions
 
 All actions that do not match the ones listed in the sections above will register as a *PATCH* action. In the controller
-shown above, these actions are ``UsersController::lockUserAction()``, ``UsersController::banUserAction()`` and 
+shown above, these actions are ``UsersController::lockUserAction()``, ``UsersController::banUserAction()`` and
 ``UsersController::voteUserCommentAction()``. You could just as easily create a method called
 ``UsersController::promoteUserAction()`` which would take a *PATCH* request to the url */users/{slug}/promote*.
 This allows for easy updating of aspects of a resource, without having to deal with the resource as a whole at
 the standard *PATCH* or *PUT* endpoint.
+
+**NOTE:** If you want to use *POST* instead of *PATCH* for custom actions, simply change your configuration:
+
+```yaml
+fos_rest:
+    routing_loader:
+        use_patch: false
+```
 
 ### Sub-Resource Actions
 
 Of course it's possible and common to have sub or child resources. They are easily defined within the same controller by
 following the naming convention ``ResourceController::actionResourceSubResource()`` - as seen in the example above with
 ``UsersController::getUserCommentsAction()``. This is a good strategy to follow when the child resource needs the parent
-resource's ID in order to look up itself. 
+resource's ID in order to look up itself.
 
 ## That was it!
 [Return to the index](index.md) or continue reading about [Automatic route generation: multiple RESTful controllers](6-automatic-route-generation_multiple-restful-controllers.md).

--- a/Resources/doc/configuration-reference.md
+++ b/Resources/doc/configuration-reference.md
@@ -5,6 +5,7 @@ Full default configuration
 fos_rest:
     routing_loader:
         default_format:       ~
+        use_patch:            true
     service:
         router:               router
         templating:           templating

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -35,16 +35,20 @@ class RestActionReader
 
     private $availableHTTPMethods = array('get', 'post', 'put', 'patch', 'delete', 'head');
     private $availableConventionalActions = array('new', 'edit', 'remove');
+    private $usePatch;
 
     /**
      * Initializes controller reader.
      *
      * @param Reader $annotationReader annotation reader
+     * @param QueryParamReader $queryParamReader
+     * @param boolean $usePatch
      */
-    public function __construct(Reader $annotationReader, QueryParamReader $queryParamReader)
+    public function __construct(Reader $annotationReader, QueryParamReader $queryParamReader, $usePatch = true)
     {
         $this->annotationReader = $annotationReader;
         $this->queryParamReader = $queryParamReader;
+        $this->usePatch = $usePatch;
     }
 
     /**
@@ -357,7 +361,7 @@ class RestActionReader
         }
 
         //custom object
-        return 'patch';
+        return $this->usePatch ? 'patch' : 'post';
     }
 
     /**
@@ -365,7 +369,7 @@ class RestActionReader
      *
      * @param \ReflectionMethod $reflection
      *
-     * @return Annotation|null
+     * @return mixed
      */
     private function readRouteAnnotation(\ReflectionMethod $reflection)
     {
@@ -379,10 +383,10 @@ class RestActionReader
     /**
      * Reads method annotations.
      *
-     * @param ReflectionMethod $reflection     controller action
+     * @param \ReflectionMethod $reflection     controller action
      * @param string           $annotationName annotation name
      *
-     * @return Annotation|null
+     * @return mixed
      */
     private function readMethodAnnotation(\ReflectionMethod $reflection, $annotationName)
     {


### PR DESCRIPTION
This flag allows using POST again for custom methods (same behavior than for older versions of the bundle) instead of PATCH. The default config is still using PATCH.

I see 2 use cases for this:
- Symfony 2.0 forms don't support PATCH in the bindRequest shortcut so the switch to PATCH broke some code for 2.1 (see FriendsOfSymfony/FOSCommentBundle#189 for the report)
- Amazon Elastic Load Balancing seems to reject PATCH request (at least with the default configuration) which broke our REST API when deploying it to prod at work (the staging server works well as it is not behind a load balancer).
