### PR TITLE
RequestParam annotation remove default property

### DIFF
--- a/Controller/Annotations/RequestParam.php
+++ b/Controller/Annotations/RequestParam.php
@@ -23,6 +23,4 @@ class RequestParam extends Param
 {
     /** @var boolean */
     public $strict = true;
-    /** @var string */
-    public $default = null;
 }

--- a/Tests/Controller/Annotations/RequestParamTest.php
+++ b/Tests/Controller/Annotations/RequestParamTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Controller\Annotations;
+
+use FOS\RestBundle\Controller\Annotations\RequestParam;
+
+/**
+ * RequestParamTest
+ *
+ * @author Eduardo Oliveira <entering@gmail.com>
+ */
+class RequestParamTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultIsNull()
+    {
+        $requestParam = new RequestParam();
+        $this->assertNull($requestParam->default, 'Expected RequestParam default property to be null');
+    }
+
+    public function testStrictIsTrue()
+    {
+        $requestParam = new RequestParam();
+        $this->assertTrue($requestParam->strict, 'Expected RequestParam strict property to be true');
+    }
+}


### PR DESCRIPTION
Looking to annotation classes I notice that the default property is of Param is override at RequestParam with the same value (probably in the past it made sense).

So this PR removes that property from RequestParam, and adds a test just in case someone changes in Param be aware that is changing RequestParam behavior also.
