### PR TITLE
Quote annotations references to fix annotations loading

### DIFF
--- a/EventListener/ViewResponseListener.php
+++ b/EventListener/ViewResponseListener.php
@@ -21,7 +21,7 @@ use Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener;
 use FOS\RestBundle\View\View;
 
 /**
- * The ViewResponseListener class handles the View core event as well as the @extra:Template annotation.
+ * The ViewResponseListener class handles the View core event as well as the "@extra:Template" annotation.
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */

--- a/Request/ParamReader.php
+++ b/Request/ParamReader.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use FOS\RestBundle\Controller\Annotations\Param;
 
 /**
- * Class loading @QueryParam and @RequestParam annotations from methods.
+ * Class loading "@QueryParam" and "@RequestParam" annotations from methods.
  *
  * @author Alexander <iam.asm89@gmail.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>


### PR DESCRIPTION
Hi,

The issue extracted from the commit message:

```
Using JMSSecurityExtraBundle with `secure_all_services: true`,
exceptions would be thrown while clearing symfony2's cache:

[Doctrine\Common\Annotations\AnnotationException]
  [Semantical Error] The annotation "@QueryParam" in class
  FOS\RestBundle\Request\ParamReader was never imported. Did you maybe
  forget to add a "use" statement for this annotation?

[Doctrine\Common\Annotations\AnnotationException]
  [Semantical Error] The annotation "@extra:Template" in class
  FOS\RestBundle\EventListener\ViewResponseListener was never imported.
  Did you maybe forget to add a "use" statement for this annotation?
```
