### PR TITLE
Fix pluralization of plurals

### DIFF
--- a/Tests/Util/PluralizationTest.php
+++ b/Tests/Util/PluralizationTest.php
@@ -24,27 +24,27 @@ class PluralizationTest extends \PHPUnit_Framework_TestCase
     /**
      * Test that pluralization pluralize words correctly.
      *
-     * @dataProvider getWords
+     * @dataProvider getPluralizableWords
      *
-     * @param string $singular
+     * @param string $source
      * @param string $plural
      */
-    public function testPluralize($singular, $plural)
+    public function testPluralize($source, $plural)
     {
-        $this->assertEquals($plural, Pluralization::pluralize($singular));
+        $this->assertEquals($plural, Pluralization::pluralize($source));
     }
 
     /**
      * Test that pluralization singularize words correctly.
      *
-     * @dataProvider getWords
+     * @dataProvider getSingularizableWords
      *
      * @param string $singular
-     * @param string $plural
+     * @param string $source
      */
-    public function testSingularize($singular, $plural)
+    public function testSingularize($singular, $source)
     {
-        $this->assertEquals($singular, Pluralization::singularize($plural));
+        $this->assertEquals($singular, Pluralization::singularize($source));
     }
 
     /**
@@ -61,5 +61,37 @@ class PluralizationTest extends \PHPUnit_Framework_TestCase
             array('news',       'news'),
             array('comment',    'comments'),
         );
+    }
+
+    /**
+     * Singularizable words provider.
+     *
+     * @return array of hashes (singular => source)
+     */
+    public function getSingularizableWords()
+    {
+        $singularizables = array(
+            array('company',    'company'),
+        );
+
+        $words = $this->getWords();
+
+        return array_merge($words, $singularizables);
+    }
+
+    /**
+     * Pluralizable words provider.
+     *
+     * @return array of hashes (source => plural)
+     */
+    public function getPluralizableWords()
+    {
+        $pluralizables = array(
+            array('companies',    'companies'),
+        );
+
+        $words = $this->getWords();
+
+        return array_merge($words, $pluralizables);
     }
 }

