### PR TITLE
Allow content-type negotiation in 403 handler

### DIFF
--- a/EventListener/AccessDeniedListener.php
+++ b/EventListener/AccessDeniedListener.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
@@ -52,19 +51,23 @@ class AccessDeniedListener extends ExceptionListener
             return false;
         }
 
-        // TODO do we need to do content type negotiation here?
-        if (empty($this->formats[$event->getRequest()->getRequestFormat()])) {
+        $request = $event->getRequest();
+
+        if (empty($this->formats[$request->getRequestFormat()]) && empty($this->formats[$request->getContentType()])) {
             return false;
         }
 
         $handling = true;
 
         $exception = $event->getException();
+
         if ($exception instanceof AccessDeniedException) {
             $exception = new AccessDeniedHttpException('You do not have the necessary permissions', $exception);
             $event->setException($exception);
             parent::onKernelException($event);
         }
+
+        $handling = false;
     }
 
     public static function getSubscribedEvents()

--- a/Tests/EventListener/AccessDeniedListenerTest.php
+++ b/Tests/EventListener/AccessDeniedListenerTest.php
@@ -14,7 +14,6 @@ namespace FOS\RestBundle\Tests\EventListener;
 use FOS\RestBundle\EventListener\AccessDeniedListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -39,12 +38,35 @@ class AccessDeniedListenerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getFormatsDataProvider
+     *
      * @param array $formats
      */
-    public function testAccessDeniedExceptionIsConvertedToAnAccessDeniedHttpException($formats)
+    public function testAccessDeniedExceptionIsConvertedToAnAccessDeniedHttpExceptionForFormat(array $formats, $format)
     {
         $request = new Request();
-        $request->setRequestFormat(key($formats));
+        $request->setRequestFormat($format);
+
+        $this->doTestAccessDeniedExceptionIsConvertedToAnAccessDeniedHttpExceptionForRequest($request, $formats);
+    }
+
+    /**
+     * @dataProvider getContentTypesDataProvider
+     * @param array $contentTypes
+     */
+    public function testAccessDeniedExceptionIsConvertedToAnAccessDeniedHttpExceptionForContentType(array $formats, $contentType)
+    {
+        $request = new Request();
+        $request->headers->set('Content-Type', $contentType);
+
+        $this->doTestAccessDeniedExceptionIsConvertedToAnAccessDeniedHttpExceptionForRequest($request, $formats);
+    }
+
+    /**
+     * @param Request $request
+     * @param array $formats
+     */
+    private function doTestAccessDeniedExceptionIsConvertedToAnAccessDeniedHttpExceptionForRequest(Request $request, array $formats)
+    {
         $exception = new AccessDeniedException();
         $event = new GetResponseForExceptionEvent(new TestKernel(), $request, 'foo', $exception);
         $listener = new AccessDeniedListener($formats, 'foo');
@@ -75,7 +97,14 @@ class AccessDeniedListenerTest extends \PHPUnit_Framework_TestCase
     public static function getFormatsDataProvider()
     {
         return array(
-            array(array('json'  => true)),
+            array(array('json'  => true), 'json'),
+        );
+    }
+
+    public static function getContentTypesDataProvider()
+    {
+        return array(
+            array(array('json'  => true), 'application/json'),
         );
     }
 }


### PR DESCRIPTION
(This should fix https://github.com/FriendsOfSymfony/FOSRestBundle/issues/365)

As well as checking for the _format parameter, also check to see
if the request content-type matches.

It appeared that the static $handling variable was never reset
to false at the end of the method. This caused two consecutive
calls to the handler method to fail during the tests.

Notes:
- Removed two unused use statements.
- Compacted the tests into one helper method to avoid duplicated
  code.
