### PR TITLE
Fix headers in View (#292)

### DIFF
--- a/Tests/View/ViewTest.php
+++ b/Tests/View/ViewTest.php
@@ -120,6 +120,14 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $view->getHeaders());
     }
 
+    public function testHeadersInConstructorAreAssignedToResponseObject()
+    {
+        $headers = array('foo' => 'bar');
+        $expected = array('foo' => array('bar'), 'cache-control' => array('no-cache'));
+        $view = new View(null, null, $headers);
+        $this->assertEquals($expected, $view->getHeaders());
+    }
+
     public function testSetStatusCode()
     {
         $view = new View();

--- a/View/View.php
+++ b/View/View.php
@@ -33,11 +33,6 @@ class View
     private $statusCode;
 
     /**
-     * @var array
-     */
-    private $headers;
-
-    /**
      * @var string|TemplateReference
      */
     private $template;
@@ -112,8 +107,8 @@ class View
     {
         $this->data = $data;
         $this->statusCode = $statusCode;
-        $this->headers = $headers;
         $this->templateVar = 'data';
+        $this->getResponse()->headers->replace($headers);
     }
 
     /**
@@ -298,7 +293,7 @@ class View
     /**
      * set the response
      *
-     * @param Response $response
+     * @param  Response $response
      * @return View
      */
     public function setResponse(Response $response)
@@ -335,7 +330,7 @@ class View
      */
     public function getHeaders()
     {
-        return $this->response->headers->all();
+        return $this->getResponse()->headers->all();
     }
 
     /**


### PR DESCRIPTION
Fix headers in View (#292)
- Fixed getHeaders() to properly use the Response getter
- Fixed constructor to properly set the headers to the Reponse object
- Removed headers property
- Added according unit test
