### PR TITLE
Need to import annotation @RequestParam before using it

### DIFF
--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -227,7 +227,8 @@ fos_rest:
 ```
 
 ```php
-use FOS\RestBundle\Request\ParamFetcher;
+use FOS\RestBundle\Request\ParamFetcher,
+    FOS\RestBundle\Controller\Annotations\RequestParam;
 
 class FooController extends Controller
 {


### PR DESCRIPTION
You can't use the @RequestParam annotation without importing it first.
