### PR TITLE
At Exception controller show status code message

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -173,7 +173,9 @@ class ExceptionController extends ContainerAware
         $exceptionMap = $this->container->getParameter('fos_rest.exception.messages');
         $showExceptionMessage = $this->isSubclassOf($exception, $exceptionMap);
 
-        return $showExceptionMessage || $this->container->get('kernel')->isDebug() ? $exception->getMessage() : '';
+        return $showExceptionMessage || $this->container->get('kernel')->isDebug()
+            ? $exception->getMessage()
+            : Response::$statusTexts[$this->getStatusCode($exception)];
     }
 
     /**
@@ -186,7 +188,7 @@ class ExceptionController extends ContainerAware
     protected function getStatusCode($exception)
     {
         $exceptionMap = $this->container->getParameter('fos_rest.exception.codes');
-        $isExceptionMappedToStatusCode = $this->isSubclassOf($exception, $exceptionMap);;
+        $isExceptionMappedToStatusCode = $this->isSubclassOf($exception, $exceptionMap);
 
         return ($isExceptionMappedToStatusCode) ? $isExceptionMappedToStatusCode : $exception->getStatusCode();
     }


### PR DESCRIPTION
On exception if is not on debug mode and is "marked" to display exception message, instead of empty message show the status code text as message. I think this approach is more user friendly then an empty message.
