### PR TITLE
[RFC] Added the constraint option on the ParamFetcher

### DIFF
--- a/Controller/Annotations/Param.php
+++ b/Controller/Annotations/Param.php
@@ -23,8 +23,8 @@ abstract class Param
     public $name;
     /** @var string */
     public $key = null;
-    /** @var string */
-    public $requirements = '';
+    /** @var mixed */
+    public $requirements = null;
     /** @var mixed */
     public $default = null;
     /** @var string */

--- a/Resources/config/request.xml
+++ b/Resources/config/request.xml
@@ -16,6 +16,7 @@
         <service id="fos_rest.request.param_fetcher" class="%fos_rest.request.param_fetcher.class%" scope="request">
             <argument type="service" id="fos_rest.request.param_fetcher.reader"/>
             <argument type="service" id="request"/>
+            <argument type="service" id="validator"/>
         </service>
 
         <service id="fos_rest.request.param_fetcher.reader" class="%fos_rest.request.param_fetcher.reader.class%">

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -421,6 +421,7 @@ fos_rest:
 use FOS\RestBundle\Request\ParamFetcher;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
+use Acme\FooBundle\Validation\Constraints\MyComplexConstraint
 
 class FooController extends Controller
 {
@@ -461,7 +462,13 @@ class FooController extends Controller
      * If ids is not defined, array(1) will be given
      *
      * Array must have a single depth or it will return default value. It's difficult to validate with
-     * preg_match each deeps of array, if you want to deal with that, use another validation system.
+     * preg_match each deeps of array, if you want to deal with that, you can use a constraint:
+     *
+     * @QueryParam(array=true, name="filters", requirements=@MyComplexConstraint, description="List of complex filters")
+     *
+     * In this example, the ParamFetcher will validate each value of the array with the constraint, returning the
+     * default value if you are in safe mode or throw a BadRequestHttpResponse containing the constraint violation
+     * messages in the message.
      *
      * @param ParamFetcher $paramFetcher
      */


### PR DESCRIPTION
Hi friends of Symfony :)

For business needs, I want that my API allows some complex `QueryParams` like deep array structures. For example I want to be able to query `/api/users?filters[0][key]=name&filters[0][operator]=equals&filters[0][value]=Foobar`.

I wanted those parameters validated in order to return a `BadRequestResponse` like its did using the `requirements` of the `QueryParam` or `RequestParam` so I added an option: `constraint` and this constraint is validated by the Validator component.

`requirements` and `constraint` cannot be combined.
