### PR TITLE
Added a way to normalize between underscore and camel case in the body listener

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -177,6 +177,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue(array('json' => 'fos_rest.decoder.json', 'xml' => 'fos_rest.decoder.xml'))
                             ->prototype('scalar')->end()
                         ->end()
+                        ->scalarNode('array_normalizer')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -133,6 +133,12 @@ class FOSRestExtension extends Extension
 
             $container->setParameter($this->getAlias().'.throw_exception_on_unsupported_content_type', $config['body_listener']['throw_exception_on_unsupported_content_type']);
             $container->setParameter($this->getAlias().'.decoders', $config['body_listener']['decoders']);
+
+            $arrayNormalizer = $config['body_listener']['array_normalizer'];
+            if (null !== $arrayNormalizer) {
+                $container->getDefinition($this->getAlias().'.body_listener')
+                    ->addMethodCall('setArrayNormalizer', array(new Reference($arrayNormalizer)));
+            }
         }
 
         if (!empty($config['format_listener']['rules'])) {

--- a/Normalizer/ArrayNormalizerInterface.php
+++ b/Normalizer/ArrayNormalizerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the FOSRest package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Normalizer;
+
+/**
+ * Normalizes arrays.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+interface ArrayNormalizerInterface
+{
+    /**
+     * Normalizes the array.
+     *
+     * @param array $data The array to normalize
+     *
+     * @return array The normalized array
+     *
+     * @throws Exception\NormalizationException
+     */
+    public function normalize(array $data);
+}

