### PR TITLE
fix issue where the view handler when enabling the jsonp support would not be public

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -135,6 +135,7 @@ class FOSRestExtension extends Extension
 
         if (!empty($config['view']['jsonp_handler'])) {
             $handler = new DefinitionDecorator($config['service']['view_handler']);
+            $handler->setPublic(true);
 
             $jsonpHandler = new Reference($this->getAlias().'.view_handler.jsonp');
             $handler->addMethodCall('registerHandler', array('jsonp', array($jsonpHandler, 'createResponse')));


### PR DESCRIPTION
attempt at fixing https://github.com/FriendsOfSymfony/FOSRestBundle/pull/266#issuecomment-22699781

@stof can you give me a hint here?
i didnt manage to reproduce the issue but it can be because of various examples I have that might for some reason change the default behavior. I can however see how things might be wrong without this change.
