### PR TITLE
Fixed http-method-override for body-listener (#724)

### DIFF
--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -81,6 +81,9 @@ class BodyListener
                 $data = $decoder->decode($content, $format);
                 if (is_array($data)) {
                     $request->request = new ParameterBag($data);
+
+                    // Reset the method in the current request to support method-overriding
+                    $request->setMethod($request->getRealMethod());
                 } else {
                     throw new BadRequestHttpException('Invalid ' . $format . ' message received');
                 }

--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -30,7 +30,7 @@
         </service>
 
         <service id="fos_rest.body_listener" class="%fos_rest.body_listener.class%">
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="10" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="64" />
             <argument type="service" id="fos_rest.decoder_provider" />
             <argument>%fos_rest.throw_exception_on_unsupported_content_type%</argument>
         </service>


### PR DESCRIPTION
Once the http-method is requested, it's cached in the request, so I have to set that cache back (resetting the http-method was the best that came to my mind). This way, it's available for the next listener.

Increased priority for listener to be higher than the router (router has 32) - I just took 64 ...

Fixes #724
