### PR TITLE
Cache validation with ETag

### DIFF
--- a/Tests/View/ViewTest.php
+++ b/Tests/View/ViewTest.php
@@ -50,7 +50,7 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         $view = RedirectView::create($url, $code);
         $this->assertAttributeEquals($url, 'location', $view);
         $this->assertAttributeEquals(null, 'route', $view);
-        $this->assertAttributeEquals($code, 'statusCode', $view);
+        $this->assertEquals($code, $view->getResponse()->getStatusCode());
 
         $view = new View();
         $location = 'location';
@@ -65,7 +65,7 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         $view = RouteRedirectView::create($routeName);
         $this->assertAttributeEquals($routeName, 'route', $view);
         $this->assertAttributeEquals(null, 'location', $view);
-        $this->assertAttributeEquals(Codes::HTTP_CREATED, 'statusCode', $view);
+        $this->assertEquals(Codes::HTTP_CREATED, $view->getResponse()->getStatusCode());
 
         $view->setLocation($routeName);
         $this->assertAttributeEquals($routeName, 'location', $view);

--- a/View/View.php
+++ b/View/View.php
@@ -30,11 +30,6 @@ class View
     private $data;
 
     /**
-     * @var int
-     */
-    private $statusCode;
-
-    /**
      * @var string|TemplateReference
      */
     private $template;
@@ -96,9 +91,9 @@ class View
      */
     public function __construct($data = null, $statusCode = null, array $headers = array())
     {
-        $this->data = $data;
-        $this->statusCode = $statusCode;
-        $this->templateVar = 'data';
+        $this->setData($data);
+        $this->setStatusCode($statusCode ?: 200);
+        $this->setTemplateVar('data');
         if (!empty($headers)) {
             $this->getResponse()->headers->replace($headers);
         }
@@ -153,7 +148,7 @@ class View
      */
     public function setStatusCode($code)
     {
-        $this->statusCode = $code;
+        $this->getResponse()->setStatusCode($code);
 
         return $this;
     }
@@ -283,7 +278,7 @@ class View
      */
     public function getStatusCode()
     {
-        return $this->statusCode;
+        return $this->getResponse()->getStatusCode();
     }
 
     /**

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -140,7 +140,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
      */
     protected function getStatusCode(View $view, $content = null)
     {
-        if (null !== ($code = $view->getStatusCode())) {
+        if (200 !== ($code = $view->getStatusCode())) {
             return $code;
         }
 


### PR DESCRIPTION
Since #284 it is possible to set Cache-Control headers, but ETags are ignored. For a REST-API it would be an improvement, if you provide can return `304` instead of a huge list (for example). I didn't tried `Last-Modified`, but ideally it should support the full S2-cache feature set.
