### PR TITLE
Fix in composer.json (require willdurand/negotiation ~1.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php":                            ">=5.3.2",
         "symfony/framework-bundle":       "~2.2",
         "doctrine/inflector":             "1.0.*",
-        "willdurand/negotiation":         "~1.1.0"
+        "willdurand/negotiation":         "~1.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
Changed willdurand/negotiation version in composer.json to ~1.1 because in ~1.0 method normalizePriorities can't be called (doesn't exist)