### PR TITLE
Get format for negotation from the correct request attribute

### DIFF
--- a/Util/FormatNegotiator.php
+++ b/Util/FormatNegotiator.php
@@ -39,6 +39,12 @@ class FormatNegotiator implements FormatNegotiatorInterface
 
         if ($preferExtension) {
             $extension = $request->get('_format');
+
+            // Due to symfony/symfony#8778
+            if (empty($extension) && $request->attributes->has('exception')) {
+                $extension = $request->attributes->get('format');
+            }
+            
             if (null !== $extension && $request->getMimeType($extension)) {
                 if ($acceptHeader) {
                     $acceptHeader.= ',';


### PR DESCRIPTION
In the case of exceptions, content negotation isn't properly
being passed the right format.  This is a workaround until
symfony/symfony#8778 is merged.
