### PR TITLE
[WIP] Add request content deserializer

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationCheckPass.php
+++ b/DependencyInjection/Compiler/ConfigurationCheckPass.php
@@ -15,9 +15,14 @@ use Symfony\Component\DependencyInjection\ContainerBuilder,
     Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 /**
- * Checks if the SensioFrameworkExtraBundle views annotations are disabled when using the View Response listener.
- *
+ * Checks if the:
+ *  - SensioFrameworkExtraBundle views annotations are disabled when using 
+ *    the View Response listener.
+ *  - SensioFrameworkExtraBundle ParamConverter annotation are enabled when 
+ *    using the Request Content Param Converter.
+ * 
  * @author Eriksen Costa <eriksencosta@gmail.com>
+ * @author Antoni Orfin <a.orfin@imagin.com.pl>
  */
 class ConfigurationCheckPass implements CompilerPassInterface
 {
@@ -25,6 +30,10 @@ class ConfigurationCheckPass implements CompilerPassInterface
     {
         if ($container->has('sensio_framework_extra.view.listener') && $container->has('fos_rest.view_response_listener')) {
             throw new \RuntimeException('You need to disable the view annotations in SensioFrameworkExtraBundle when using the FOSRestBundle View Response listener.');
+        }
+
+        if ($container->has('fos_rest.request.param_converter.request_content') && !$container->has('sensio_framework_extra.converter.listener')) {
+            throw new \RuntimeException('You need to enable the ParamConverter annotation in SensioFrameworkExtraBundle when using the FOSRestBundle Request Content Param Converter.');
         }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,13 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->arrayNode('request_content_param_converter')
+                    ->canBeUnset()
+                    ->children()
+                        ->scalarNode('enabled')->defaultTrue()->end()
+                        ->scalarNode('exception_on_fault')->defaultFalse()->end()
+                    ->end()
+                ->end()
                 ->scalarNode('query_fetcher_listener')->defaultFalse()
                     ->validate()
                         ->ifNotInArray($this->forceOptionValues)

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -142,7 +142,6 @@ class FOSRestExtension extends Extension
             if ($config['request_content_param_converter']['enabled']) {
                 $loader->load('request_content_param_converter.xml');
 
-                // Default - false
                 $exceptionOnFault = $config['request_content_param_converter']['exception_on_fault'];
 
                 $container->setParameter($this->getAlias().'.request.param_converter.request_content_param_converter.exception_on_fault', $exceptionOnFault);

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -138,14 +138,12 @@ class FOSRestExtension extends Extension
             }
         }
 
-        if (!empty($config['request_content_param_converter'])) {
-            if ($config['request_content_param_converter']['enabled']) {
-                $loader->load('request_content_param_converter.xml');
+        if (!empty($config['request_content_param_converter']['enabled'])) {
+            $loader->load('request_content_param_converter.xml');
 
-                $exceptionOnFault = $config['request_content_param_converter']['exception_on_fault'];
+            $exceptionOnFault = $config['request_content_param_converter']['exception_on_fault'];
 
-                $container->setParameter($this->getAlias().'.request.param_converter.request_content_param_converter.exception_on_fault', $exceptionOnFault);
-            }
+            $container->setParameter($this->getAlias().'.request.param_converter.request_content_param_converter.exception_on_fault', $exceptionOnFault);
         }
     }
 

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -143,7 +143,7 @@ class FOSRestExtension extends Extension
 
             $exceptionOnFault = $config['request_content_param_converter']['exception_on_fault'];
 
-            $container->setParameter($this->getAlias().'.request.param_converter.request_content_param_converter.exception_on_fault', $exceptionOnFault);
+            $container->setParameter($this->getAlias().'.request.param_converter.request_content.exception_on_fault', $exceptionOnFault);
         }
     }
 

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -139,7 +139,7 @@ class FOSRestExtension extends Extension
         }
 
         if (!empty($config['request_content_param_converter'])) {
-            if($config['request_content_param_converter']['enabled']) {
+            if ($config['request_content_param_converter']['enabled']) {
                 $loader->load('request_content_param_converter.xml');
 
                 // Default - false

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -137,6 +137,17 @@ class FOSRestExtension extends Extension
                 $container->setParameter($this->getAlias().'.query_fetch_listener.set_params_as_attributes', true);
             }
         }
+
+        if (!empty($config['request_content_param_converter'])) {
+            if($config['request_content_param_converter']['enabled']) {
+                $loader->load('request_content_param_converter.xml');
+
+                // Default - false
+                $exceptionOnFault = $config['request_content_param_converter']['exception_on_fault'];
+
+                $container->setParameter($this->getAlias().'.request.param_converter.request_content_param_converter.exception_on_fault', $exceptionOnFault);
+            }
+        }
     }
 
     /**

--- a/Request/DataTransferObject.php
+++ b/Request/DataTransferObject.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Request;
+
+/**
+ * DataTransferObject
+ * 
+ * All objects which you want to deserialize from the Request content 
+ * must extend DataTransferObject.
+ * 
+ * Instances should accept empty constructor.
+ * 
+ * @author Antoni Orfin <a.orfin@imagin.com.pl>
+ * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
+ */
+abstract class DataTransferObject
+{
+}

