### PR TITLE
Allow array notation for QueryParam

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -95,7 +95,7 @@ class ParamFetcher implements ParamFetcherInterface
         }
 
         if ($config instanceof RequestParam) {
-            $param = $this->request->request->get($name, $default);
+            $param = $this->request->request->get($name, $default, true);
         } elseif ($config instanceof QueryParam) {
             $param = $this->request->query->get($name, $default);
         } else {


### PR DESCRIPTION
Related to issue #529
It's not possible to use the array notation with annotation currently(or, at least, I didn't find a way to do so).
When providing a JSON object with sub-object it's not possible to set requirements on this sub-object.
For instance : 

``` javascript
{name: "Paul",
category: { 
   id:3,
   name: "Gardener"
  }
}
```

We can't specify that we need category id to be an integer using the category[id] notation.

I don't know if I missed something and if a reason exists to prevent this behavior.
