### PR TITLE
add CLASS to @View annotation scopes

### DIFF
--- a/Controller/Annotations/View.php
+++ b/Controller/Annotations/View.php
@@ -16,7 +16,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 /**
  * View annotation class.
  * @Annotation
- * @Target("METHOD")
+ * @Target({"METHOD","CLASS"})
  */
 class View extends Template
 {


### PR DESCRIPTION
The @View annotation can be used on class  level without breaking functionality. 
Or is there a particular reason we have to annotate each action?

This PR widens the scope of the annotation to allow @View on Class level for all actions.
