### PR TITLE
Added compatibility with Symfony 2.2.1

### DIFF
--- a/Routing/Loader/RestYamlCollectionLoader.php
+++ b/Routing/Loader/RestYamlCollectionLoader.php
@@ -92,7 +92,7 @@ class RestYamlCollectionLoader extends YamlFileLoader
 
                 $imported->addPrefix($prefix);
                 $collection->addCollection($imported);
-            } elseif (isset($config['pattern'])) {
+            } elseif (isset($config['pattern']) || isset($config['path'])) {
                 $this->parseRoute($collection, $name, $config, $path);
             } else {
                 throw new \InvalidArgumentException(sprintf('Unable to parse the "%s" route.', $name));


### PR DESCRIPTION
Hi.

Do you have any plan to upgrade bundle for compatibility with the new version of the framework?

There is conflict with: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Loader/YamlFileLoader.php#L127

Do you prefer merge this PR or in the near future there will be a tag with full compatibility with 2.2.1 or 2.3?

Regards,
Dmitry
