### PR TITLE
Added upper bounds on composer constraints and added a branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,21 @@
 
     "require": {
         "php":                            ">=5.3.2",
-        "friendsofsymfony/rest":          "*",
+        "friendsofsymfony/rest":          "0.7.*",
         "symfony/symfony":                ">=2.0,<2.2",
-        "sensio/framework-extra-bundle":  "*",
-        "jms/serializer-bundle":          "*"
+        "sensio/framework-extra-bundle":  ">=2.0,<2.2",
+        "jms/serializer-bundle":          "0.9.*"
     },
 
     "autoload": {
         "psr-0": { "FOS\\RestBundle": "" }
     },
 
-    "target-dir": "FOS/RestBundle"
+    "target-dir": "FOS/RestBundle",
+
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.7.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This PR requires sensio/SensioFrameworkExtraBundle#126 to avoid breaking the support on symfony 2.1 (the constraint in SensioFrameworkExtraBundle being totally broken without my 2 PRs, you would end up with the 2.0 branch in your project)
