### PR TITLE
[WIP] accept header based selection of the controller

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -100,6 +100,7 @@ class Configuration implements ConfigurationInterface
         $this->addExceptionSection($rootNode);
         $this->addBodyListenerSection($rootNode);
         $this->addFormatListenerSection($rootNode);
+        $this->addMediaTypeListenerSection($rootNode);
 
         return $treeBuilder;
     }
@@ -226,6 +227,14 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+            ->end();
+    }
+
+    private function addMediaTypeListenerSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->booleanNode('media_type_listener')->defaultFalse()
             ->end();
     }
 }

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -200,6 +200,10 @@ class FOSRestExtension extends Extension
                 );
             }
         }
+
+        if (!empty($config['media_type_listener'])) {
+            $loader->load('media_type_listener.xml');
+        }
     }
 
     /**

--- a/EventListener/FormatListener.php
+++ b/EventListener/FormatListener.php
@@ -11,7 +11,7 @@
 
 namespace FOS\RestBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -45,7 +45,7 @@ class FormatListener
      *
      * @param GetResponseEvent $event The event
      */
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
         $format = $this->formatNegotiator->getBestFormat($request);

--- a/EventListener/MediaTypeListener.php
+++ b/EventListener/MediaTypeListener.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\EventListener;
+
+use FOS\Rest\Decoder\DecoderProviderInterface;
+
+use FOS\RestBundle\Util\MediaTypeMapperInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * This listener handles Request body decoding.
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class MediaTypeListener
+{
+    /**
+     * @var MediaTypeMapperInterface
+     */
+    private $versionMapper;
+
+    /**
+     * Constructor.
+     *
+     * @param MediaTypeMapperInterface $versionMapper
+     */
+    public function __construct(MediaTypeMapperInterface $versionMapper)
+    {
+        $this->versionMapper = $versionMapper;
+    }
+
+    /**
+     * Core request handler
+     *
+     * @param GetResponseEvent $event The event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        $controllerMap = $request->attributes->get('_controller_map');
+        if ($controllerMap) {
+            $format = $request->getRequestFormat();
+            $acceptHeader = $request->getAcceptableContentTypes();
+            foreach ($acceptHeader as $mediaType) {
+                if ($format === $request->getFormat($mediaType)) {
+                    $controller = $this->versionMapper->map($controllerMap, $mediaType);
+                    break;
+                }
+            }
+
+            if (empty($controller)) {
+                $controller = $this->versionMapper->fallback($controllerMap);
+            }
+
+            if (isset($controller)) {
+                $request->attributes->set('_controller', $controller);
+            }
+        }
+    }
+}

--- a/Resources/config/format_listener.xml
+++ b/Resources/config/format_listener.xml
@@ -7,7 +7,7 @@
     <services>
 
         <service id="fos_rest.format_listener" class="FOS\RestBundle\EventListener\FormatListener">
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="-10" />
             <argument type="service" id="fos_rest.format_negotiator" />
         </service>
 

--- a/Resources/config/media_type_listener.xml
+++ b/Resources/config/media_type_listener.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_rest.media_type_mapper" class="FOS\RestBundle\Util\MediaTypeMapper" />
+
+        <service id="fos_rest.media_type_listener" class="FOS\RestBundle\EventListener\MediaTypeListener">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="-100" />
+            <argument type="service" id="fos_rest.media_type_mapper" />
+        </service>
+
+    </services>
+</container>

--- a/Tests/EventListener/FormatListenerTest.php
+++ b/Tests/EventListener/FormatListenerTest.php
@@ -23,9 +23,9 @@ use FOS\RestBundle\EventListener\FormatListener;
  */
 class FormatListenerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testOnKernelControllerNegotiation()
+    public function testOnKernelRequestNegotiation()
     {
-        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\FilterControllerEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
 
         $request = new Request();
 
@@ -40,7 +40,7 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new FormatListener($formatNegotiator);
 
-        $listener->onKernelController($event);
+        $listener->onKernelRequest($event);
 
         $this->assertEquals($request->getRequestFormat(), 'xml');
     }
@@ -48,9 +48,9 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
      */
-    public function testOnKernelControllerException()
+    public function testOnKernelRequestException()
     {
-        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\FilterControllerEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
 
         $request = new Request();
 
@@ -66,6 +66,6 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new FormatListener($formatNegotiator);
 
-        $listener->onKernelController($event);
+        $listener->onKernelRequest($event);
     }
 }

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,7 +32,8 @@ list important BC breaks.
     _Alternatively you can inject your own implementation. See https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Resources/doc/2-the-view-layer.md#forms-and-views_
 
  * The ``format_listener`` configuration has changed to allow different settings per host/path.
