### PR TITLE
ensure that building with the Symfony 2.5 dev dependency succeeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - SYMFONY_VERSION=2.2.*
   - SYMFONY_VERSION=2.3.*
   - SYMFONY_VERSION=2.4.*
-  - SYMFONY_VERSION=dev-master
+  - SYMFONY_VERSION='dev-master symfony/event-dispatcher:~2.5@dev'
 
 before_script:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
@@ -21,6 +21,3 @@ notifications:
   email:
     - friendsofsymfony-dev@googlegroups.com
 
-matrix:
-  allow_failures:
-    - env: SYMFONY_VERSION=dev-master


### PR DESCRIPTION
It's hard to handle whitespaces with Travis. This PR should fix the issue described in #656.
