### PR TITLE
Empty responses

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -130,8 +130,8 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                         ->scalarNode('failed_validation')->defaultValue(Codes::HTTP_BAD_REQUEST)->end()
-                        ->booleanNode('force_no_content_code')->defaultFalse()->end()
-                        ->booleanNode('should_serialize_null')->defaultFalse()->end()
+                        ->scalarNode('empty_content')->defaultValue(Codes::HTTP_NO_CONTENT)->end()
+                        ->booleanNode('serialize_null')->defaultFalse()->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -79,9 +79,12 @@ class FOSRestExtension extends Extension
         }
         $container->setParameter($this->getAlias().'.failed_validation', $config['view']['failed_validation']);
 
-        $container->setParameter($this->getAlias().'.force_no_content_code', $config['view']['force_no_content_code']);
+        if (!is_numeric($config['view']['empty_content'])) {
+            $config['view']['empty_content'] = constant('\FOS\Rest\Util\Codes::'.$config['view']['empty_content']);
+        }
+        $container->setParameter($this->getAlias().'.empty_content', $config['view']['empty_content']);
 
-        $container->setParameter($this->getAlias().'.should_serialize_null', $config['view']['should_serialize_null']);
+        $container->setParameter($this->getAlias().'.serialize_null', $config['view']['serialize_null']);
 
         if (!empty($config['view']['view_response_listener'])) {
             $loader->load('view_response_listener.xml');

--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -14,8 +14,8 @@
         <service id="fos_rest.view_handler.default" class="FOS\RestBundle\View\ViewHandler" public="false">
             <argument>%fos_rest.formats%</argument>
             <argument>%fos_rest.failed_validation%</argument>
-            <argument>%fos_rest.force_no_content_code%</argument>
-            <argument>%fos_rest.should_serialize_null%</argument>
+            <argument>%fos_rest.empty_content%</argument>
+            <argument>%fos_rest.serialize_null%</argument>
             <argument>%fos_rest.force_redirects%</argument>
             <argument>%fos_rest.default_engine%</argument>
             <call method="setContainer">

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -109,30 +109,30 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->container->hasDefinition('fos_rest.view_response_listener'));
     }
 
-    public function testViewForceNoContentCodeDefault()
+    public function testForceEmptyContentDefault()
     {
         $this->extension->load(array(), $this->container);
-        $this->assertFalse($this->container->getParameter('fos_rest.force_no_content_code'));
+        $this->assertEquals(204, $this->container->getParameter('fos_rest.empty_content'));
     }
 
-    public function testViewForceNoContentCodeIsTrue()
+    public function testForceEmptyContentIs200()
     {
-        $config = array('fos_rest' => array('view' => array('force_no_content_code' => true)));
+        $config = array('fos_rest' => array('view' => array('empty_content' => 200)));
         $this->extension->load($config, $this->container);
-        $this->assertTrue($this->container->getParameter('fos_rest.force_no_content_code'));
+        $this->assertEquals(200, $this->container->getParameter('fos_rest.empty_content'));
     }
 
-    public function testViewShouldSerializeNullDefault()
+    public function testViewSerializeNullDefault()
     {
         $this->extension->load(array(), $this->container);
-        $this->assertFalse($this->container->getParameter('fos_rest.should_serialize_null'));
+        $this->assertFalse($this->container->getParameter('fos_rest.serialize_null'));
     }
 
-    public function testViewShouldSerializeNullIsTrue()
+    public function testViewSerializeNullIsTrue()
     {
-        $config = array('fos_rest' => array('view' => array('should_serialize_null' => true)));
+        $config = array('fos_rest' => array('view' => array('serialize_null' => true)));
         $this->extension->load($config, $this->container);
-        $this->assertTrue($this->container->getParameter('fos_rest.should_serialize_null'));
+        $this->assertTrue($this->container->getParameter('fos_rest.serialize_null'));
     }
 
     /**

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -48,14 +48,14 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
     protected $failedValidationCode;
 
     /**
-     * @param int Forces a 204 HTTP response status code when the view data is empty
+     * @param int HTTP response status code when the view data is null
      */
