### PR TITLE
Update ParamFetcher to handle UTF8 requirements

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -161,7 +161,7 @@ class ParamFetcher implements ParamFetcherInterface
 
         if ('' !== $config->requirements
             && ($param !== $default || null === $default)
-            && !preg_match('#^'.$config->requirements.'$#xs', $param)
+            && !preg_match('#^'.$config->requirements.'$#xsu', $param)
         ) {
             if ($strict) {
                 $paramType = $config instanceof QueryParam ? 'Query' : 'Request';


### PR DESCRIPTION
Added the 'u' modifier to the regex in cleanParamWithRequirements() so that parameters with UTF8 content will work with the regex.

Fixes #696