--- a/Request/DataTransferObject.php
+++ b/Request/DataTransferObject.php
@@ -12,8 +12,6 @@
 namespace FOS\RestBundle\Request;
 
 /**
- * DataTransferObject
- * 
  * All objects which you want to deserialize from the Request content 
  * must extend DataTransferObject.
  * 

--- a/Request/DataTransferObjectInterface.php
+++ b/Request/DataTransferObjectInterface.php
@@ -18,7 +18,6 @@ namespace FOS\RestBundle\Request;
  * Instances should accept empty constructor.
  * 
  * @author Antoni Orfin <a.orfin@imagin.com.pl>
- * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
  */
 interface DataTransferObjectInterface
 {

--- a/Request/DataTransferObjectInterface.php
+++ b/Request/DataTransferObjectInterface.php
@@ -13,13 +13,13 @@ namespace FOS\RestBundle\Request;
 
 /**
  * All objects which you want to deserialize from the Request content 
- * must extend DataTransferObject.
+ * must implements DataTransferObjectInterface.
  * 
  * Instances should accept empty constructor.
  * 
  * @author Antoni Orfin <a.orfin@imagin.com.pl>
  * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
  */
-abstract class DataTransferObject
+interface DataTransferObjectInterface
 {
 }

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -103,9 +103,9 @@ class RequestContentParamConverter implements ParamConverterInterface
 
             if (isset($this->options['exception_on_fault']) && $this->options['exception_on_fault'] === true) {
                 throw $e;
-            } else {
-                $object = new $class;
-            }
+            } 
+            
+            $object = new $class;
         }
 
         // set the object as the request attribute with the given name

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -24,7 +24,6 @@ use JMS\SerializerBundle\Exception\Exception;
  *
  * @author Antoni Orfin <a.orfin@imagin.com.pl>
  * @author Matthias Noback
- * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
  */
 class RequestContentParamConverter implements ParamConverterInterface
 {

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -36,16 +36,17 @@ class RequestContentParamConverter implements ParamConverterInterface
     private $serializer;
 
     /**
-     * Optional options.
+     * If true exceptions from serializer will be thrown, otherwise
+     * new instance of object will be returned (using empty constructor).
      *
-     * @var array
+     * @var boolean
      */
-    private $options;
+    private $exceptionOnFault;
 
-    public function __construct(SerializerInterface $serializer, array $options = array())
+    public function __construct(SerializerInterface $serializer, $exceptionOnFault)
     {
         $this->serializer = $serializer;
-        $this->options = $options;
+        $this->exceptionOnFault = $exceptionOnFault;
     }
 
     /**
@@ -101,7 +102,7 @@ class RequestContentParamConverter implements ParamConverterInterface
              * don't throw Exception but new Object (using empty constructor)
              */
 
-            if (isset($this->options['exception_on_fault']) && $this->options['exception_on_fault'] === true) {
+            if ($this->exceptionOnFault) {
                 throw $e;
             } 
             

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -23,7 +23,7 @@ use JMS\SerializerBundle\Exception\Exception;
  * by Matthias Noback (http://php-and-symfony.matthiasnoback.nl)
  *
  * @author Antoni Orfin <a.orfin@imagin.com.pl>
- * @author Matthias Noback
+ * @author Matthias Noback <matthiasnoback@gmail.com>
  */
 class RequestContentParamConverter implements ParamConverterInterface
 {
@@ -91,9 +91,7 @@ class RequestContentParamConverter implements ParamConverterInterface
             : $request->getFormat($request->headers->get('Content-Type'));
 
         try {
-            $object = $this->serializer->deserialize(
-                    $request->getContent(), $class, $format
-            );
+            $object = $this->serializer->deserialize($request->getContent(), $class, $format);
         } catch (Exception $e) {
 
             /**

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -23,11 +23,11 @@ use JMS\SerializerBundle\Exception\Exception;
  * by Matthias Noback (http://php-and-symfony.matthiasnoback.nl)
  *
  * @author Antoni Orfin <a.orfin@imagin.com.pl>
+ * @author Matthias Noback
  * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
  */
 class RequestContentParamConverter implements ParamConverterInterface
 {
-
     /**
      * Serializer instance.
      *

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -14,7 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInte
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Symfony\Component\HttpFoundation\Request;
 use JMS\SerializerBundle\Serializer\SerializerInterface;
-use JMS\SerializerBundle\Exception\RuntimeException;
+use JMS\SerializerBundle\Exception\Exception;
 
 /**
  * It supports deserializing content of the request into needed object.
@@ -69,14 +69,14 @@ class RequestContentParamConverter implements ParamConverterInterface
      * @param Request                $request
      * @param ConfigurationInterface $configuration
      *
-     * @throws RuntimeException Only if request_content_param_converter.exception_on_fault is set to true
+     * @throws Exception Only if request_content_param_converter.exception_on_fault is set to true
      */
     public function apply(Request $request, ConfigurationInterface $configuration)
     {
         $class = $configuration->getClass();
 
         $contentType = $request->headers->get('Content-Type');
-
+        
         $format = null === $contentType
             ? $request->getRequestFormat()
             : $request->getFormat($request->headers->get('Content-Type'));
@@ -85,7 +85,7 @@ class RequestContentParamConverter implements ParamConverterInterface
             $object = $this->serializer->deserialize(
                     $request->getContent(), $class, $format
             );
-        } catch (RuntimeException $e) {
+        } catch (Exception $e) {
 
             /**
              * If request_content_param_converter.exception_on_fault is set to false

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -18,8 +18,6 @@ use JMS\SerializerBundle\Serializer\SerializerInterface;
 use JMS\SerializerBundle\Exception\RuntimeException;
 
 /**
- * RequestContentParamConverter
- *
  * It supports deserializing content of the request into needed object.
  * 
  * Based on http://php-and-symfony.matthiasnoback.nl/2012/03/symfony2-creating-a-paramconverter-for-deserializing-request-content/
@@ -28,7 +26,8 @@ use JMS\SerializerBundle\Exception\RuntimeException;
  * @author Antoni Orfin <a.orfin@imagin.com.pl>
  * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
  */
-class RequestContentParamConverter implements ParamConverterInterface {
+class RequestContentParamConverter implements ParamConverterInterface 
+{
     
     /**
      * Serializer instance.
@@ -68,6 +67,7 @@ class RequestContentParamConverter implements ParamConverterInterface {
      * 
      * @param Request $request
      * @param ConfigurationInterface $configuration
+     * 
      * @throws RuntimeException Only if request_content_param_converter.exception_on_fault is set to true
      */
     public function apply(Request $request, ConfigurationInterface $configuration) {
@@ -103,5 +103,4 @@ class RequestContentParamConverter implements ParamConverterInterface {
         // (this will later be an argument for the action)
         $request->attributes->set($configuration->getName(), $object);
     }
-
 }

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -13,48 +13,49 @@ namespace FOS\RestBundle\Request\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use JMS\SerializerBundle\Serializer\SerializerInterface;
 use JMS\SerializerBundle\Exception\RuntimeException;
 
 /**
  * It supports deserializing content of the request into needed object.
- * 
+ *
  * Based on http://php-and-symfony.matthiasnoback.nl/2012/03/symfony2-creating-a-paramconverter-for-deserializing-request-content/
  * by Matthias Noback (http://php-and-symfony.matthiasnoback.nl)
- * 
+ *
  * @author Antoni Orfin <a.orfin@imagin.com.pl>
  * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
  */
-class RequestContentParamConverter implements ParamConverterInterface 
+class RequestContentParamConverter implements ParamConverterInterface
 {
-    
+
     /**
      * Serializer instance.
-     * 
+     *
      * @var SerializerInterface
      */
     private $serializer;
-    
+
     /**
      * Optional options.
-     * 
+     *
      * @var array
      */
     private $options;
-    
-    public function __construct(SerializerInterface $serializer, array $options = array()) {
+
+    public function __construct(SerializerInterface $serializer, array $options = array())
+    {
         $this->serializer = $serializer;
         $this->options = $options;
     }
-    
+
     /**
      * Only objects are supported.
-     * 
-     * @param ConfigurationInterface $configuration
-     * @return boolean 
+     *
+     * @param  ConfigurationInterface $configuration
+     * @return boolean
      */
-    public function supports(ConfigurationInterface $configuration) {
+    public function supports(ConfigurationInterface $configuration)
+    {
         if (!$configuration->getClass()) {
             return false;
         }
@@ -64,15 +65,16 @@ class RequestContentParamConverter implements ParamConverterInterface
 
     /**
      * Deserialize request content to object.
-     * 
-     * @param Request $request
+     *
+     * @param Request                $request
      * @param ConfigurationInterface $configuration
-     * 
+     *
      * @throws RuntimeException Only if request_content_param_converter.exception_on_fault is set to true
      */
-    public function apply(Request $request, ConfigurationInterface $configuration) {
+    public function apply(Request $request, ConfigurationInterface $configuration)
+    {
         $class = $configuration->getClass();
-        
+
         $contentType = $request->headers->get('Content-Type');
 
         $format = null === $contentType
@@ -83,18 +85,16 @@ class RequestContentParamConverter implements ParamConverterInterface
             $object = $this->serializer->deserialize(
                     $request->getContent(), $class, $format
             );
-        }
-        catch (RuntimeException $e) {
-            
+        } catch (RuntimeException $e) {
+
             /**
              * If request_content_param_converter.exception_on_fault is set to false
              * don't throw Exception but new Object (using empty constructor)
              */
-            
-            if(isset($this->options['exception_on_fault']) && $this->options['exception_on_fault'] === true) {
+
+            if (isset($this->options['exception_on_fault']) && $this->options['exception_on_fault'] === true) {
                 throw $e;
-            }
-            else {
+            } else {
                 $object = new $class;
             }
         }

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -49,18 +49,26 @@ class RequestContentParamConverter implements ParamConverterInterface
     }
 
     /**
-     * Only objects are supported.
+     * Only objects implementing FOS\RestBundle\Request\DataTransferObjectInterface
+     * are supported.
      *
      * @param  ConfigurationInterface $configuration
      * @return boolean
      */
     public function supports(ConfigurationInterface $configuration)
     {
-        if (!$configuration->getClass()) {
+        $class = $configuration->getClass();
+        
+        if (!$class) {
             return false;
         }
+        
+        $argumentClass = new \ReflectionClass($class);
+        
+        $interfaceNames = $argumentClass->getInterfaceNames();
+        $hasInterface = in_array('FOS\RestBundle\Request\DataTransferObjectInterface', $interfaceNames);
 
-        return true;
+        return $hasInterface;
     }
 
     /**

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -63,12 +63,13 @@ class RequestContentParamConverter implements ParamConverterInterface
             return false;
         }
         
+        $acceptedInterface = 'FOS\RestBundle\Request\DataTransferObjectInterface';
+
         $argumentClass = new \ReflectionClass($class);
         
-        $interfaceNames = $argumentClass->getInterfaceNames();
-        $hasInterface = in_array('FOS\RestBundle\Request\DataTransferObjectInterface', $interfaceNames);
-
-        return $hasInterface;
+        $implementsInterface = $argumentClass->implementsInterface($acceptedInterface);
+        
+        return $implementsInterface;
     }
 
     /**

--- a/Request/ParamConverter/RequestContentParamConverter.php
+++ b/Request/ParamConverter/RequestContentParamConverter.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Request\ParamConverter;
+
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use JMS\SerializerBundle\Serializer\SerializerInterface;
+use JMS\SerializerBundle\Exception\RuntimeException;
+
+/**
+ * RequestContentParamConverter
+ *
+ * It supports deserializing content of the request into needed object.
+ * 
+ * Based on http://php-and-symfony.matthiasnoback.nl/2012/03/symfony2-creating-a-paramconverter-for-deserializing-request-content/
+ * by Matthias Noback (http://php-and-symfony.matthiasnoback.nl)
+ * 
+ * @author Antoni Orfin <a.orfin@imagin.com.pl>
+ * @copyright (c) 2012  IMAGIN IT Marcin Engelmann
+ */
+class RequestContentParamConverter implements ParamConverterInterface {
+    
+    /**
+     * Serializer instance.
+     * 
+     * @var SerializerInterface
+     */
+    private $serializer;
+    
+    /**
+     * Optional options.
+     * 
+     * @var array
+     */
+    private $options;
+    
+    public function __construct(SerializerInterface $serializer, array $options = array()) {
+        $this->serializer = $serializer;
+        $this->options = $options;
+    }
+    
+    /**
+     * Only objects are supported.
+     * 
+     * @param ConfigurationInterface $configuration
+     * @return boolean 
+     */
+    public function supports(ConfigurationInterface $configuration) {
+        if (!$configuration->getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Deserialize request content to object.
+     * 
+     * @param Request $request
+     * @param ConfigurationInterface $configuration
+     * @throws RuntimeException Only if request_content_param_converter.exception_on_fault is set to true
+     */
+    public function apply(Request $request, ConfigurationInterface $configuration) {
+        $class = $configuration->getClass();
+        
+        $contentType = $request->headers->get('Content-Type');
+
+        $format = null === $contentType
+            ? $request->getRequestFormat()
+            : $request->getFormat($request->headers->get('Content-Type'));
+
+        try {
+            $object = $this->serializer->deserialize(
+                    $request->getContent(), $class, $format
+            );
+        }
+        catch (RuntimeException $e) {
+            
+            /**
+             * If request_content_param_converter.exception_on_fault is set to false
+             * don't throw Exception but new Object (using empty constructor)
+             */
+            
+            if(isset($this->options['exception_on_fault']) && $this->options['exception_on_fault'] === true) {
+                throw $e;
+            }
+            else {
+                $object = new $class;
+            }
+        }
+
+        // set the object as the request attribute with the given name
+        // (this will later be an argument for the action)
+        $request->attributes->set($configuration->getName(), $object);
+    }
+
+}

--- a/Resources/config/request_content_param_converter.xml
+++ b/Resources/config/request_content_param_converter.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        
+        <parameter key="fos_rest.request.param_converter.request_content_param_converter.class">FOS\RestBundle\Request\ParamConverter\RequestContentParamConverter</parameter>
+    
+    </parameters>
+        
+    <services>
+        
+        <service id="fos_rest.request.param_converter.request_content_param_converter"
+                 class="%fos_rest.request.param_converter.request_content_param_converter.class%">
+            <argument type="service" id="serializer" />
+            <argument type="collection">
+                <argument key="exception_on_fault">%fos_rest.request.param_converter.request_content_param_converter.exception_on_fault%</argument>
+            </argument>
+            <tag name="request.param_converter" priority="-100" />
+        </service>
+        
+    </services>
+    
+</container>

--- a/Resources/config/request_content_param_converter.xml
+++ b/Resources/config/request_content_param_converter.xml
@@ -15,9 +15,7 @@
         <service id="fos_rest.request.param_converter.request_content_param_converter"
                  class="%fos_rest.request.param_converter.request_content_param_converter.class%">
             <argument type="service" id="serializer" />
-            <argument type="collection">
-                <argument key="exception_on_fault">%fos_rest.request.param_converter.request_content_param_converter.exception_on_fault%</argument>
-            </argument>
+            <argument>%fos_rest.request.param_converter.request_content_param_converter.exception_on_fault%</argument>
             <tag name="request.param_converter" priority="-100" />
         </service>
         

--- a/Resources/config/request_content_param_converter.xml
+++ b/Resources/config/request_content_param_converter.xml
@@ -6,16 +6,16 @@
 
     <parameters>
         
-        <parameter key="fos_rest.request.param_converter.request_content_param_converter.class">FOS\RestBundle\Request\ParamConverter\RequestContentParamConverter</parameter>
+        <parameter key="fos_rest.request.param_converter.request_content.class">FOS\RestBundle\Request\ParamConverter\RequestContentParamConverter</parameter>
     
     </parameters>
         
     <services>
         
-        <service id="fos_rest.request.param_converter.request_content_param_converter"
-                 class="%fos_rest.request.param_converter.request_content_param_converter.class%">
+        <service id="fos_rest.request.param_converter.request_content"
+                 class="%fos_rest.request.param_converter.request_content.class%">
             <argument type="service" id="serializer" />
-            <argument>%fos_rest.request.param_converter.request_content_param_converter.exception_on_fault%</argument>
+            <argument>%fos_rest.request.param_converter.request_content.exception_on_fault%</argument>
             <tag name="request.param_converter" priority="-100" />
         </service>
         

--- a/Resources/doc/configuration-reference.md
+++ b/Resources/doc/configuration-reference.md
@@ -53,5 +53,7 @@ fos_rest:
             - */*
         prefer_extension:     true
         fallback_format:      html
+    request_content_param_converter:
+        enabled: true
+        exception_on_fault: false
 ```
-

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -253,9 +253,11 @@ class RestActionReader
         // ignore type hinted arguments that are or extend from:
         // * Symfony\Component\HttpFoundation\Request
         // * FOS\RestBundle\Request\QueryFetcher
+        // * FOS\RestBundle\Request\DataTransferObject - needed for ParamConverter
         $ignoreClasses = array(
             'Symfony\Component\HttpFoundation\Request',
             'FOS\RestBundle\Request\QueryFetcherInterface',
+            'FOS\RestBundle\Request\DataTransferObject',
         );
 
         $arguments = array();

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -272,13 +272,14 @@ class RestActionReader
 
             $argumentClass = $argument->getClass();
             if ($argumentClass) {
+                foreach ($ignoreInterfaces as $interface) {
+                    if ($argumentClass->implementsInterface($interface)) {
+                        continue 2;
+                    }
+                }
+                
                 foreach ($ignoreClasses as $class) {
-                    $interfaceNames = $argumentClass->getInterfaceNames();
-                    
-                    $interfacesIntersect = array_intersect($ignoreInterfaces, $interfaceNames);
-                    $hasInterface = !empty($interfacesIntersect);
-                    
-                    if ($argumentClass->getName() === $class || $argumentClass->isSubclassOf($class) || $hasInterface) {
+                    if ($argumentClass->getName() === $class || $argumentClass->isSubclassOf($class)) {
                         continue 2;
                     }
                 }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -253,11 +253,15 @@ class RestActionReader
         // ignore type hinted arguments that are or extend from:
         // * Symfony\Component\HttpFoundation\Request
         // * FOS\RestBundle\Request\QueryFetcher
-        // * FOS\RestBundle\Request\DataTransferObject - needed for ParamConverter
         $ignoreClasses = array(
             'Symfony\Component\HttpFoundation\Request',
             'FOS\RestBundle\Request\QueryFetcherInterface',
-            'FOS\RestBundle\Request\DataTransferObject',
+        );
+        
+        // ignore type hinted arguments that are interfaces of:
+        // * FOS\RestBundle\Request\DataTransferObject - needed for ParamConverter
+        $ignoreInterfaces = array(
+            'FOS\RestBundle\Request\DataTransferObjectInterface',
         );
 
         $arguments = array();
@@ -269,7 +273,12 @@ class RestActionReader
             $argumentClass = $argument->getClass();
             if ($argumentClass) {
                 foreach ($ignoreClasses as $class) {
-                    if ($argumentClass->getName() === $class || $argumentClass->isSubclassOf($class)) {
+                    $interfaceNames = $argumentClass->getInterfaceNames();
+                    
+                    $interfacesIntersect = array_intersect($ignoreInterfaces, $interfaceNames);
+                    $hasInterface = !empty($interfacesIntersect);
+                    
+                    if ($argumentClass->getName() === $class || $argumentClass->isSubclassOf($class) || $hasInterface) {
                         continue 2;
                     }
                 }


### PR DESCRIPTION
Hi,

this addon allows to use DataTransferObjects as an argument of controller actions. It's based on Matthias Noback ParamConverter [http://php-and-symfony.matthiasnoback.nl/2012/03/symfony2-creating-a-paramconverter-for-deserializing-request-content/].

It is very convenient in post methods.

Sample usage:

Controller:

```php
// ...
public function postTestsAction(Test $client) { 
// ... 
}
```

Test class:

```php
<?php

namespace Acme\DemoBundle\Model;

use FOS\RestBundle\Request\DataTransferObject;
use JMS\SerializerBundle\Annotation\XmlRoot;
use JMS\SerializerBundle\Annotation\Type;

/**
 * @XmlRoot("test") 
 */
class Test extends DataTransferObject {

    /**
     * @Type("string") 
     */
    public $field_one;

    /**
     * @Type("boolean") 
     */
    public $field_two;

    public function __construct() {
        
    }

}
```

Objects must extends DataTransferObject due to "RestActionReader" mechanism (otherwise controller's actions params will be included in the route).

By default it's turned off.

To turn it on just add to your config:
```
fos_rest:
  request_content_param_converter: ~    
```

In default mode, exceptions from Serializer are 'hidden' and 'empty' new object of given type is created. But if you add:
```
fos_rest:
  request_content_param_converter:
        exception_on_fault: true
```
=
all serializer exceptions will be thrown.

TODO:
 - missing documentation
 - need tests!

btw. This is my first github pull request ;-)