### PR TITLE
At Param fetch listener replace the and operator use with &&

### DIFF
--- a/EventListener/ParamFetcherListener.php
+++ b/EventListener/ParamFetcherListener.php
@@ -59,7 +59,7 @@ class ParamFetcherListener
         if ($this->setParamsAsAttributes) {
             $params = $paramFetcher->all();
             foreach ($params as $name => $param) {
-                if ($request->attributes->has($name) and null !== $request->attributes->get($name)) {
+                if ($request->attributes->has($name) && null !== $request->attributes->get($name)) {
                     $msg = sprintf("ParamFetcher parameter conflicts with a path parameter '$name' for route '%s'", $request->attributes->get('_route'));
                     throw new \InvalidArgumentException($msg);
                 }


### PR DESCRIPTION
The use of and catch my eye when looking at code, and didn't find any case AND use on RestBundle codebase so submitting a PR to change it to && to be uniform with the rest of code.
