### PR TITLE
Fixed missing attribute configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -197,6 +197,7 @@ class Configuration implements ConfigurationInterface
                                     ->booleanNode('prefer_extension')->defaultTrue()->end()
                                     ->scalarNode('fallback_format')->defaultValue('html')->end()
                                     ->arrayNode('priorities')
+                                        ->useAttributeAsKey('name')
                                         ->beforeNormalization()->ifString()->then(function ($v) { return preg_split('/\s*,\s*/', $v); })->end()
                                         ->prototype('scalar')->end()
                                     ->end()


### PR DESCRIPTION
Regarding the documentation (https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Resources/doc/configuration-reference.md) and the rest of the file there is a missing 'useAttributeAsKey' on the format_listener priorities
