### PR TITLE
be less strict on jsonpcallbackvalidator version to be compatible with FOSJsRout...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/framework-bundle":       "~2.2",
         "doctrine/inflector":             "1.0.*",
         "willdurand/negotiation":         "~1.2.0",
-        "willdurand/jsonp-callback-validator": "~1.0.0"
+        "willdurand/jsonp-callback-validator": "~1.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
to be compatible with FOSJsRoutingBundle. Otherwise you cannot install both in the same project. 

There are no BC breaks on version 1.1 of jsonpcallbackvalidator.

This fixes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/699
