### PR TITLE
Update ViewHandler to return content of response code is 202 Accepted

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -278,7 +278,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
     public function createRedirectResponse(View $view, $location, $format)
     {
         $content = null;
-        if ($view->getStatusCode() == Codes::HTTP_CREATED && $view->getData() != null) {
+        if (($view->getStatusCode() == Codes::HTTP_CREATED || $view->getStatusCode() == Codes::HTTP_ACCEPTED) && $view->getData() != null) {
             $response = $this->initResponse($view, $format);
         } else {
             $response = $view->getResponse();


### PR DESCRIPTION
If you have a view with statuscode 201, the content is ignored. This is wrong - it should work in the same manner as responses for 201 - Created.

From the RFC (http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html):

> 10.2.3 202 Accepted
> [...] The entity returned with this response SHOULD include an indication of the request's current status and either a pointer to a status monitor or some estimate of when the user can expect the request to be fulfilled.

This pull request allows that.
