### PR TITLE
add serializerGroups to View Annotation

### DIFF
--- a/Controller/Annotations/View.php
+++ b/Controller/Annotations/View.php
@@ -30,6 +30,11 @@ class View extends Template
     protected $statusCode;
 
     /**
+     * @var array
+     */
+    protected $serializerGroups;
+
+    /**
      * Returns the annotation alias name.
      *
      * @return string
@@ -74,5 +79,21 @@ class View extends Template
     public function getStatusCode()
     {
         return $this->statusCode;
+    }
+
+    /**
+     * @var array $serializerGroups
+     */
+    public function setSerializerGroups($serializerGroups)
+    {
+        $this->serializerGroups = $serializerGroups;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSerializerGroups()
+    {
+        return $this->serializerGroups;
     }
 }

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -115,6 +115,20 @@ public function deleteUserAction()
 }
 ```
 
+The groups for the serializer can be configured as follows:
+
+```php
+<?php
+
+/**
+ * @View(serializerGroups={"group1", "group2"})
+ */
+public function getUsersAction()
+{
+    //...
+}
+```
+
 See the following example code for more details:
 https://github.com/liip/LiipHelloBundle/blob/master/Controller/ExtraController.php
 


### PR DESCRIPTION
The View presents a function to set serialization groups for use in JMSSerializer.
Currently this is not available through the @View() Annotation and the view has to be initialized "by hand" for each Action using this Feature.

This PR adds support for a parameter _serializerGroups_ inside the @View() Annotation which takes an array containing the lists configured in JMSSerializer
