### PR TITLE
Allow filtering for methods in format_listener rules

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -194,6 +194,7 @@ class Configuration implements ConfigurationInterface
                                 ->children()
                                     ->scalarNode('path')->defaultNull()->info('URL path info')->end()
                                     ->scalarNode('host')->defaultNull()->info('URL host name')->end()
+                                    ->variableNode('methods')->defaultNull()->info('Method for URL')->end()
                                     ->booleanNode('prefer_extension')->defaultTrue()->end()
                                     ->scalarNode('fallback_format')->defaultValue('html')->end()
                                     ->arrayNode('priorities')

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -131,7 +131,8 @@ class FOSRestExtension extends Extension
                 $matcher = $this->createRequestMatcher(
                     $container,
                     $rule['path'],
-                    $rule['host']
+                    $rule['host'],
+                    $rule['methods']
                 );
 
                 unset($rule['path'], $rule['host']);
@@ -248,9 +249,9 @@ class FOSRestExtension extends Extension
         }
     }
 
-    protected function createRequestMatcher(ContainerBuilder $container, $path = null, $host = null)
+    protected function createRequestMatcher(ContainerBuilder $container, $path = null, $host = null, $methods = null)
     {
-        $arguments = array($path, $host);
+        $arguments = array($path, $host, $methods);
         $serialized = serialize($arguments);
         $id = $this->getAlias().'.request_matcher.'.md5($serialized).sha1($serialized);
 

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -322,7 +322,7 @@ fos_rest:
             # setting fallback_format to false means that instead of considering the next rule in case of a priority mismatch, a 406 will be caused
             - { path: '^/image', priorities: ['jpeg', 'gif'], fallback_format: false, prefer_extension: true }
             # setting fallback_format to null means that in case of a priority mismatch the next rule will be considered
-            - { path: '^/admin', priorities: [ 'xml', 'html'], fallback_format: ~, prefer_extension: false }
+            - { path: '^/admin', methods: [ 'GET', 'POST'], priorities: [ 'xml', 'html'], fallback_format: ~, prefer_extension: false }
             - { path: '^/', priorities: [ 'text/html', '*/*'], fallback_format: html, prefer_extension: true }
 ```
 


### PR DESCRIPTION
I've haded the need to filter for specific methods in a single URI.

I have a handler, that can return an object representation in RSS and is just used for GET, but it can't take one of the other methods available on that URI.
