### PR TITLE
add support for format related configuration options to the RestYamlColl...

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -31,12 +31,18 @@
         <service id="fos_rest.routing.loader.yaml_collection" class="%fos_rest.routing.loader.yaml_collection.class%">
             <argument type="service" id="file_locator" />
             <argument type="service" id="fos_rest.routing.loader.processor" />
+            <argument>%fos_rest.routing.loader.include_format%</argument>
+            <argument>%fos_rest.formats%</argument>
+            <argument>%fos_rest.routing.loader.default_format%</argument>
             <tag name="routing.loader" />
         </service>
 
         <service id="fos_rest.routing.loader.xml_collection" class="%fos_rest.routing.loader.xml_collection.class%">
             <argument type="service" id="file_locator" />
             <argument type="service" id="fos_rest.routing.loader.processor" />
+            <argument>%fos_rest.routing.loader.include_format%</argument>
+            <argument>%fos_rest.formats%</argument>
+            <argument>%fos_rest.routing.loader.default_format%</argument>
             <tag name="routing.loader" />
         </service>
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -25,13 +25,42 @@ use FOS\RestBundle\DependencyInjection\FOSRestExtension;
  */
 class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ContainerBuilder
+     */
     private $container;
+
+    /**
+     * @var FOSRestExtension
+     */
     private $extension;
+
+    /**
+     * @var boolean
+     */
+    private $includeFormat;
+
+    /**
+     * @var array
+     */
+    private $formats;
+
+    /**
+     * @var string
+     */
+    private $defaultFormat;
 
     public function setUp()
     {
         $this->container = new ContainerBuilder();
         $this->extension = new FOSRestExtension();
+        $this->includeFormat = true;
+        $this->formats = array(
+            'json' => false,
+            'xml'  => false,
+            'html' => true,
+        );
+        $this->defaultFormat = null;
     }
 
     public function tearDown()
@@ -177,14 +206,131 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->container->hasDefinition($yamlCollectionLoaderDefinitionName));
         $this->assertValidRestFileLoader(
             $this->container->getDefinition($yamlCollectionLoaderDefinitionName),
-            $yamlCollectionLoaderClassParameter
+            $yamlCollectionLoaderClassParameter,
+            $this->includeFormat,
+            $this->formats,
+            $this->defaultFormat
         );
 
         $this->assertEquals($xmlCollectionLoaderClass, $this->container->getParameter($xmlCollectionLoaderClassParameter));
         $this->assertTrue($this->container->hasDefinition($xmlCollectionLoaderDefinitionName));
         $this->assertValidRestFileLoader(
             $this->container->getDefinition($xmlCollectionLoaderDefinitionName),
-            $xmlCollectionLoaderClassParameter
+            $xmlCollectionLoaderClassParameter,
+            $this->includeFormat,
+            $this->formats,
+            $this->defaultFormat
+        );
+    }
+
+    public function testIncludeFormatDisabled()
+    {
+        $this->extension->load(
+            array(
+                'fos_rest' => array(
+                    'routing_loader' => array(
+                        'include_format' => false,
+                    ),
+                ),
+            ),
+            $this->container
+        );
+
+        $yamlCollectionLoaderDefinitionName = 'fos_rest.routing.loader.yaml_collection';
+        $yamlCollectionLoaderClassParameter = 'fos_rest.routing.loader.yaml_collection.class';
+        $this->assertValidRestFileLoader(
+            $this->container->getDefinition($yamlCollectionLoaderDefinitionName),
+            $yamlCollectionLoaderClassParameter,
+            false,
+            $this->formats,
+            $this->defaultFormat
+        );
+
+        $xmlCollectionLoaderDefinitionName  = 'fos_rest.routing.loader.xml_collection';
+        $xmlCollectionLoaderClassParameter  = 'fos_rest.routing.loader.xml_collection.class';
+        $this->assertValidRestFileLoader(
+            $this->container->getDefinition($xmlCollectionLoaderDefinitionName),
+            $xmlCollectionLoaderClassParameter,
+            false,
+            $this->formats,
+            $this->defaultFormat
+        );
+    }
+
+    public function testDefaultFormat()
+    {
+        $this->extension->load(
+            array(
+                'fos_rest' => array(
+                    'routing_loader' => array(
+                        'default_format' => 'xml',
+                    ),
+                ),
+            ),
+            $this->container
+        );
+
+        $yamlCollectionLoaderDefinitionName = 'fos_rest.routing.loader.yaml_collection';
+        $yamlCollectionLoaderClassParameter = 'fos_rest.routing.loader.yaml_collection.class';
+        $this->assertValidRestFileLoader(
+            $this->container->getDefinition($yamlCollectionLoaderDefinitionName),
+            $yamlCollectionLoaderClassParameter,
+            $this->includeFormat,
+            $this->formats,
+            'xml'
+        );
+
+        $xmlCollectionLoaderDefinitionName  = 'fos_rest.routing.loader.xml_collection';
+        $xmlCollectionLoaderClassParameter  = 'fos_rest.routing.loader.xml_collection.class';
+        $this->assertValidRestFileLoader(
+            $this->container->getDefinition($xmlCollectionLoaderDefinitionName),
+            $xmlCollectionLoaderClassParameter,
+            $this->includeFormat,
+            $this->formats,
+            'xml'
+        );
+    }
+
+    public function testFormats()
+    {
+        $this->extension->load(
+            array(
+                'fos_rest' => array(
+                    'view' => array(
+                        'formats' => array(
+                            'json' => false,
+                            'xml'  => true,
+                        ),
+                    ),
+                ),
+            ),
+            $this->container
+        );
+
+        $yamlCollectionLoaderDefinitionName = 'fos_rest.routing.loader.yaml_collection';
+        $yamlCollectionLoaderClassParameter = 'fos_rest.routing.loader.yaml_collection.class';
+        $this->assertValidRestFileLoader(
+            $this->container->getDefinition($yamlCollectionLoaderDefinitionName),
+            $yamlCollectionLoaderClassParameter,
+            $this->includeFormat,
+            array(
+                'xml'  => false,
+                'html' => true,
+            ),
+            $this->defaultFormat
+        );
+
+        $xmlCollectionLoaderDefinitionName  = 'fos_rest.routing.loader.xml_collection';
+        $xmlCollectionLoaderClassParameter  = 'fos_rest.routing.loader.xml_collection.class';
+        $this->assertValidRestFileLoader(
+            $this->container->getDefinition($xmlCollectionLoaderDefinitionName),
+            $xmlCollectionLoaderClassParameter,
+            $this->includeFormat,
+            array(
+                'xml'  => false,
+                'html' => true,
+            ),
+            $this->defaultFormat
         );
     }
 
