### PR TITLE
Adds Content to the list of uncountable words

### DIFF
--- a/Util/Pluralization.php
+++ b/Util/Pluralization.php
@@ -33,7 +33,8 @@ class Pluralization
         'series',
         'fish',
         'sheep',
-        'media'
+        'media',
+        'content'
     );
 
     /**


### PR DESCRIPTION
'Content' does not have the plural 'contents', it is always 'content'.

Example: the _content_ of a website can be singular or plural.

This PR adds 'content' to the static array of uncountable words.
