### PR TITLE
Remove some extra options passed on wrapper handler construction 

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -493,10 +493,7 @@ class ViewHandler extends ContainerAware implements ConfigurableViewHandlerInter
 
         return $exceptionWrapperHandler->wrap(
             array(
-                 'status'         => 'error',
                  'status_code'    => $this->failedValidationCode,
-                 'status_text'    => Response::$statusTexts[$this->failedValidationCode],
-                 'currentContent' => '',
                  'message'        => 'Validation Failed',
                  'errors'         => $form
             )


### PR DESCRIPTION
Remove some extra options passed on wrapper handler construction on invalid form (were used in previous versions of RestBundle)
