### PR TITLE
Fixes #219 - route prefix ignored

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -192,7 +192,7 @@ class RestActionReader
                 $annoRequirements['_method'] = $requirements['_method'];
             }
 
-            $pattern      = $annotation->getPattern() ? $this->routePrefix . '/' . ltrim($annotation->getPattern(), '/') : $pattern;
+            $pattern      = $annotation->getPattern() ? $this->routePrefix . $annotation->getPattern() : $pattern;
             $requirements = array_merge($requirements, $annoRequirements);
             $options      = array_merge($options, $annotation->getOptions());
             $defaults     = array_merge($defaults, $annotation->getDefaults());


### PR DESCRIPTION
Don't have much time, so can't donate a test as well, but I've verified that this fixes the missing prefix issue. Tested against yml prefix as well as class annotation prefix, with method @Get annotation routes.

Fixes #219 
