### PR TITLE
[WIP] Support Using Directories as a Routing Resource

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -7,6 +7,7 @@
     <parameters>
 
         <parameter key="fos_rest.routing.loader.controller.class">FOS\RestBundle\Routing\Loader\RestRouteLoader</parameter>
+        <parameter key="fos_rest.routing.loader.controller_directory.class">FOS\RestBundle\Routing\Loader\RestRouteDirectoryLoader</parameter>
         <parameter key="fos_rest.routing.loader.yaml_collection.class">FOS\RestBundle\Routing\Loader\RestYamlCollectionLoader</parameter>
         <parameter key="fos_rest.routing.loader.xml_collection.class">FOS\RestBundle\Routing\Loader\RestXmlCollectionLoader</parameter>
         <parameter key="fos_rest.routing.loader.processor.class">FOS\RestBundle\Routing\Loader\RestRouteProcessor</parameter>
@@ -18,6 +19,15 @@
     <services>
 
         <service id="fos_rest.routing.loader.controller" class="%fos_rest.routing.loader.controller.class%">
+            <argument type="service" id="service_container" />
+            <argument type="service" id="file_locator" />
+            <argument type="service" id="controller_name_converter" />
+            <argument type="service" id="fos_rest.routing.loader.reader.controller" />
+            <argument>%fos_rest.routing.loader.default_format%</argument>
+            <tag name="routing.loader" />
+        </service>
+
+        <service id="fos_rest.routing.loader.controller_directory" class="%fos_rest.routing.loader.controller_directory.class%">
             <argument type="service" id="service_container" />
             <argument type="service" id="file_locator" />
             <argument type="service" id="controller_name_converter" />

--- a/Resources/doc/6-automatic-route-generation_multiple-restful-controllers.md
+++ b/Resources/doc/6-automatic-route-generation_multiple-restful-controllers.md
@@ -150,3 +150,36 @@ With this configuration, route name would become:
 
 
 Say NO to name collisions!
+
+Directory of Annotated RESTful controllers
+==========================================
+
+If you have multiple controllers, it may often be convenient to import a whole directory rather
+than each individual controller. You can use the following syntax to import a whole directory:
+
+```yaml
+# app/config/routing.yml
+acme_hello:
+    type:        rest
+    resource:    "@AcmeHelloBundle/Controller/Api"
+    prefix:      /api/hello
+```
+
+You should use the `@NamePrefix` annotation on the controllers in the directory:
+
+```php
+<?php
+
+namespace Acme\HelloBundle\Controller\Api;
+
+use FOS\RestBundle\Controller\Annotations as Rest;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @Rest\NamePrefix("api_hello_")
+ */
+class FooController extends Controller
+{
+    ...
+}
+```

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -59,6 +59,10 @@ class RestControllerReader
         $collection = new RestRouteCollection();
         $collection->addResource(new FileResource($reflection->getFileName()));
 
+        $originalRoutePrefix = $this->actionReader->getRoutePrefix();
+        $originalNamePrefix = $this->actionReader->getNamePrefix();
+        $originalParents = $this->actionReader->getParents();
+
         // read prefix annotation
         if ($annotation = $this->readClassAnnotation($reflection, 'Prefix')) {
             $this->actionReader->setRoutePrefix($annotation->value);
@@ -92,9 +96,9 @@ class RestControllerReader
             $this->actionReader->read($collection, $method, $resource);
         }
 
-        $this->actionReader->setRoutePrefix(null);
-        $this->actionReader->setNamePrefix(null);
-        $this->actionReader->setParents(array());
+        $this->actionReader->setRoutePrefix($originalRoutePrefix);
+        $this->actionReader->setNamePrefix($originalNamePrefix);
+        $this->actionReader->setParents($originalParents);
 
         return $collection;
     }

--- a/Routing/Loader/RestRouteDirectoryLoader.php
+++ b/Routing/Loader/RestRouteDirectoryLoader.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Routing\Loader;
+
+use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Directory of REST-enabled controllers router loader.
+ * Based mostly on: Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+ *
+ * @author Chad Sikorra <chad.sikorra@gmail.com>
+ */
+class RestRouteDirectoryLoader extends RestRouteLoader
+{
+    /**
+     * Loads a Routes collection by parsing Controller method names from a directory of controllers.
+     *
+     * @param string $path   The path/resource where the controllers are located
+     * @param string $type   The resource type
+     *
+     * @return RouteCollection A RouteCollection instance
+     */
+    public function load($path, $type = null)
+    {
+        $dir = $this->locator->locate($path);
+
+        $collection = new RouteCollection();
+        $collection->addResource(new DirectoryResource($dir, '/\.php$/'));
+        $files = iterator_to_array(new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir), \RecursiveIteratorIterator::LEAVES_ONLY));
+        usort($files, function (\SplFileInfo $a, \SplFileInfo $b) {
+            return (string) $a > (string) $b ? 1 : -1;
+        });
+
+        foreach ($files as $file) {
+            if (!$file->isFile() || '.php' !== substr($file->getFilename(), -4)) {
+                continue;
+            }
+
+            if ($class = $this->findClass($file)) {
+                $refl = new \ReflectionClass($class);
+                if ($refl->isAbstract()) {
+                    continue;
+                }
+                list($prefix, $class) = $this->getControllerLocator($class);
+
+                $restCollection = $this->controllerReader->read($refl);
+                $restCollection->prependRouteControllersWithPrefix($prefix);
+                $restCollection->setDefaultFormat($this->defaultFormat);
+
+                $collection->addCollection($restCollection);
+            }
+        }
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        try {
+            $path = $this->locator->locate($resource);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return is_string($resource)
+            && 'rest' === $type
+            && is_dir($path);
+    }
+}

