### PR TITLE
ViewHandler, check Serializer against Interface, not against concrete class

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -11,7 +11,7 @@
 
 namespace FOS\RestBundle\View;
 
-use JMS\Serializer\Serializer;
+use JMS\Serializer\SerializerInterface;
 use JMS\Serializer\SerializationContext;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -393,7 +393,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
             $content = $this->renderTemplate($view, $format);
         } elseif ($this->serializeNull || null !== $view->getData()) {
             $serializer = $this->getSerializer($view);
-            if ($serializer instanceof Serializer) {
+            if ($serializer instanceof SerializerInterface) {
                 $context = $this->getSerializationContext($view);
                 $content = $serializer->serialize($view->getData(), $format, $context);
             } else {


### PR DESCRIPTION
In the ViewHandler, allow receiving the context for Serializer class that implement JMSSerializerInterface
