### PR TITLE
Update Resources/doc/1-setting_up_the_bundle.md

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -79,6 +79,11 @@ public function registerBundles()
     $bundles = array(
         // ...
         new FOS\RestBundle\FOSRestBundle(),
+        
+        // if you installed FOSRestBundle using composer you shoudn't forget
+        // also registering JMSSerializerBundle.
+        
+        // new JMS\SerializerBundle\JMSSerializerBundle($this),
     );
 }
 ```


### PR DESCRIPTION
Composer install doesn't register JMSSerializerBundle. In documentation, we should remind this important detail to user.