--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -93,10 +93,16 @@ class RestRouteLoader extends Loader
      */
     public function supports($resource, $type = null)
     {
+        try {
+            $path = $this->locator->locate($resource);
+        } catch (\Exception $e) {
+            $path = null;
+        }
+
         return is_string($resource)
             && 'rest' === $type
-            && !in_array(pathinfo($resource, PATHINFO_EXTENSION), array('xml', 'yml')
-        );
+            && !in_array(pathinfo($resource, PATHINFO_EXTENSION), array('xml', 'yml'))
+            && !is_dir($path);
     }
 
     /**
@@ -106,7 +112,7 @@ class RestRouteLoader extends Loader
      *
      * @return array
      */
-    private function getControllerLocator($controller)
+    protected function getControllerLocator($controller)
     {
         $class  = null;
         $prefix = null;

--- a/Routing/Loader/RestRouteProcessor.php
+++ b/Routing/Loader/RestRouteProcessor.php
@@ -49,6 +49,9 @@ class RestRouteProcessor
 
         if ($loader instanceof FileLoader && null !== $currentDir) {
             $resource = $loader->getLocator()->locate($resource, $currentDir);
+        } elseif ($loader instanceof RestRouteDirectoryLoader) {
+            $loader->getControllerReader()->getActionReader()->setParents($parents);
+            $loader->getControllerReader()->getActionReader()->setNamePrefix($namePrefix);
         } elseif ($loader instanceof RestRouteLoader) {
             $loader->getControllerReader()->getActionReader()->setParents($parents);
             $loader->getControllerReader()->getActionReader()->setRoutePrefix($routePrefix);

--- a/Tests/Routing/Loader/LoaderTest.php
+++ b/Tests/Routing/Loader/LoaderTest.php
@@ -14,8 +14,10 @@ namespace FOS\RestBundle\Tests\Routing\Loader;
 use Doctrine\Common\Annotations\AnnotationReader;
 
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Config\FileLocator;
 
 use FOS\RestBundle\Routing\Loader\RestRouteLoader;
+use FOS\RestBundle\Routing\Loader\RestRouteDirectoryLoader;
 use FOS\RestBundle\Routing\Loader\Reader\RestControllerReader;
 use FOS\RestBundle\Routing\Loader\Reader\RestActionReader;
 use FOS\RestBundle\Request\ParamReader;
@@ -43,14 +45,12 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
         return new AnnotationReader();
     }
 
-    protected function getControllerLoader()
+    private function getControllerLoaderArguments()
     {
         $c = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
             ->disableOriginalConstructor()
             ->getMock();
-        $l = $this->getMockBuilder('Symfony\Component\Config\FileLocator')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $l = new FileLocator();
         $p = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser')
             ->disableOriginalConstructor()
             ->getMock();
@@ -62,6 +62,20 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
         $ar = new RestActionReader($annotationReader, $paramReader, $inflector, true);
         $cr = new RestControllerReader($ar, $annotationReader);
 
-        return new RestRouteLoader($c, $l, $p, $cr, 'html');
+        return array($c, $l, $p, $cr, 'html');
+    }
+
+    protected function getControllerLoader()
+    {
+        list($c, $l, $p, $cr, $df) = $this->getControllerLoaderArguments();
+
+        return new RestRouteLoader($c, $l, $p, $cr, $df);
+    }
+
+    protected function getControllerDirectoryLoader()
+    {
+        list($c, $l, $p, $cr, $df) = $this->getControllerLoaderArguments();
+
+        return new RestRouteDirectoryLoader($c, $l, $p, $cr, $df);
     }
 }

--- a/Tests/Routing/Loader/RestRouteDirectoryLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteDirectoryLoaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Routing\Loader;
+
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * RestRouteDirectoryLoader test.
+ *
+ * @author Chad Sikorra <chad.sikorra@gmail.com>
+ */
+class RestRouteDirectoryLoaderTest extends LoaderTest
+{
+    /**
+     * Test that it will support a directory but ignore a file
+     */
+    public function testLoaderSupport()
+    {
+        $loader = $this->getControllerDirectoryLoader();
+
+        $this->assertfalse($loader->supports('FOS\RestBundle\Tests\Fixtures\Controller\UsersController', 'rest'));
+        $this->assertTrue($loader->supports(__DIR__ . '/../../Fixtures/Controller', 'rest'));
+    }
+
+    /**
+     * Test that all the controllers routes in the directory get loaded
+     */
+    public function testLoadControllerDirectory()
+    {
+        $loader = $this->getControllerDirectoryLoader();
+        $collection = $loader->load(__DIR__ . '/../../Fixtures/Controller');
+
+        $this->assertTrue($collection instanceof RouteCollection);
+        $this->assertEquals(76, count($collection->all()));
+    }
+}

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -160,6 +160,17 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
+     * Test that it will support a controller but ignore a directory
+     */
+    public function testLoaderSupport()
+    {
+        $loader = $this->getControllerLoader();
+
+        $this->assertTrue($loader->supports('FOS\RestBundle\Tests\Fixtures\Controller\UsersController', 'rest'));
+        $this->assertFalse($loader->supports(__DIR__.'/../../Fixtures/Controller', 'rest'));
+    }
+
+    /**
      * Load routes collection from fixture class under Tests\Fixtures directory.
      *
      * @param string $fixtureName name of the class fixture


### PR DESCRIPTION
This change lets you import all controllers in a directory using a syntax like `@AcmeDemoBundle/Controller/Api`. I recently wanted to do this in a project and realized it wasn't currently possible. This fixes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/189