### PR TITLE
[WIP][RFC] yep another [Header API Versioning] recap, todo list, and PR

### DIFF
--- a/Routing/Loader/RestYamlCollectionLoader.php
+++ b/Routing/Loader/RestYamlCollectionLoader.php
@@ -70,6 +70,7 @@ class RestYamlCollectionLoader extends YamlFileLoader
                 $namePrefix = isset($config['name_prefix']) ? $config['name_prefix']    : null;
                 $parent     = isset($config['parent'])      ? $config['parent']         : null;
                 $type       = isset($config['type'])        ? $config['type']           : null;
+                $condition  = isset($config['condition'])   ? $config['condition']      : null;
                 $currentDir = dirname($path);
 
                 $parents = array();
@@ -90,6 +91,9 @@ class RestYamlCollectionLoader extends YamlFileLoader
                     $this->collectionParents[$name] = $parents;
                 }
 
+                if (null !== $condition) {
+                    $imported->setExpressionLanguageCondition($condition);
+                }
                 $imported->addPrefix($prefix);
                 $collection->addCollection($imported);
             } elseif (isset($config['pattern']) || isset($config['path'])) {

--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -67,6 +67,18 @@ class RestRouteCollection extends RouteCollection
     }
 
     /**
+     * Adds condition to all collection routes.
+     *
+     * @param string $condition
+     */
+    public function setExpressionLanguageCondition($condition)
+    {
+        foreach (parent::all() as $route) {
+            $route->setCondition($condition);
+        }
+    }
+
+    /**
      * Returns routes sorted by custom HTTP methods first.
      *
      * @return array


### PR DESCRIPTION
Hi,
a little recap about the issues:
#12 #30, #610, #607,  #136, #561, #612
### A. @lsmith77 approach showed in #561

One route definition, one path, multiple controllers.

``` yml
hello_version:
    pattern:  /liip/version
    defaults:
        _controller_map:
            fallback: '1.0'
            config:
                '1.0': 'liip_hello.world.controller:v1Action'
                '2.0': 'liip_hello.world.controller:v2Action'
        _format: json
```

_pro_ : 
- really clean and easy to use
- partially already implemented
- works with sf 2.*

_cons_: 
- not very flexible (is not possible to add additional parameters and constrains eg version2 is only for xml etc.)

_Note_: need to implement something for the naming collision
### B. @adrienbrault approach showed in #561

``` yml
hello_version_v1:
    pattern:  /liip/version
    defaults:
        _controller: 'liip_hello.world.controller:v1Action'
        _format: json
    condition: 'matchesVersion(request, "1.*")'

hello_version_v2:
    pattern:  /liip/version
    defaults:
        _controller: 'liip_hello.world.controller:v2Action'
        _format: json
    condition: 'matchesVersion(request, "2.*")'
```

_pro_ : 
- flexible uses the Exp.Lang.
- each version has a separated route (so it may possible to add additional parameters and constrains eg version2 is only for xml etc.)

_cons_: 
- different routes same path (is this a problem?)
- will work only in >=SF2.4
- no explicit fallback
### C. @amenophis  in the #612

using annotations `@since`, `@until` is possible to filter controller.

_pro_ : 
- simplest approach
- partially already implemented

_cons_:
- not so clean (maybe because I don't get the goal)
- only annotations (?)
## This PR

This PR just wants to reach the goal of API version asap using the Expression Language, has all the cons of the _B_.

Now already works with

```
users:
    type: rest
    prefix: /
    resource: "@AcmeDemoBundle/Controller/UserController.php"
    name_prefix: api_1_ # naming collision
    condition: "request.headers.get('X-API-Version') matches '/1.0/i'"
```

But is better create a function and register it  (as Adrien has suggested)
the goal is to have:

```
users:
    type: rest
    prefix: /
    resource: "@AcmeDemoBundle/Controller/UserController.php"
    name_prefix: api_1_ # naming collision
    condition: "matchVersion(request.headers.get('X-API-Version'), '>1.0')'"
```

If you decide I could continue with:
- [ ] Tests 
- [ ] Develop and register a `semver` function for the EL

optional:
- [ ] Find a way to register a custom function for the EL

[edited] another thing to do is to find a good way to support old sf2 versions.
