### PR TITLE
Load body_listener before "security.firewall"

### DIFF
--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -20,7 +20,7 @@
         </service>
 
         <service id="fos_rest.body_listener" class="FOS\RestBundle\EventListener\BodyListener">
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="10" />
             <argument type="service" id="fos_rest.decoder_provider" />
         </service>
 


### PR DESCRIPTION
As of Symfony2.1, the security.firewall is loaded with priority 8 (earlier 64).

To use the body_listener for login-services, it has to be loaded before the firewall.

Please add a priority higher than 8. I just took 10 ...
