### PR TITLE
use the new annotation in the eventlistener

### DIFF
--- a/EventListener/ViewResponseListener.php
+++ b/EventListener/ViewResponseListener.php
@@ -86,6 +86,9 @@ class ViewResponseListener extends TemplateListener
             if (null === $view->getStatusCode() && $configuration->getStatusCode()) {
                 $view->setStatusCode($configuration->getStatusCode());
             }
+            if ($configuration->getSerializerGroups()) {
+                $view->setSerializerGroups($configuration->getSerializerGroups());
+            }
         }
 
         if (null === $view->getFormat()) {


### PR DESCRIPTION
#276 introduced a serializerGroups param inside the View Annotation.

I just forgot using it inside the Event Listener -_-
This makes the Annotation Parameter actually usable.
