### PR TITLE
[WIP] Fix ParamFetcher scalar parameter and default=null with strict

### DIFF
--- a/Tests/Request/ParamFetcherTest.php
+++ b/Tests/Request/ParamFetcherTest.php
@@ -67,6 +67,11 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $annotations['boo']->name = 'boo';
         $annotations['boo']->description = 'An array with no default value';
 
+        $annotations['boozz'] = new QueryParam;
+        $annotations['boozz']->name = 'boozz';
+        $annotations['boozz']->requirements = '\d+';
+        $annotations['boozz']->description = 'A scalar param with no default value (an optional limit param for example)';
+
         $this->paramReader
             ->expects($this->any())
             ->method('read')
@@ -121,35 +126,35 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
             array( // check that non-strict missing params take default value
                 'foo',
                 '1',
-                array('foo' => '1', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array()),
+                array('foo' => '1', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null),
                 array(),
                 array('bar' => '2', 'baz' => '4'),
             ),
             array( // pass Param in GET
                 'foo',
                 '42',
-                array('foo' => '42', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array()),
+                array('foo' => '42', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null),
                 array('foo' => '42'),
                 array('bar' => '2', 'baz' => '4'),
             ),
             array( // check that invalid non-strict params take default value
                 'foo',
                 '1',
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array()),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null),
                 array('foo' => 'bar'),
                 array('bar' => '1', 'baz' => '4'),
             ),
             array( // invalid array
                 'buzz',
                 array(1),
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array()),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null),
                 array('buzz' => 'invaliddata'),
                 array('bar' => '1', 'baz' => '4'),
             ),
             array( // invalid array (multiple depth)
                 'buzz',
                 array(1),
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array()),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null),
                 array('buzz' => array(array(1))),
                 array('bar' => '1', 'baz' => '4'),
             ),
@@ -157,39 +162,61 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
             array( // multiple array
                 'buzz',
                 array(2, 3, 4),
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array()),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null),
                 array('buzz' => array(2, 3, 4)),
                 array('bar' => '1', 'baz' => '4'),
             ),
             array( // multiple array with one invalid value
                 'buzz',
                 array(2, 1, 4),
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 1, 4), 'boo' => array()),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 1, 4), 'boo' => array(), 'boozz' => null),
                 array('buzz' => array(2, 'invaliddata', 4)),
                 array('bar' => '1', 'baz' => '4'),
             ),
             array(  // Array not provided in GET query
                 'boo',
                 array(),
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array()),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null),
                 array('buzz' => array(2, 3, 4)),
                 array('bar' => '1', 'baz' => '4'),
             ),
             array(  // QueryParam provided in GET query but as a scalar
                 'boo',
                 array(),
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array()),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null),
                 array('buzz' => array(2, 3, 4), 'boo' => 'scalar'),
                 array('bar' => '1', 'baz' => '4'),
             ),
             array(  // QueryParam provided in GET query with valid values
                 'boo',
                 array('1', 'foo', 5),
-                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5)),
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => null),
                 array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5)),
                 array('bar' => '1', 'baz' => '4'),
+            ),
+            array(  // QueryParam provided in GET query with valid values
+                'boozz',
+                null,
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => null),
+                array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5)),
+                array('bar' => '1', 'baz' => '4'),
+            ),
+            array(  // QueryParam provided in GET query with valid values
+                'boozz',
+                5,
+                array('foo' => '1', 'bar' => '1', 'baz' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5),
+                array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5),
+                array('bar' => '1', 'baz' => '4', 'boozz' => 5),
             )
         );
+    }
+
+    public function testValidatesConfiguredParamStrictly()
+    {
+        $queryFetcher = $this->getParamFetcher(array(), array());
+        $queryFetcher->setController($this->controller);
+
+        $this->assertNull($queryFetcher->get('boozz', true));
     }
 
     /**


### PR DESCRIPTION
This add a failing test case with a scalar parameter which default value is null.

Reference issue #301
