### PR TITLE
Change the FormatListener from a controller to a request event

### DIFF
--- a/EventListener/FormatListener.php
+++ b/EventListener/FormatListener.php
@@ -11,7 +11,7 @@
 
 namespace FOS\RestBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -43,9 +43,11 @@ class FormatListener
     /**
      * Determines and sets the Request format
      *
-     * @param FilterControllerEvent $event The event
+     * @param GetResponseEvent $event The event
+     *
+     * @throws HttpException
      */
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
         $format = $this->formatNegotiator->getBestFormat($request);

--- a/Resources/config/format_listener.xml
+++ b/Resources/config/format_listener.xml
@@ -7,7 +7,7 @@
     <services>
 
         <service id="fos_rest.format_listener" class="FOS\RestBundle\EventListener\FormatListener">
-            <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="20" />
             <argument type="service" id="fos_rest.format_negotiator" />
         </service>
 

--- a/Tests/EventListener/FormatListenerTest.php
+++ b/Tests/EventListener/FormatListenerTest.php
@@ -25,7 +25,7 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
 {
     public function testOnKernelControllerNegotiation()
     {
-        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\FilterControllerEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
 
         $request = new Request();
 
@@ -40,7 +40,7 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new FormatListener($formatNegotiator);
 
-        $listener->onKernelController($event);
+        $listener->onKernelRequest($event);
 
         $this->assertEquals($request->getRequestFormat(), 'xml');
     }
@@ -50,7 +50,7 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelControllerException()
     {
-        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\FilterControllerEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder('\Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
 
         $request = new Request();
 
@@ -66,6 +66,6 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new FormatListener($formatNegotiator);
 
-        $listener->onKernelController($event);
+        $listener->onKernelRequest($event);
     }
 }


### PR DESCRIPTION
Controller events are not always called, when for example using the Security layer. As the FormatListener was listening on a controller event, the format negation was not executed, and the response format after a AuthenticationException or AccessDeniedException was always html.

Changing the listener to a request event fixes the issue.

This PR fixes:
- FriendsOfSymfony/FOSRestBundle#548
- FriendsOfSymfony/FOSRestBundle#381
