### PR TITLE
Moved dependencies from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,16 @@
         "friendsofsymfony/rest":          ">=0.7.0,<0.9.0-dev",
         "symfony/framework-bundle":       "~2.1",
         "doctrine/inflector":             "1.0.*",
-        "willdurand/negotiation":         "1.0.*"
-    },
-
-    "require-dev": {
+        "willdurand/negotiation":         "1.0.*",
         "sensio/framework-extra-bundle":  "~2.1",
         "symfony/form": "~2.1",
         "symfony/yaml": "~2.1",
         "symfony/security": "~2.1",
         "jms/serializer-bundle": "0.12.*"
+    },
+
+    "require-dev": {
+
     },
 
     "suggest": {


### PR DESCRIPTION
Dependencies from require-dev should be moved to require

They are hardcoded in Bundle anyway and cause exceptions when installed in production environment.

Require-dev ( http://getcomposer.org/doc/04-schema.md#require-dev )
_Lists packages required for developing this package, or running tests, etc._

Most of developers could miss that problem because we usually work in dev environment and later install application through deployment scripts which usually use composer.lock file.

I left empty require-dev on purpose, let me know if you disagree with that.
### Examples of hard coded dependencies

**JMS/SerializerBundle dependency**

```
php app/console container:debug

  [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]   
  Unable to replace alias "jms_serializer.serializer" with "fos_rest.serializer".                                                                         


  [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]  
  The service definition "jms_serializer.serializer" does not exist.          
```

**JMS/SerializerBundle and Sensio\FrameworkExtraBundle dependency**
at the beginning

```
use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;

use Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener;

use JMS\Serializer\SerializationContext;
```

https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/EventListener/ViewResponseListener.php
