### PR TITLE
On ExceptionController getExceptionMessage() fallback to error

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -172,11 +172,12 @@ class ExceptionController extends ContainerAware
     {
         $exceptionMap = $this->container->getParameter('fos_rest.exception.messages');
         $showExceptionMessage = $this->isSubclassOf($exception, $exceptionMap);
-        $statusCode = $this->getStatusCode($exception);
 
         if ($showExceptionMessage || $this->container->get('kernel')->isDebug()) {
             return $exception->getMessage();
         }
+
+        $statusCode = $this->getStatusCode($exception);
 
         return array_key_exists($statusCode, Response::$statusTexts) ? Response::$statusTexts[$statusCode] : 'error';
     }


### PR DESCRIPTION
On ExceptionController getExceptionMessage() fallback to 'error' if the status code is not recognized.

On getParameters() code I notice this:

``` php
'status_text' => array_key_exists($code, Response::$statusTexts) ? Response::$statusTexts[$code] : "error",
```

I think is good idea to do the same on getExceptionMessage(), this PR is related with the code introduced on
https://github.com/FriendsOfSymfony/FOSRestBundle/pull/647