@@ -259,17 +405,43 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
      *
      * @param Definition $loader               loader definition
      * @param string     $loaderClassParameter loader class parameter name
+     * @param boolean    $includeFormat        whether or not the requested view format must be included in the route path
+     * @param string[]   $formats              supported view formats
+     * @param string     $defaultFormat        default view format
      */
-    private function assertValidRestFileLoader(Definition $loader, $loaderClassParameter)
-    {
+    private function assertValidRestFileLoader(
+        Definition $loader,
+        $loaderClassParameter,
+        $includeFormat,
+        array $formats,
+        $defaultFormat
+    ) {
         $locatorRef = new Reference('file_locator');
         $processorRef = new Reference('fos_rest.routing.loader.processor');
         $arguments  = $loader->getArguments();
 
         $this->assertEquals('%' . $loaderClassParameter . '%', $loader->getClass());
-        $this->assertEquals(2, count($arguments));
+        $this->assertEquals(5, count($arguments));
         $this->assertEquals($locatorRef, $arguments[0]);
         $this->assertEquals($processorRef, $arguments[1]);
+        $this->assertEquals(
+            $includeFormat,
+            $this->container->getParameter(
+                strtr($arguments[2], array('%' => ''))
+            )
+        );
+        $this->assertEquals(
+            $formats,
+            $this->container->getParameter(
+                strtr($arguments[3], array('%' => ''))
+            )
+        );
+        $this->assertEquals(
+            $defaultFormat,
+            $this->container->getParameter(
+                strtr($arguments[4], array('%' => ''))
+            )
+        );
         $this->assertArrayHasKey('routing.loader', $loader->getTags());
     }
 

--- a/Tests/Fixtures/Routes/routes.xml
+++ b/Tests/Fixtures/Routes/routes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://friendsofsymfony.github.com/schema/rest"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest
+        http://friendsofsymfony.github.com/schema/rest/routing-1.0.xsd"
+>
+    <route id="get_users" pattern="/users">
+        <default key="_controller">FOSRestBundle:UsersController:getUsers</default>
+    </route>
+</routes>

--- a/Tests/Fixtures/Routes/routes.yml
+++ b/Tests/Fixtures/Routes/routes.yml
@@ -1,0 +1,4 @@
+get_users:
+    path: /users
+    defaults:
+        _controller: FOSRestBundle:UsersController:getUsers

--- a/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
@@ -13,7 +13,7 @@ namespace FOS\RestBundle\Tests\Routing\Loader;
 
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
-
+use Symfony\Component\Routing\RouteCollection;
 use FOS\RestBundle\Routing\Loader\RestRouteProcessor;
 use FOS\RestBundle\Routing\Loader\RestXmlCollectionLoader;
 
@@ -60,16 +60,79 @@ class RestXmlCollectionLoaderTest extends LoaderTest
         }
     }
 
