### PR TITLE
Fixing php unit tests agains php5.4

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -103,9 +103,9 @@ class ParamFetcher implements ParamFetcherInterface
             $failMessage = null;
 
             if (!is_array($param)) {
-                $failMessage = sprintf("Query parameter value '%s' is not an array", $param);
+                $failMessage = sprintf("Query parameter value '%s' is not an array", $name);
             } elseif (count($param) !== count($param, COUNT_RECURSIVE)) {
-                $failMessage = sprintf("Query parameter value '%s' must not have a depth of more than one", $param);
+                $failMessage = sprintf("Query parameter value '%s' must not have a depth of more than one", $name);
             }
 
             if (null !== $failMessage) {


### PR DESCRIPTION
$param was used in Exception message an caused an array to string cast warning with php5.4.
More over it's logic to indicate the name of the param in the message when the param is an array
