### PR TITLE
[Proposal] Change how ViewHandler#createRedirectResponse handles 2xx status codes

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -273,7 +273,7 @@ class ViewHandler extends ContainerAware implements ViewHandlerInterface
     public function createRedirectResponse(View $view, $location, $format)
     {
         $content = null;
-        if (($view->getStatusCode() == Codes::HTTP_CREATED || $view->getStatusCode() == Codes::HTTP_ACCEPTED) && $view->getData() != null) {
+        if (substr($view->getStatusCode(), 0, 1) == 2 && $view->getData() != null) {
             $response = $this->initResponse($view, $format);
         } else {
             $response = $view->getResponse();


### PR DESCRIPTION
I dont like that we're only checking 201 and 202 status codes when a Location header is intended. If the user specifically sets the status code to a 2xx series code and provides data, we should treat them the same.