--- a/Util/Pluralization.php
+++ b/Util/Pluralization.php
@@ -20,6 +20,93 @@ namespace FOS\RestBundle\Util;
 class Pluralization
 {
     /**
+     * Uncountable words.
+     *
+     * @var array
+     */
+    public static $uncountables = array(
+        'equipment',
+        'information',
+        'rice',
+        'money',
+        'species',
+        'series',
+        'fish',
+        'sheep',
+        'media'
+    );
+
+    /**
+     * Irregular words.
+     *
+     * @var array
+     */
+    public static $irregulars = array(
+        'person'  => 'people',
+        'man'     => 'men',
+        'child'   => 'children',
+        'sex'     => 'sexes',
+        'move'    => 'moves'
+    );
+
+    /**
+     * Singular rules.
+     *
+     * @var array
+     */
+    public static $singulars = array(
+        '/(quiz)zes$/i'         => '\1',
+        '/(matr)ices$/i'        => '\1ix',
+        '/(vert|ind)ices$/i'    => '\1ex',
+        '/^(ox)en/i'            => '\1',
+        '/(alias|status)es$/i'  => '\1',
+        '/([octop|vir])i$/i'    => '\1us',
+        '/(cris|ax|test)es$/i'  => '\1is',
+        '/(shoe)s$/i'           => '\1',
+        '/(o)es$/i'             => '\1',
+        '/(bus)es$/i'           => '\1',
+        '/([m|l])ice$/i'        => '\1ouse',
+        '/(x|ch|ss|sh)es$/i'    => '\1',
+        '/(m)ovies$/i'          => '\1ovie',
+        '/(s)eries$/i'          => '\1eries',
+        '/([^aeiouy]|qu)ies$/i' => '\1y',
+        '/([lr])ves$/i'         => '\1f',
+        '/(tive)s$/i'           => '\1',
+        '/(hive)s$/i'           => '\1',
+        '/([^f])ves$/i'         => '\1fe',
+        '/(^analy)ses$/i'       => '\1sis',
+        '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
+        '/([ti])a$/i'           => '\1um',
+        '/(n)ews$/i'            => '\1ews',
+        '/s$/i'                 => '',
+    );
+
+    /**
+     * Pural rules
+     *
+     * @var array
+     */
+    public static $plurals = array(
+        '/(quiz)$/i'                => '\1zes',
+        '/^(ox)$/i'                 => '\1en',
+        '/([m|l])ouse$/i'           => '\1ice',
+        '/(matr|vert|ind)ix|ex$/i'  => '\1ices',
+        '/(x|ch|ss|sh)$/i'          => '\1es',
+        '/([^aeiouy]|qu)y$/i'       => '\1ies',
+        '/(hive)$/i'                => '\1s',
+        '/(?:([^f])fe|([lr])f)$/i'  => '\1\2ves',
+        '/sis$/i'                   => 'ses',
+        '/([ti])um$/i'              => '\1a',
+        '/(buffal|tomat)o$/i'       => '\1oes',
+        '/(bu)s$/i'                 => '\1ses',
+        '/(alias|status)/i'         => '\1es',
+        '/(octop|vir)us$/i'         => '\1i',
+        '/(ax|test)is$/i'           => '\1es',
+        '/s$/i'                     => 's',
+        '/$/'                       => 's'
+    );
+
+    /**
      * Pluralizes English noun.
      *
      * @param string $word english noun to pluralize
@@ -28,43 +115,13 @@ class Pluralization
      */
     public static function pluralize($word)
     {
-        $plurals = array(
-            '/(quiz)$/i'                => '\1zes',
-            '/^(ox)$/i'                 => '\1en',
-            '/([m|l])ouse$/i'           => '\1ice',
-            '/(matr|vert|ind)ix|ex$/i'  => '\1ices',
-            '/(x|ch|ss|sh)$/i'          => '\1es',
-            '/([^aeiouy]|qu)ies$/i'     => '\1y',
-            '/([^aeiouy]|qu)y$/i'       => '\1ies',
-            '/(hive)$/i'                => '\1s',
-            '/(?:([^f])fe|([lr])f)$/i'  => '\1\2ves',
-            '/sis$/i'                   => 'ses',
-            '/([ti])um$/i'              => '\1a',
-            '/(buffal|tomat)o$/i'       => '\1oes',
-            '/(bu)s$/i'                 => '\1ses',
-            '/(alias|status)/i'         => '\1es',
-            '/(octop|vir)us$/i'         => '\1i',
-            '/(ax|test)is$/i'           => '\1es',
-            '/s$/i'                     => 's',
-            '/$/'                       => 's'
-        );
-        $uncountables = array(
-            'equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep', 'media'
-        );
-        $irregulars = array(
-            'person'  => 'people',
-            'man'     => 'men',
-            'child'   => 'children',
-            'sex'     => 'sexes',
-            'move'    => 'moves'
-        );
         $lowerCasedWord = strtolower($word);
-        foreach ($uncountables as $uncountable) {
+        foreach (static::$uncountables as $uncountable) {
             if (substr($lowerCasedWord, (-1 * strlen($uncountable))) == $uncountable) {
                 return $word;
             }
         }
-        foreach ($irregulars as $plural => $singular) {
+        foreach (static::$irregulars as $plural => $singular) {
             if (preg_match('/(' . $plural . ')$/i', $word, $arr)) {
                 return preg_replace(
                     '/(' . $plural . ')$/i',
@@ -73,7 +130,7 @@ class Pluralization
                 );
             }
         }
-        foreach ($plurals as $rule => $replacement) {
+        foreach (static::$plurals as $rule => $replacement) {
             if (preg_match($rule, $word)) {
                 return preg_replace($rule, $replacement, $word);
             }
@@ -91,36 +148,11 @@ class Pluralization
      */
     public static function singularize($word)
     {
-        $singulars = array(
-            '/(quiz)zes$/i'         => '\1',
-            '/(matr)ices$/i'        => '\1ix',
-            '/(vert|ind)ices$/i'    => '\1ex',
-            '/^(ox)en/i'            => '\1',
-            '/(alias|status)es$/i'  => '\1',
-            '/([octop|vir])i$/i'    => '\1us',
-            '/(cris|ax|test)es$/i'  => '\1is',
-            '/(shoe)s$/i'           => '\1',
-            '/(o)es$/i'             => '\1',
-            '/(bus)es$/i'           => '\1',
-            '/([m|l])ice$/i'        => '\1ouse',
-            '/(x|ch|ss|sh)es$/i'    => '\1',
-            '/(m)ovies$/i'          => '\1ovie',
-            '/(s)eries$/i'          => '\1eries',
-            '/([^aeiouy]|qu)ies$/i' => '\1y',
-            '/([lr])ves$/i'         => '\1f',
-            '/(tive)s$/i'           => '\1',
-            '/(hive)s$/i'           => '\1',
-            '/([^f])ves$/i'         => '\1fe',
-            '/(^analy)ses$/i'       => '\1sis',
-            '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
-            '/([ti])a$/i'           => '\1um',
-            '/(n)ews$/i'            => '\1ews',
-            '/s$/i'                 => '',
-        );
-        $uncountables = array(
+
+        static::$uncountables = array(
             'equipment', 'information', 'rice', 'money', 'species', 'series', 'fish', 'sheep', 'media'
         );
-        $irregulars = array(
+        static::$irregulars = array(
             'person'  => 'people',
             'man'     => 'men',
             'child'   => 'children',
@@ -128,12 +160,12 @@ class Pluralization
             'move'    => 'moves'
         );
         $lowerCasedWord = strtolower($word);
-        foreach ($uncountables as $uncountable) {
+        foreach (static::$uncountables as $uncountable) {
             if (substr($lowerCasedWord, (-1 * strlen($uncountable))) == $uncountable) {
                 return $word;
             }
         }
-        foreach ($irregulars as $plural => $singular) {
+        foreach (static::$irregulars as $plural => $singular) {
             if (preg_match('/(' . $singular.')$/i', $word, $arr)) {
                 return preg_replace(
                     '/(' . $singular . ')$/i',
@@ -142,7 +174,7 @@ class Pluralization
                 );
             }
         }
-        foreach ($singulars as $rule => $replacement) {
+        foreach (static::$singulars as $rule => $replacement) {
             if (preg_match($rule, $word)) {
                 return preg_replace($rule, $replacement, $word);
             }


### PR DESCRIPTION
When creating action like `getFamiliesFoosAction($familyId, $paramFetcher)` the generated route looks like this:

```
api_get_families_foo => GET /family/{$familyId}/foos.{format}
```

That's because the pluralization of plurals words finishing in "ies" (like families) replaces the end by "y"

```
families => family
```

I added test cases and made rules, irregulars and uncountables words global to the class.
