### PR TITLE
Update FOSRestExtension.php

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -165,6 +165,8 @@ class FOSRestExtension extends Extension
                     'fos_rest.converter.request_body.validation_errors_argument',
                     $config['body_converter']['validation_errors_argument']
                 );
+            } else {
+                $container->setParameter('fos_rest.converter.request_body.validation_errors_argument', null);
             }
         }
     }


### PR DESCRIPTION
Fixed fos_rest.converter.request_body.validation_errors_argument argument if validate param of body_converter is false.

Avoid Fatal error: Uncaught exception 'Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException' with message 'The service "fos_rest.converter.request_body" has a dependency on a non-existent parameter "fos_rest.converter.request_body.validation_errors_argument".' in /home/valentin/web2/akinator_api/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php on line 108
