### PR TITLE
[WIP] Fixed incompatibility with firewalls implementation for handling AuthenticationFailureHandlerInterface

### DIFF
--- a/EventListener/AccessDeniedListener.php
+++ b/EventListener/AccessDeniedListener.php
@@ -79,7 +79,7 @@ class AccessDeniedListener extends ExceptionListener
     public static function getSubscribedEvents()
     {
         return array(
-            KernelEvents::EXCEPTION => array('onKernelException', 5),
+            KernelEvents::EXCEPTION => array('onKernelException', -16),
         );
     }
 }


### PR DESCRIPTION
Fixed #434, becuase the original AuthenticationFailureHandler defined in the firewall is used instead of this one.

Details are provided in #666 ...
