### PR TITLE
Update config format_listener rules to be array prototype fixes #589

### DIFF
--- a/Resources/doc/configuration-reference.md
+++ b/Resources/doc/configuration-reference.md
@@ -73,16 +73,18 @@ fos_rest:
     format_listener:
         rules:
 
-            # URL path info
-            path:                 ~
-
-            # URL host name
-            host:                 ~
-            prefer_extension:     true
-            fallback_format:      html
-            priorities:
-
-                # Prototype
-                name:                 []
+            # Prototype array
+            -
+                # URL path info
+                path:                 ~
+    
+                # URL host name
+                host:                 ~
+                prefer_extension:     true
+                fallback_format:      html
+                priorities:
+    
+                    # Prototype
+                    name:                 []
 ```
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #589 |
| License | MIT |
| Doc PR | update |

Yaml dumper support in symfony/symfony misses this point i think while dumping prototype arrays, this manually fixes the proper way of configuring the rules under format_listener.

great talk guys @willdurand & @lsmith77 
