### PR TITLE
Add a option to specify the request original name

### DIFF
--- a/Controller/Annotations/Param.php
+++ b/Controller/Annotations/Param.php
@@ -22,7 +22,7 @@ abstract class Param
     /** @var string */
     public $name;
     /** @var string */
-    public $requestName = null;
+    public $key = null;
     /** @var string */
     public $requirements = '';
     /** @var mixed */
@@ -35,4 +35,12 @@ abstract class Param
     public $array = false;
     /** @var boolean */
     public $nullable = false;
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key ?: $this->name;
+    }
 }

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -94,11 +94,10 @@ class ParamFetcher implements ParamFetcherInterface
             $strict = $config->strict;
         }
 
-        $requestName = $config->requestName ? $config->requestName : $config->name;
         if ($config instanceof RequestParam) {
-            $param = $this->request->request->get($requestName, $default);
+            $param = $this->request->request->get($config->getKey(), $default);
         } elseif ($config instanceof QueryParam) {
-            $param = $this->request->query->get($requestName, $default);
+            $param = $this->request->query->get($config->getKey(), $default);
         } else {
             $param = null;
         }

--- a/Resources/doc/annotations-reference.md
+++ b/Resources/doc/annotations-reference.md
@@ -11,6 +11,7 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 /**
  * @QueryParam(
  *   name="",
+ *   key=null,
  *   requirements="",
  *   default=null,
  *   description="",
@@ -29,6 +30,7 @@ use FOS\RestBundle\Controller\Annotations\RequestParam;
 /**
  * @RequestParam(
  *   name="",
+ *   key=null,
  *   requirements="",
  *   default=null,
  *   description="",

--- a/Tests/Request/ParamFetcherTest.php
+++ b/Tests/Request/ParamFetcherTest.php
@@ -76,7 +76,7 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
 
         $annotations['biz'] = new QueryParam;
         $annotations['biz']->name = 'biz';
-        $annotations['biz']->requestName = 'business';
+        $annotations['biz']->key = 'business';
         $annotations['biz']->requirements = '\d+';
         $annotations['biz']->default = null;
         $annotations['biz']->nullable = true;
@@ -332,7 +332,7 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $queryFetcher->get('none', '42');
     }
 
-    public function testRequestName()
+    public function testKeyPrecedenceOverName()
     {
         $queryFetcher = $this->getParamFetcher(array('business' => 5));
         $queryFetcher->setController($this->controller);


### PR DESCRIPTION
I'm not sure this code is the way to go, I would thanks if someone enlighten me and point me an direction.

I want to be able do have:

URL?sent_date=XXXX

``` php
/**
 * @Rest\QueryParam(
 *     name="sentDate",
 *     strict=true,
 *     nullable=false,
 * )
 * ...
 */
public function XXXAction($sentDate)
```

This case is just about underscore and camel case, but I also want to be able to decouple my URL query parameters names from the name of variable, eg:

I also want to be able to do stuff like:

URL?country=PT

public function XXXAction($countryCode)

At URL I don't need to country_code, because in all the API I just use country as the code, there is not other way to identify a country, but lower layers I can have: $country (the Country entity) $countryId (the ID of country on DB) and $countryCode, so I need my variable to be more specific.

With this code I add a option at Param annotation, so the following code is supported:

``` php
/**
 * @Rest\QueryParam(
 *     name="sentDate",
 *     requestName="sent_date",
 *     strict=true,
 *     nullable=false,
 * )
 * ...
 */
public function XXXAction($sentDate)
```

The requestName is optional if is not provided will fallback to name so no BC. I'm not sure about the name requestName, but I couldn't come with anything better.

If this PR is accepted I can add this option to documentation on the current PR or in a new PR (if preferable).
