### PR TITLE
Added set Content-Length to create response in the ViewHandler

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -374,6 +374,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
         if (!$response->headers->has('Content-Type')) {
             $response->headers->set('Content-Type', $request->getMimeType($format));
         }
+        $response->headers->set('Content-Length', strlen($content));
 
         return $response;
     }


### PR DESCRIPTION
I've added set Content-Length to the create response in the ViewHandler because this is useful if you are using the API in combination with mobile apps. This way mobile apps can show a loading screen while downloading / parsing data.
