### PR TITLE
fix duplication route prefix in RestCollectionLoader

### DIFF
--- a/Routing/Loader/RestXmlCollectionLoader.php
+++ b/Routing/Loader/RestXmlCollectionLoader.php
@@ -81,7 +81,6 @@ class RestXmlCollectionLoader extends XmlFileLoader
                     $this->collectionParents[$name] = $parents;
                 }
 
-                $imported->addPrefix($prefix);
                 $collection->addCollection($imported);
                 break;
             default:

--- a/Routing/Loader/RestYamlCollectionLoader.php
+++ b/Routing/Loader/RestYamlCollectionLoader.php
@@ -90,7 +90,6 @@ class RestYamlCollectionLoader extends YamlFileLoader
                     $this->collectionParents[$name] = $parents;
                 }
 
-                $imported->addPrefix($prefix);
                 $collection->addCollection($imported);
             } elseif (isset($config['pattern']) || isset($config['path'])) {
                 $this->parseRoute($collection, $name, $config, $path);


### PR DESCRIPTION
The prefix is included in the import resource:
`$imported = $this->processor->importResource($this, $resource, $parents, $prefix, $namePrefix, $type, $currentDir);`

In the line
`$imported->addPrefix($prefix);`
prefix again added

Generated route:
`/api/foo/foo/bar`
instead:
`/api/foo/bar`
