### PR TITLE
Default value and strict parameters

### DIFF
--- a/Controller/Annotations/Param.php
+++ b/Controller/Annotations/Param.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * Represents a parameter that can be present in GET or POST data.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Boris Guéry <guery.b@gmail.com>
  */
 abstract class Param
 {
@@ -30,4 +31,6 @@ abstract class Param
     public $strict = false;
     /** @var boolean */
     public $array = false;
+    /** @var boolean */
+    public $nullable = false;
 }

--- a/Controller/Annotations/RequestParam.php
+++ b/Controller/Annotations/RequestParam.php
@@ -16,6 +16,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  *
  * @Annotation
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Boris Guéry    <guery.b@gmail.com>
  */
 class RequestParam extends Param
 {

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  * @author Alexander <iam.asm89@gmail.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Boris Guéry <guery.b@gmail.com>
  */
 class ParamFetcher implements ParamFetcherInterface
 {
@@ -80,8 +81,9 @@ class ParamFetcher implements ParamFetcherInterface
             throw new \InvalidArgumentException(sprintf("No @QueryParam/@RequestParam configuration for parameter '%s'.", $name));
         }
 
-        $config  = $this->params[$name];
-        $default = $config->default;
+        $config   = $this->params[$name];
+        $nullable = $config->nullable;
+        $default  = $config->default;
 
         if ($config->array) {
             $default = (array) $default;
@@ -125,8 +127,12 @@ class ParamFetcher implements ParamFetcherInterface
         }
 
         if (!is_scalar($param)) {
-            if ($strict) {
-                throw new \RuntimeException(sprintf("Query parameter value '%s' is not a scalar", $param));
+            if (!$nullable) {
+                if ($strict) {
+                    throw new \RuntimeException(sprintf("Query parameter value '%s' is not a scalar", $param));
+                }
+
+                return $this->cleanParamWithRequirements($config, $param, $strict);
             }
 
             return $default;

--- a/Request/ParamReader.php
+++ b/Request/ParamReader.php
@@ -19,6 +19,7 @@ use FOS\RestBundle\Controller\Annotations\Param;
  *
  * @author Alexander <iam.asm89@gmail.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ * @author Boris Guéry  <guery.b@gmail.com>
  */
 class ParamReader implements ParamReaderInterface
 {

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -256,6 +256,14 @@ class FooController extends Controller
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page of the overview.")
      *
+     * In some case you also want to have a strict requirements but accept a null value, this is possible
+     * thanks to the nullable option.
+     * If ?count= parameter is set, the requirements will be checked strictly, if not, the null value will be used.
+     * If you set the strict parameter without a nullable option, this will result in an error if the parameter is
+     * missing from the query.
+     *
+     * @QueryParam(name="count", requirements="\d+", strict=true, nullable=true, description="Item count limit")
+     *
      * Will look for a firstname request parameters, ie. firstname=foo in POST data.
      * If not passed it will error out when read out of the ParamFetcher since RequestParam defaults to strict=true
      * If passed but doesn't match the requirement "\d+" it will also error out (400 Bad Request)


### PR DESCRIPTION
I wrote PoC for #306 and #301.

> Since the PR #291 has been merged I've got the following exception:
> 
> ```
> Query parameter value '' is not a scalar
> ```
> 
> This is actually because in the ParamFetcher::get the default value is null and not scalar so it does not pass the is_scalar test since I have set the $strict var to true, it fails.
> 
> However I wish the ParamFetcher::cleanParamWithRequirements() method "strictly" validates my parameters, that's why I really need the "$strict" variable to be kept true.
> 
> I can make a PR with a patch but I would like your point of view upfront.

I'm not sure it is the most elegant way to solve the problem neither if it should be solved but it seems legitime to.

However, I think it is excepted to throw an Exception when using `strict` option without an explicitly set default value.

@lsmith77,  any thoughts?
