### PR TITLE
only use param fetcher with validator when listener enabled

### DIFF
--- a/EventListener/ParamFetcherListener.php
+++ b/EventListener/ParamFetcherListener.php
@@ -11,8 +11,8 @@
 
 namespace FOS\RestBundle\EventListener;
 
+use FOS\RestBundle\Request\ParamFetcher;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * This listener handles various setup tasks related to the query fetcher
@@ -25,21 +25,21 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ParamFetcherListener
 {
     /**
-     * @var ContainerInterface
+     * @var ParamFetcher
      */
-    private $container;
+    private $paramFetcher;
 
     private $setParamsAsAttributes;
 
     /**
      * Constructor.
      *
-     * @param ContainerInterface $container             container
-     * @param boolean            $setParamsAsAttributes params as attributes
+     * @param ParamFetcher $paramFetcher          ParamFetcher
+     * @param boolean      $setParamsAsAttributes params as attributes
      */
-    public function __construct(ContainerInterface $container, $setParamsAsAttributes = false)
+    public function __construct(ParamFetcher $paramFetcher, $setParamsAsAttributes = false)
     {
-        $this->container = $container;
+        $this->paramFetcher = $paramFetcher;
         $this->setParamsAsAttributes = $setParamsAsAttributes;
     }
 
@@ -51,13 +51,12 @@ class ParamFetcherListener
     public function onKernelController(FilterControllerEvent $event)
     {
         $request = $event->getRequest();
-        $paramFetcher = $this->container->get('fos_rest.request.param_fetcher');
 
-        $paramFetcher->setController($event->getController());
-        $request->attributes->set('paramFetcher', $paramFetcher);
+        $this->paramFetcher->setController($event->getController());
+        $request->attributes->set('paramFetcher', $this->paramFetcher);
 
         if ($this->setParamsAsAttributes) {
-            $params = $paramFetcher->all();
+            $params = $this->paramFetcher->all();
             foreach ($params as $name => $param) {
                 if ($request->attributes->has($name) && null !== $request->attributes->get($name)) {
                     $msg = sprintf("ParamFetcher parameter conflicts with a path parameter '$name' for route '%s'", $request->attributes->get('_route'));

--- a/Resources/config/param_fetcher_listener.xml
+++ b/Resources/config/param_fetcher_listener.xml
@@ -6,6 +6,7 @@
 
     <parameters>
 
+        <parameter key="fos_rest.request.param_fetcher.class">FOS\RestBundle\Request\ParamFetcher</parameter>
         <parameter key="fos_rest.param_fetcher_listener.class">FOS\RestBundle\EventListener\ParamFetcherListener</parameter>
         <parameter key="fos_rest.param_fetcher_listener.set_params_as_attributes">false</parameter>
 
@@ -13,9 +14,15 @@
 
     <services>
 
+        <service id="fos_rest.request.param_fetcher" class="%fos_rest.request.param_fetcher.class%" scope="request">
+            <argument type="service" id="fos_rest.request.param_fetcher.reader"/>
+            <argument type="service" id="request"/>
+            <argument type="service" id="validator"/>
+        </service>
+
         <service id="fos_rest.param_fetcher_listener" class="%fos_rest.param_fetcher_listener.class%">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="5"/>
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="fos_rest.request.param_fetcher"/>
             <argument>%fos_rest.param_fetcher_listener.set_params_as_attributes%</argument>
         </service>
 

--- a/Resources/config/request.xml
+++ b/Resources/config/request.xml
@@ -6,18 +6,11 @@
 
     <parameters>
 
-        <parameter key="fos_rest.request.param_fetcher.class">FOS\RestBundle\Request\ParamFetcher</parameter>
         <parameter key="fos_rest.request.param_fetcher.reader.class">FOS\RestBundle\Request\ParamReader</parameter>
 
     </parameters>
 
     <services>
-
-        <service id="fos_rest.request.param_fetcher" class="%fos_rest.request.param_fetcher.class%" scope="request">
-            <argument type="service" id="fos_rest.request.param_fetcher.reader"/>
-            <argument type="service" id="request"/>
-            <argument type="service" id="validator"/>
-        </service>
 
         <service id="fos_rest.request.param_fetcher.reader" class="%fos_rest.request.param_fetcher.reader.class%">
             <argument type="service" id="annotation_reader"/>

--- a/Tests/EventListener/ParamFetcherListenerTest.php
+++ b/Tests/EventListener/ParamFetcherListenerTest.php
@@ -13,18 +13,12 @@ namespace FOS\RestBundle\Tests\EventListener;
 
 use FOS\RestBundle\EventListener\ParamFetcherListener;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
  * Param Fetcher Listener Tests
  */
 class ParamFetcherListenerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    private $container;
-
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -99,18 +93,10 @@ class ParamFetcherListenerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerInterface')
-            ->getMock();
-
         $this->paramFetcher = $this->getMockBuilder('FOS\\RestBundle\\Request\\ParamFetcher')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->container->expects($this->once())
-            ->method('get')
-            ->with('fos_rest.request.param_fetcher')
-            ->will($this->returnValue($this->paramFetcher));
-
-        $this->paramFetcherListener = new ParamFetcherListener($this->container, true);
+        $this->paramFetcherListener = new ParamFetcherListener($this->paramFetcher, true);
     }
 }


### PR DESCRIPTION
Fixing #717 

Moved ParamFetcher to param_fetcher_listener.xml which is only loaded when listener enabled.