+    public function testManualRoutes()
+    {
+        $collection = $this->loadFromXmlCollectionFixture('routes.xml');
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('/users.{_format}', $route->getPath());
+        $this->assertEquals('json|xml|html', $route->getRequirement('_format'));
+    }
+
+    public function testManualRoutesWithoutIncludeFormat()
+    {
+        $collection = $this->loadFromXmlCollectionFixture('routes.xml', false);
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('/users', $route->getPath());
+    }
+
+    public function testManualRoutesWithFormats()
+    {
+        $collection = $this->loadFromXmlCollectionFixture(
+            'routes.xml',
+            true,
+            array(
+                'json' => false
+            )
+        );
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('json', $route->getRequirement('_format'));
+    }
+
+    public function testManualRoutesWithDefaultFormat()
+    {
+        $collection = $this->loadFromXmlCollectionFixture(
+            'routes.xml',
+            true,
+            array(
+                'json' => false,
+                'xml'  => false,
+                'html' => true,
+            ),
+            'xml'
+        );
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('xml', $route->getDefault('_format'));
+    }
+
     /**
      * Load routes collection from XML fixture routes under Tests\Fixtures directory.
      *
-     * @param string $fixtureName name of the class fixture
+     * @param string   $fixtureName   name of the class fixture
+     * @param boolean  $includeFormat whether or not the requested view format must be included in the route path
+     * @param string[] $formats       supported view formats
+     * @param string   $defaultFormat default view format
+     * @return RouteCollection
      */
-    protected function loadFromXmlCollectionFixture($fixtureName)
-    {
+    protected function loadFromXmlCollectionFixture(
+        $fixtureName,
+        $includeFormat = true,
+        array $formats = array(
+            'json' => false,
+            'xml'  => false,
+            'html' => true,
+        ),
+        $defaultFormat = null
+    ) {
         $collectionLoader = new RestXmlCollectionLoader(
             new FileLocator(array(__DIR__ . '/../../Fixtures/Routes')),
-            new RestRouteProcessor()
+            new RestRouteProcessor(),
+            $includeFormat,
+            $formats,
+            $defaultFormat
         );
         $controllerLoader = $this->getControllerLoader();
 

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\Routing\Loader;
 
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\RouteCollection;
 
 use FOS\RestBundle\Routing\Loader\RestRouteProcessor;
 use FOS\RestBundle\Routing\Loader\RestYamlCollectionLoader;
@@ -60,16 +61,79 @@ class RestYamlCollectionLoaderTest extends LoaderTest
         }
     }
 
+    public function testManualRoutes()
+    {
+        $collection = $this->loadFromYamlCollectionFixture('routes.yml');
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('/users.{_format}', $route->getPath());
+        $this->assertEquals('json|xml|html', $route->getRequirement('_format'));
+    }
+
+    public function testManualRoutesWithoutIncludeFormat()
+    {
+        $collection = $this->loadFromYamlCollectionFixture('routes.yml', false);
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('/users', $route->getPath());
+    }
+
+    public function testManualRoutesWithFormats()
+    {
+        $collection = $this->loadFromYamlCollectionFixture(
+            'routes.yml',
+            true,
+            array(
+                'json' => false
+            )
+        );
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('json', $route->getRequirement('_format'));
+    }
+
+    public function testManualRoutesWithDefaultFormat()
+    {
+        $collection = $this->loadFromYamlCollectionFixture(
+            'routes.yml',
+            true,
+            array(
+                'json' => false,
+                'xml'  => false,
+                'html' => true,
+            ),
+            'xml'
+        );
+        $route = $collection->get('get_users');
+
+        $this->assertEquals('xml', $route->getDefault('_format'));
+    }
+
     /**
      * Load routes collection from YAML fixture routes under Tests\Fixtures directory.
      *
-     * @param string $fixtureName name of the class fixture
+     * @param string   $fixtureName   name of the class fixture
+     * @param boolean  $includeFormat whether or not the requested view format must be included in the route path
+     * @param string[] $formats       supported view formats
+     * @param string   $defaultFormat default view format
+     * @return RouteCollection
      */
-    protected function loadFromYamlCollectionFixture($fixtureName)
-    {
+    protected function loadFromYamlCollectionFixture(
+        $fixtureName,
+        $includeFormat = true,
+        array $formats = array(
+            'json' => false,
+            'xml'  => false,
+            'html' => true,
+        ),
+        $defaultFormat = null
+    ) {
         $collectionLoader = new RestYamlCollectionLoader(
             new FileLocator(array(__DIR__ . '/../../Fixtures/Routes')),
-            new RestRouteProcessor()
+            new RestRouteProcessor(),
+            $includeFormat,
+            $formats,
+            $defaultFormat
         );
         $controllerLoader = $this->getControllerLoader();
 


### PR DESCRIPTION
...ectionLoader

This pull request aims to fix #626. It also adds a fix to support the deprecated `pattern` option.

If you guys are fine with this pull request, I'll extend this with a similar fix for the `RestXmlCollectionLoader` class.
