### PR TITLE
simplified installation documentation

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -1,6 +1,7 @@
 Step 1: Setting up the bundle
 =============================
-### A) Download FOSRestBundle
+
+### A) Install FOSRestBundle
 
 **Note:**
 
@@ -10,66 +11,13 @@ Step 1: Setting up the bundle
 > If you do not add a dependency to JMSSerializerBundle, you will need to manually setup an alternative
 > service and configure the Bundle to use it via the ``service`` section in the app config
 
-Ultimately, the FOSRestBundle files should be downloaded to the
-`vendor/bundles/FOS/RestBundle` directory.
-
-This can be done in several ways, depending on your preference. The first
-method is the standard Symfony2 method.
-
-**Using the vendors script**
-
-Add the following lines in your `deps` file:
-
-```
-[FOSRest]
-    git=git://github.com/FriendsOfSymfony/FOSRest.git
-    target=fos/FOS/Rest
-
-[FOSRestBundle]
-    git=git://github.com/FriendsOfSymfony/FOSRestBundle.git
-    target=bundles/FOS/RestBundle
-```
-
-Now, run the vendors script to download the bundle:
-
-``` bash
-$ php bin/vendors install
-```
-
-**Using submodules**
-
-If you prefer instead to use git submodules, then run the following:
-
-``` bash
-$ git submodule add git://github.com/FriendsOfSymfony/FOSRestBundle.git vendor/bundles/FOS/RestBundle
-$ git submodule add git://github.com/FriendsOfSymfony/FOSRest.git vendor/fos/FOS/Rest
-$ git submodule update --init
-```
-
-**Using composer**
-
 Simply run assuming you have installed composer.phar or composer binary:
 
 ``` bash
 $ composer require friendsofsymfony/rest-bundle
 ```
 
-### B) Configure the Autoloader (not needed for composer)
-
-Add the `FOS` namespace to your autoloader:
-
-``` php
-<?php
-// app/autoload.php
-
-$loader->registerNamespaces(array(
-    // ...
-    'FOS\\Rest' => __DIR__.'/../vendor/fos',
-    'FOS'       => __DIR__.'/../vendor/bundles',
-));
-```
-
-### C) Enable the bundle
+### B) Enable the bundle
 
 Finally, enable the bundle in the kernel:
 
@@ -92,4 +40,5 @@ public function registerBundles()
 ```
 
 ## That was it!
+
 Check out the docs for information on how to use the bundle! [Return to the index.](index.md)


### PR DESCRIPTION
As the bundle requires Symfony 2.1+, we can safely keep the Composer way of installing the bundle (the method using the vendors.php file does not exist in 2.1 and using a submodule is not recommended anyway).
