### PR TITLE
Add fos_rest.serializer.serialize_null to control null value serializati...

### DIFF
--- a/Resources/doc/configuration-reference.md
+++ b/Resources/doc/configuration-reference.md
@@ -6,57 +6,58 @@ fos_rest:
     access_denied_listener:
 
         # Prototype
-        name:                 []
-    param_fetcher_listener:  false
-    cache_dir:            %kernel.cache_dir%/fos_rest
-    allowed_methods_listener:  false
+        name:                   []
+    param_fetcher_listener:     false
+    cache_dir:                  %kernel.cache_dir%/fos_rest
+    allowed_methods_listener:   false
     routing_loader:
-        default_format:       ~
-        include_format:       ~
+        default_format:         ~
+        include_format:         ~
     service:
-        router:               router
-        templating:           templating
-        serializer:           jms_serializer.serializer
-        view_handler:         fos_rest.view_handler.default
+        router:                 router
+        templating:             templating
+        serializer:             jms_serializer.serializer
+        view_handler:           fos_rest.view_handler.default
     serializer:
-        version:              ~
-        groups:               []
+        version:                ~
+        groups:                 []
+        serialize_null:         false
     view:
-        default_engine:       twig
+        default_engine:         twig
         force_redirects:
 
             # Prototype
-            name:                 []
+            name:               []
         mime_types:
 
             # Prototype
-            name:                 []
+            name:               []
         formats:
 
             # Prototype
-            name:                 []
+            name:               []
         templating_formats:
 
             # Prototype
-            name:                 []
-        view_response_listener:  false
-        failed_validation:       400
-        empty_content:           204
-        serialize_null:          false
+            name:               []
+        view_response_listener: false
+        failed_validation:      400
+        empty_content:          204
+        serialize_null:         false
     exception:
         codes:
 
             # Prototype
-            name:                 []
+            name:               []
         messages:
 
             # Prototype
-            name:                 []
+            name:               []
     body_listener:
         decoders:
 
             # Prototype
-            name:                 []
+            name:               []
     body_converter: false
     format_listener:
         default_priorities:
@@ -64,7 +65,7 @@ fos_rest:
             # Defaults:
             - html
             - */*
-        prefer_extension:     true
-        fallback_format:      html
+        prefer_extension:       true
+        fallback_format:        html
 ```
 

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -220,6 +220,9 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
             }
         }
 
+        $serializeNull = $this->container->getParameter('fos_rest.serializer.serialize_null');
+        $context->setSerializeNull($serializeNull);
+
         return $context;
     }
 
@@ -374,7 +377,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
 
         return $response;
     }
-    
+
     /**
      * Initializes a response object that represents the view and holds the view's status code.
      *
@@ -383,7 +386,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
      *
      * @return Response
      */
-    private function initResponse(View $view, $format) 
+    private function initResponse(View $view, $format)
     {
         $content = null;
         if ($this->isFormatTemplating($format)) {
@@ -406,5 +409,5 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
         }
 
         return $response;
-    }    
+    }
 }


### PR DESCRIPTION
...on

The JMS serializer by default will not serialize keys with a null value.
This new parameter allows control of this behavior via the FOSRestBundle
configuration in app/config/config.yml.
Setting fos_rest.serializer.serialize_null to true will cause the
setSerializeNull() method on the Context object to be called with the
value that is set in the configuration.
Add test case to check that the Context Object has its member
$serializeNull set to the correct value.
Add new parameter to the Resource/doc/configuration-reference.md
documentation file.
