### PR TITLE
Add support for not pluralizing an url

### DIFF
--- a/Controller/Annotations/RouteResource.php
+++ b/Controller/Annotations/RouteResource.php
@@ -18,6 +18,15 @@ namespace FOS\RestBundle\Controller\Annotations;
  */
 class RouteResource
 {
-    /** @var string required */
+    /**
+     * @var string required
+     */
     public $resource;
+
+    /**
+     * @var boolean
+     */
+    public $pluralize = false;
+
+
 }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -432,4 +432,13 @@ class RestActionReader
             return $annotation;
         }
     }
+    
+    /**
+     * Set the inflector for the reder.
+     * @param InflectorInterface $inflector
+     */
+    public function setInflector($inflector) 
+    {
+        $this->inflector = $inflector;
+    }
 }

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -73,6 +73,10 @@ class RestControllerReader
         // read route-resource annotation
         if ($annotation = $this->readClassAnnotation($reflection, 'RouteResource')) {
             $resource = explode('_', $annotation->resource);
+            var_dump($annotation->pluralize);
+            if ($annotation->pluralize === false) {
+                $this->actionReader->setInflector(new NullInflector());
+            }
         } elseif ($reflection->implementsInterface('FOS\RestBundle\Routing\ClassResourceInterface')) {
             $resource  = preg_split(
                 '/([A-Z][^A-Z]*)Controller/', $reflection->getShortName(), -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE

--- a/Tests/Fixtures/Controller/AnnotatedNonPlurlizedArticleController.php
+++ b/Tests/Fixtures/Controller/AnnotatedNonPlurlizedArticleController.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Routing\ClassResourceInterface;
+use FOS\RestBundle\Controller\FOSRestController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use FOS\RestBundle\Controller\Annotations as Rest;
+
+/**
+ *  @Rest\RouteResource("Article", false)
+ */
+class AnnotatedNonPlurlizedArticleController extends FosRestController
+{
+    public function cgetAction()
+    {} // [GET] /article
+
+    public function getAction($slug)
+    {} // [GET] /article/{slug}
+}

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -106,6 +106,21 @@ class RestRouteLoaderTest extends LoaderTest
         }
     }
 
+    public function testDisabledPluralization() 
+    {
+        $collection = $this->loadFromControllerFixture('AnnotatedNonPlurlizedArticleController');
+
+        foreach($collection as $name => $params) {
+            $route = $collection->get($name);
+            print $name . " " . $route->getPattern() . "\n";
+        }
+
+        $cget = $collection->get('get_article');
+        $this->assertEquals('/article/', $cget->getPattern());
+
+    }
+
+
     /**
      * Test that a custom format annotation is not overwritten
      */

--- a/Util/Inflector/NullInflector.php
+++ b/Util/Inflector/NullInflector.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of the FOSRestBundle package.
+ * 
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ * 
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace FOS\RestBundle\Util\Inflector;
+
+/**
+ * Inflector object that does not pluralize 
+ * 
+ * @author Tarjei Huse <tarjei.huse@gmail.com>
+ */
+class NullInflector implements InflectorInterface
+{
+    public function pluralize($word)
+    {
+        return $word;
+    }
+}


### PR DESCRIPTION
This is an attempt to fix #294.  
This commit tries to add support for not pluralizing urls by adding an
extra parameter to the RouteResource annotation
    @RouteResource("user", false)

Right now the tests fails bc the annotation system does not like this.