### PR TITLE
Explicit error when query param is empty 

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -130,7 +130,11 @@ class ParamFetcher implements ParamFetcherInterface
         if (!is_scalar($param)) {
             if (!$nullable) {
                 if ($strict) {
-                    throw new HttpException(Codes::HTTP_BAD_REQUEST, sprintf("Query parameter value '%s' is not a scalar", $param));
+                    $paramType = $config instanceof QueryParam ? 'Query' : 'Request';
+                    $problem = empty($param) ? 'empty' : 'not a scalar';
+
+                    throw new HttpException(Codes::HTTP_BAD_REQUEST,
+                        sprintf('%s parameter "%s" is %s', $paramType, $name, $problem));
                 }
 
                 return $this->cleanParamWithRequirements($config, $param, $strict);


### PR DESCRIPTION
When a param is missing from the query, the exception message is not helpful.
I also removed the read value from the message because it is hardly useful when not a scalar (e.g. "Notice: Array to string conversion" and only "Array" printed).
