### PR TITLE
Added configuration to set challenge in UnauthorizedHttpException

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,6 +46,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('boolean')->end()
                 ->end()
+                ->scalarNode('unauthorized_challenge')->defaultNull()->end()
                 ->scalarNode('param_fetcher_listener')->defaultFalse()
                     ->validate()
                         ->ifNotInArray($this->forceOptionValues)

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -198,6 +198,7 @@ class FOSRestExtension extends Extension
         if (!empty($config['access_denied_listener'])) {
             $loader->load('access_denied_listener.xml');
             $container->setParameter($this->getAlias().'.access_denied_listener.formats', $config['access_denied_listener']);
+            $container->setParameter($this->getAlias().'.access_denied_listener.unauthorized_challenge', $config['unauthorized_challenge']);
         }
 
         if (!empty($config['body_converter'])) {

--- a/Resources/config/access_denied_listener.xml
+++ b/Resources/config/access_denied_listener.xml
@@ -8,6 +8,7 @@
 
         <parameter key="fos_rest.access_denied_listener.class">FOS\RestBundle\EventListener\AccessDeniedListener</parameter>
         <parameter key="fos_rest.access_denied_listener.formats" type="collection"/>
+        <parameter key="fos_rest.access_denied_listener.unauthorized_challenge" type="string" />
 
     </parameters>
 
@@ -17,6 +18,7 @@
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument>%fos_rest.access_denied_listener.formats%</argument>
+            <argument>%fos_rest.access_denied_listener.unauthorized_challenge%</argument>
             <argument>%twig.exception_listener.controller%</argument>
             <argument type="service" id="logger" on-invalid="null" />
         </service>

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -548,10 +548,17 @@ and firewall entry points and forces returning either a 403 or 401 status code f
 It will return 401 for `Symfony\Component\Security\Core\Exception\AuthenticationException` or 403 for
 `Symfony\Component\Security\Core\Exception\AccessDeniedException`.
 
+As a 401-response requires an authentication-challenge, you can set one using the configuration `unauthorized_challenge`
+or leave it blank if you don't want to send a challenge in the `WWW-Authenticate` header to the client.
+
+If you want to use an advanced value in this header, it's worth looking at this:
+[Test Cases for HTTP Test Cases for the HTTP WWW-Authenticate header field](http://greenbytes.de/tech/tc/httpauth/)
+
 You need to enable this listener like this as it is disabled by default:
 
 ```
 fos_rest:
+    unauthorized_challenge: "Basic realm=\"Restricted Area\""
     access_denied_listener:
         # all requests using the 'json' format will return a 403 on an access denied violation
         json: true

--- a/Resources/doc/configuration-reference.md
+++ b/Resources/doc/configuration-reference.md
@@ -5,6 +5,7 @@ Full default configuration
 fos_rest:
     disable_csrf_role:    ~
     access_denied_listener:
+    unauthorized_challenge: ~
 
         # Prototype
         name:                 []


### PR DESCRIPTION
I've added a configuration-option to set a custom challenge for the UnauthorizedHttpException, thrown in the AccessDeniedListener.

If you don't set a value (as it's the default), the old exception is sent, that does not have the `WWW-Authenticate`-header, even so this is against the specs - just to keep backwards-compatibility.

This can be seen as a work-around for #434, but is furthermore a way to let the user set a custom challenge.
