### PR TITLE
PoC integration with FSCHateoasBundle

### DIFF
--- a/Controller/Annotations/Hateoas.php
+++ b/Controller/Annotations/Hateoas.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Hateoas annotation class.
+ * @Annotation
+ */
+class Hateoas extends Annotation
+{
+    /** @var string */
+    public $subject;
+    /** @var string */
+    public $identifier = 'id';
+    /** @var string */
+    public $relName;
+}

--- a/Routing/HateoasCollectionInterface.php
+++ b/Routing/HateoasCollectionInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Routing;
+
+/**
+ * Hateoas
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+interface HateoasCollectionInterface
+{
+    /**
+     * Get subject class
+     *
+     * @return string
+     */
+    public function getSubject();
+}

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -17,6 +17,7 @@ use Symfony\Component\Routing\Route;
 
 use FOS\RestBundle\Util\Inflector\InflectorInterface;
 use FOS\RestBundle\Routing\RestRouteCollection;
+use FOS\RestBundle\Routing\RestRoute;
 use FOS\RestBundle\Request\ParamReader;
 
 /**
@@ -167,8 +168,18 @@ class RestActionReader
             $resources[] = null;
         }
 
+        $hateoas = $this->readMethodAnnotation($method, 'Hateoas');
+        if ($hateoas && $hateoas->relName) {
+            $relName = $hateoas->relName;
+        } elseif ('get' === $httpMethod) {
+            $relName = empty($arguments) ? 'collection' : 'entity';
+        } else {
+            $relName = false;
+        }
+
         $routeName = $httpMethod.$this->generateRouteName($resources);
-        $urlParts  = $this->generateUrlParts($resources, $arguments, $httpMethod);
+        $placeholders = array();
+        $urlParts  = $this->generateUrlParts($resources, $arguments, $httpMethod, $placeholders, $relName);
 
         // if passed method is not valid HTTP method then it's either
         // a hypertext driver, a custom object (PUT) or collection (GET)
@@ -208,9 +219,12 @@ class RestActionReader
         }
 
         // add route to collection
-        $collection->add($routeName, new Route(
-            $pattern, $defaults, $requirements, $options
-        ));
+        $route = new RestRoute($pattern, $defaults, $requirements, $options);
+        $route->setPlaceholders($placeholders);
+        if ($relName) {
+            $route->setRelName($relName);
+        }
+        $collection->add($routeName, $route);
     }
 
     /**
@@ -338,7 +352,7 @@ class RestActionReader
      *
      * @return array
      */
-    private function generateUrlParts(array $resources, array $arguments, $httpMethod)
+    private function generateUrlParts(array $resources, array $arguments, $httpMethod, array &$placeholders)
     {
         $urlParts = array();
         foreach ($resources as $i => $resource) {
@@ -358,6 +372,7 @@ class RestActionReader
                 } else {
                     $urlParts[] = '{'.$arguments[$i]->getName().'}';
                 }
+                $placeholders[] = $arguments[$i]->getName();
             } elseif (null !== $resource) {
                 if ((0 === count($arguments) && !in_array($httpMethod, $this->availableHTTPMethods))
                     || 'new' === $httpMethod

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -69,6 +69,12 @@ class RestControllerReader
             $this->actionReader->setNamePrefix($annotation->value);
         }
 
+        // read hateoas annotation
+        if ($annotation = $this->readClassAnnotation($reflection, 'Hateoas')) {
+            $collection->setSubject($annotation->subject);
+            $collection->setIdentifier($annotation->identifier);
+        }
+
         $resource = array();
         // read route-resource annotation
         if ($annotation = $this->readClassAnnotation($reflection, 'RouteResource')) {

--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -80,6 +80,17 @@ class RestRouteLoader extends Loader
         $collection->prependRouteControllersWithPrefix($prefix);
         $collection->setDefaultFormat($this->defaultFormat);
 
+        if ($collection->getSubject()) {
+            $cacheDir = $this->container->getParameter('kernel.cache_dir');
+            $dir = $cacheDir.'/fos_rest/hateoas';
+            if (!is_dir($dir) && false === $this->container->get('filesystem')->mkdir($dir)) {
+                throw new \RuntimeException(sprintf(
+                    'Could not create hateoas cache directory %s', $dir
+                ));
+            }
+            file_put_contents($dir.'/'.str_replace('\\', '', $collection->getSubject()), serialize($collection));
+        }
+
         return $collection;
     }
 

--- a/Routing/RestRoute.php
+++ b/Routing/RestRoute.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Routing;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * Restful route.
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class RestRoute extends Route
+{
+    private $placeholders;
+    private $relName;
+
+    /**
+     * Set argument names of the route.
+     *
+     * @param array $placeholders argument names
+     */
+    public function setPlaceholders($placeholders)
+    {
+        $this->placeholders = $placeholders;
+    }
+
+    /**
+     * Returns argument names of the route.
+     *
+     * @return array
+     */
+    public function getPlaceholders()
+    {
+        return $this->placeholders;
+    }
+
+    /**
+     * Returns rel name of the route.
+     *
+     * @return string
+     */
+    public function getRelName()
+    {
+        return $this->relName;
+    }
+
+    /**
+     * Set rel name of the route.
+     *
+     * @param string $relName rel name
+     */
+    public function setRelName($relName)
+    {
+        $this->relName = $relName;
+    }
+
+    public function serialize()
+    {
+        $data = parent::serialize();
+        $data = unserialize($data);
+        $data['placeholders'] = $this->placeholders;
+        $data['relName'] = $this->relName;
+        return serialize($data);
+    }
+
+    public function unserialize($data)
+    {
+        parent::unserialize($data);
+        $data = unserialize($data);
+        $this->placeholders = $data['placeholders'];
+        $this->relName = $data['relName'];
+    }
+}

--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -21,6 +21,9 @@ use Symfony\Component\Routing\RouteCollection;
 class RestRouteCollection extends RouteCollection
 {
     private $singularName;
+    private $subject;
+    private $identifier;
+    private $isFormatInRoute = false;
 
     /**
      * Set collection singular name.
@@ -43,6 +46,56 @@ class RestRouteCollection extends RouteCollection
     }
 
     /**
+     * Set route subject class.
+     *
+     * @param string $subject route subject class
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+    }
+
+    /**
+     * Set route subject class.
+     *
+     * @return string
+     */
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    /**
+     * Set subject identifier.
+     *
+     * @param string $identifier route identifier class
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * Set subject identifier.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Check if the format should be set in the route
+     *
+     * @return Boolean
+     */
+    public function isFormatInRoute()
+    {
+        return $this->isFormatInRoute;
+    }
+
+    /**
      * Adds controller prefix to all collection routes.
      *
      * @param string $prefix
@@ -61,6 +114,7 @@ class RestRouteCollection extends RouteCollection
      */
     public function setDefaultFormat($format)
     {
+        $this->isFormatInRoute = true;
         foreach (parent::all() as $route) {
             $route->setDefault('_format', $format);
         }


### PR DESCRIPTION
just opening this to allow for discussion and brain storming.

this is just a proof of concept to show that its possible to leverage the route collection data to add the hateoas link relations.

a proper implementation would add the metadata during the bootstrap phase of Symfony2. this would prevent the runtime overhead and would ensure that the metadata isnt just linked to specific routes/controllers.

this would probably also allow the removal of the `HateoasCollectionInterface`
