### PR TITLE
Replace generic HttpExceptions with more specific subclasses

### DIFF
--- a/EventListener/FormatListener.php
+++ b/EventListener/FormatListener.php
@@ -12,11 +12,9 @@
 namespace FOS\RestBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-use FOS\RestBundle\Util\Codes;
 use FOS\RestBundle\Util\FormatNegotiatorInterface;
 use FOS\RestBundle\Util\MediaTypeNegotiatorInterface;
 
@@ -47,7 +45,7 @@ class FormatListener
      *
      * @param GetResponseEvent $event The event
      *
-     * @throws HttpException
+     * @throws NotAcceptableHttpException
      */
     public function onKernelRequest(GetResponseEvent $event)
     {

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -11,14 +11,12 @@
 
 namespace FOS\RestBundle\Request;
 
-use FOS\RestBundle\Util\Codes;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\Param;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Helper to validate parameters of the active request.
@@ -153,7 +151,7 @@ class ParamFetcher implements ParamFetcherInterface
      * @param string  $param  param to clean
      * @param boolean $strict is strict
      *
-     * @throws \RuntimeException
+     * @throws BadRequestHttpException
      * @return string
      */
     public function cleanParamWithRequirements(Param $config, $param, $strict)
@@ -167,7 +165,9 @@ class ParamFetcher implements ParamFetcherInterface
             if ($strict) {
                 $paramType = $config instanceof QueryParam ? 'Query' : 'Request';
 
-                throw new BadRequestHttpException($paramType . " parameter value '$param', does not match requirements '{$config->requirements}'");
+                throw new BadRequestHttpException(
+                    $paramType . " parameter value '$param', does not match requirements '{$config->requirements}'"
+                );
             }
 
             return null === $default ? '' : $default;

--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -13,7 +13,6 @@ namespace FOS\RestBundle\Request;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\Exception\Exception as SymfonySerializerException;
@@ -25,7 +24,6 @@ use JMS\Serializer\Exception\UnsupportedFormatException;
 use JMS\Serializer\Exception\Exception as JMSSerializerException;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\SerializerInterface;
-use FOS\RestBundle\Util\Codes;
 
 /**
  * @author Tyler Stroud <tyler@tylerstroud.com>

--- a/View/JsonpHandler.php
+++ b/View/JsonpHandler.php
@@ -14,9 +14,6 @@ namespace FOS\RestBundle\View;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-
-use FOS\RestBundle\Util\Codes;
 
 /**
  * Implements a custom handler for JSONP leveraging the ViewHandler

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -278,6 +278,8 @@ class ViewHandler extends ContainerAware implements ConfigurableViewHandlerInter
      * @param Request $request Request object
      *
      * @return Response
+     *
+     * @throws UnsupportedMediaTypeHttpException
      */
     public function handle(View $view, Request $request = null)
     {


### PR DESCRIPTION
Currently, most HttpExceptions thrown are of the generic HttpException class. This pull request makes all HttpExceptions more specific, without breaking unit tests and thus BC, since they all extend from HttpException and set the same status codes.

Explanation:

It would be nice if these exceptions were more specific, so that it would work better in conjunction with `FOS\RestBundle\Controller\ExceptionController::getExceptionMessage` and the accompanying config settings as described in [the documentation](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Resources/doc/4-exception-controller-support.md):

``` yaml
# app/config/config.yml
fos_rest:
    exception:
        codes:
            'Symfony\Component\Routing\Exception\ResourceNotFoundException': 404
            'Doctrine\ORM\OptimisticLockException': HTTP_CONFLICT
        messages:
            'Symfony\Component\HttpKernel\Exception\BadRequestHttpException': true
```

This way users could for instance decide to show messages for a BadRequestHttpException, but not for a UnsupportedMediaTypeHttpException.