-    protected $forceNoContentCode;
+    protected $emptyContentCode;
 
     /**
      * @param int Whether or not to serialize null view data
      */
-    protected $shouldSerializeNull;
+    protected $serializeNull;
 
     /**
      * @var array if to force a redirect for the given key format, with value being the status code to use
@@ -72,23 +72,23 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
      *
      * @param array   $formats              the supported formats as keys and if the given formats uses templating is denoted by a true value
      * @param int     $failedValidationCode The HTTP response status code for a failed validation
-     * @param Boolean $forceNoContentCode   Forces a 204 HTTP response status code when the view data is empty
-     * @param Boolean $shouldSerializeNull  Whether or not to serialize null view data
+     * @param int     $emptyContentCode     HTTP response status code when the view data is null
+     * @param Boolean $serializeNull        Whether or not to serialize null view data
      * @param array   $forceRedirects       If to force a redirect for the given key format, with value being the status code to use
      * @param string  $defaultEngine        default engine (twig, php ..)
      */
     public function __construct(
         array $formats = null,
         $failedValidationCode = Codes::HTTP_BAD_REQUEST,
-        $forceNoContentCode = false,
-        $shouldSerializeNull = false,
+        $emptyContentCode = Codes::HTTP_NO_CONTENT,
+        $serializeNull = false,
         array $forceRedirects = null,
         $defaultEngine = 'twig'
     ) {
         $this->formats = (array) $formats;
         $this->failedValidationCode = $failedValidationCode;
-        $this->forceNoContentCode = $forceNoContentCode;
-        $this->shouldSerializeNull = $shouldSerializeNull;
+        $this->emptyContentCode = $emptyContentCode;
+        $this->serializeNull = $serializeNull;
         $this->forceRedirects = (array) $forceRedirects;
         $this->defaultEngine = $defaultEngine;
     }
@@ -154,7 +154,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
             return $this->failedValidationCode;
         }
 
-        return null !== $data ? Codes::HTTP_OK : ($this->forceNoContentCode ? Codes::HTTP_NO_CONTENT : Codes::HTTP_OK);
+        return null !== $data ? Codes::HTTP_OK : $this->emptyContentCode;
     }
 
     /**
@@ -351,7 +351,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
         $content = null;
         if ($this->isFormatTemplating($format)) {
             $content = $this->renderTemplate($view, $format);
-        } elseif ($this->shouldSerializeNull || null !== $view->getData()) {
+        } elseif ($this->serializeNull || null !== $view->getData()) {
             $serializer = $this->getSerializer($view);
             $content = $serializer->serialize($view->getData(), $format);
         }


### PR DESCRIPTION
Fixes issue #355

I went ahead and set up defaults to make it somewhat BC... however, I made it so that the serializer, by default, never tries to serialize null values.  I can change this default value, but I feel that you should never really have to serialize an explicitly set null value.

Here are some outputs of what this does:

1)

``` php
echo $this->view()
```

Produces headers:

```
HTTP/1.1 204 No Content
Content-Type: application/json
Connection: keep-alive
cache-control: no-cache
date: Thu, 10 Jan 2013 21:05:48 GMT
```

2)

``` php
echo $this->view(['content' => 'goes here!'])
```

Produces headers:

```
HTTP/1.1 200 OK
Content-Type: application/json
Connection: keep-alive
cache-control: no-cache
date: Thu, 10 Jan 2013 21:07:11 GMT

{ "content": "goes here!" }
```

3)

``` php
echo $this->view()->setStatusCode(Codes::HTTP_NOT_FOUND);
```

Produces headers:

```
HTTP/1.1 404 Not Found
Content-Type: application/json
Connection: keep-alive
cache-control: no-cache
date: Thu, 10 Jan 2013 21:11:36 GMT
```

---

This functionality is disabled by default.  To enable:

``` yml
fos_rest:
    view:
        force_no_content_code: true
```

Included in this PR is also the ability to serialize null values.  This is enabled by default.  To disable and serialize null values:
This functionality is disabled by default.  To enable:

``` yml
fos_rest:
    view:
        should_serialize_null: true
```

... however, I don't know when this would be appropriate... and we can enforce never serializing null values in the ViewHandler and we can remove that commit.