--- a/Normalizer/CamelKeysNormalizer.php
+++ b/Normalizer/CamelKeysNormalizer.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the FOSRest package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Normalizer;
+
+use FOS\RestBundle\Normalizer\Exception\NormalizationException;
+
+/**
+ * Normalizes the array by changing its keys from underscore to camel case.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class CamelKeysNormalizer implements ArrayNormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize(array $data)
+    {
+        $this->normalizeArray($data);
+
+        return $data;
+    }
+
+    /**
+     * Normalizes an array.
+     *
+     * @param array &$data
+     *
+     * @throws Exception\NormalizationException
+     */
+    private function normalizeArray(array &$data)
+    {
+        foreach ($data as $key => $val) {
+            $normalizedKey = $this->normalizeString($key);
+
+            if ($normalizedKey !== $key) {
+                if (array_key_exists($normalizedKey, $data)) {
+                    throw new NormalizationException(sprintf(
+                        'The key "%s" is invalid as it will override the existing key "%s"',
+                        $key,
+                        $normalizedKey
+                    ));
+                }
+
+                unset($data[$key]);
+                $data[$normalizedKey] = $val;
+                $key = $normalizedKey;
+            }
+
+            if (is_array($val)) {
+                $this->normalizeArray($data[$key]);
+            }
+        }
+    }
+
+    /**
+     * Normalizes a string.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    private function normalizeString($string)
+    {
+        if (false === strpos($string, '_')) {
+            return $string;
+        }
+
+        return preg_replace_callback('/_([a-zA-Z0-9])/', function ($matches) {
+            return strtoupper($matches[1]);
+        }, $string);
+    }
+}

--- a/Normalizer/Exception/NormalizationException.php
+++ b/Normalizer/Exception/NormalizationException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the FOSRest package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Normalizer\Exception;
+
+/**
+ * Exception thrown when the normalization failed.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class NormalizationException extends \RuntimeException
+{
+}

--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -6,6 +6,7 @@
 
     <parameters>
 
+        <parameter key="fos_rest.normalizer.camel_keys.class">FOS\RestBundle\Normalizer\CamelKeysNormalizer</parameter>
         <parameter key="fos_rest.decoder.json.class">FOS\RestBundle\Decoder\JsonDecoder</parameter>
         <parameter key="fos_rest.decoder.jsontoform.class">FOS\RestBundle\Decoder\JsonToFormDecoder</parameter>
         <parameter key="fos_rest.decoder.xml.class">FOS\RestBundle\Decoder\XmlDecoder</parameter>
@@ -15,6 +16,8 @@
     </parameters>
 
     <services>
+
+        <service id="fos_rest.normalizer.camel_keys" class="%fos_rest.normalizer.camel_keys.class%" />
 
         <service id="fos_rest.decoder.json" class="%fos_rest.decoder.json.class%" />
 

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -175,11 +175,13 @@ public function getUserDetails(User $user)
 
 ### Body listener
 
-The Request body decoding listener makes it possible to decode the contents of
+The Request body listener makes it possible to decode the contents of
 a request in order to populate the "request" parameter bag of the Request. This
 for example allows to receive data that normally would be sent via POST as
 ``application/x-www-form-urlencode`` in a different format (for example
 application/json) in a PUT.
+
+#### Decoders
 
 You can add a decoder for a custom format. You can also replace the default
 decoder services provided by the bundle for the ``json`` and ``xml`` formats.
@@ -202,6 +204,36 @@ If you want to be able to use form with checkbox and have true and false value (
 
 If the listener receives content that it tries to decode but the decode fails then a BadRequestHttpException will be thrown with the message:
 ``'Invalid ' . $format . ' message received'``. When combined with the [exception controller support](4-exception-controller-support.md) this means your API will provide useful error messages to your API users if they are making invalid requests.
+
+#### Array Normalizer
+
+Array Normalizers allow to transform the data after it has been decoded in order to facilitate its processing.
+
+For example, you may want your API's clients to be able to send requests with underscored keys but if you use a decoder
+without a normalizer, you will receive the data as it is and it can lead to incorrect mapping if you submit the request directly to a Form.
+If you wish the body listener to transform underscored keys to camel cased ones, you can use the ``camel_keys`` array normalizer:
+
+```yaml
+# app/config/config.yml
+fos_rest:
+    body_listener:
+        array_normalizer: fos_rest.normalizer.camel_keys
+```
+
+Sometimes an array contains a key, which once normalized, will override an existing array key. For example ``foo_bar`` and ``foo_Bar`` will both lead to ``fooBar``.
+If the normalizer receives this data, the listener will throw a BadRequestHttpException with the message
+``The key "foo_Bar" is invalid as it will override the existing key "fooBar"``.
+
+NB: If you use the ``camel_keys`` normalizer, you must be careful when choosing your Form name.
+
+You can also create your own array normalizer by implementing the ``FOS\RestBundle\Normalizer\ArrayNormalizerInterface``.
+
+```yaml
+# app/config/config.yml
+fos_rest:
+    body_listener:
+        array_normalizer: acme.normalizer.custom
+```
 
 ### Request Body Converter Listener
 

--- a/Tests/Normalizer/CamelKeysNormalizerTest.php
+++ b/Tests/Normalizer/CamelKeysNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Normalizer;
+
+use FOS\RestBundle\Normalizer\CamelKeysNormalizer;
+
+class CamelKeysNormalizerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \FOS\RestBundle\Normalizer\Exception\NormalizationException
+     */
+    public function testNormalizeSameValueException()
+    {
+        $normalizer = new CamelKeysNormalizer();
+        $normalizer->normalize(array(
+            'foo' => array(
+                'foo_bar' => 'foo',
+                'foo_Bar' => 'foo',
+            )
+        ));
+    }
+
+    /**
+     * @dataProvider normalizeProvider
+     */
+    public function testNormalize(array $array, array $expected)
+    {
+        $normalizer = new CamelKeysNormalizer();
+        $this->assertEquals($expected, $normalizer->normalize($array));
+    }
+
+    public function normalizeProvider()
+    {
+        return array(
+            array(array(), array()),
+            array(
+                array('foo' => array('Foo_bar_baz' => array('foo_Bar' => array('foo_bar' => 'foo_bar'))),
+                    'foo_1ar' => array('foo_bar')
+                ),
+                array('foo' => array('FooBarBaz' => array('fooBar' => array('fooBar' => 'foo_bar'))),
+                    'foo1ar' => array('foo_bar')
+                )
+            ),
+        );
+    }
+}


### PR DESCRIPTION
This is an attempt to solve https://github.com/FriendsOfSymfony/FOSRestBundle/issues/137 by allowing normalizers to process the decoded data before populating the request in the body listener.