-   Finally the signature of FormatNegotiatorInterface::getBestFormat() changed.
+   Finally the signature of FormatNegotiatorInterface::getBestFormat() changed. Furthermore the
+   format listener now is triggered as a request listener at priority -10
 
 ### upgrading from 0.12.0
 

--- a/Util/MediaTypeMapper.php
+++ b/Util/MediaTypeMapper.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Util;
+
+class MediaTypeMapper implements MediaTypeMapperInterface
+{
+    private $regexp = '/v(\d\.\d)/';
+
+    /**
+     * @param $regexp
+     */
+    public function setRegexp($regexp)
+    {
+        $this->regexp = $regexp;
+    }
+
+    /**
+     * @param array $controllerMap
+     * @param string $mediaType
+     *
+     * @return null|string
+     */
+    public function map(array $controllerMap, $mediaType)
+    {
+        if (preg_match($this->regexp, $mediaType, $matches) && isset($controllerMap['config'][$matches[1]])) {
+            return $controllerMap['config'][$matches[1]];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array $controllerMap
+     *
+     * @return null|string
+     */
+    public function fallback(array $controllerMap)
+    {
+        if (isset($controllerMap['fallback'])
+            && isset($controllerMap['config'][$controllerMap['fallback']])
+        ) {
+            return $controllerMap['config'][$controllerMap['fallback']];
+        }
+
+        return null;
+    }
+}

--- a/Util/MediaTypeMapperInterface.php
+++ b/Util/MediaTypeMapperInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the FOSRest package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Util;
+
+interface MediaTypeMapperInterface
+{
+    /**
+     * @param array $controllerMap
+     * @param string $mediaType
+     *
+     * @return null|string
+     */
+    public function map(array $controllerMap, $mediaType);
+
+    /**
+     * @param array $controllerMap
+     *
+     * @return null|string
+     */
+    public function fallback(array $controllerMap);
+}


### PR DESCRIPTION
Essentially the approach here is to register a listener after the core `RouterListener` that tries to map the controller based on the media type. The media type map is configured inside the route.

Example route:

``` yaml
hello_version:
    pattern:  /liip/version
    defaults:
        _controller_map:
            fallback: '1.0'
            config:
                '1.0': 'liip_hello.world.controller:v1Action'
                '2.0': 'liip_hello.world.controller:v2Action'
        _format: json
```

Todos:
- [ ] don't really like the MediaType\* naming. we already have a MimeTypeListener
- [ ] make it possible to configure a different mapper, should it be possible to configure mappers via the route definition? if so if we support services, we would need a factory that has access to the DIC
- [ ] integrate with the routing generation
- [ ] make it possible to configure version ranges in the default mapper (lift code from https://github.com/composer/composer/blob/master/src/Composer/Package/Version/VersionParser.php or https://github.com/vierbergenlars/php-semver)
- [ ] potentially support a default config by defining some naming convention (potentially allow to configure one naming convention that uses a different controller and another one that uses a different method) so that not all routes need to have an actual `_controller_map` defined (instead one can just use `true` to enable the feature)
- [ ] add tests

@newloki: if you have time to work on any of the above items please let me know via a comment in this ticket.
