### PR TITLE
Make the validator component optional

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -69,12 +69,12 @@ class ParamFetcher implements ParamFetcherInterface
      * @param ValidatorInterface          $validator            The validator service
      * @param ViolationFormatterInterface $violationFormatter   The violation formatter service
      */
-    public function __construct(ParamReader $paramReader, Request $request, ValidatorInterface $validator, ViolationFormatterInterface $violationFormatter)
+    public function __construct(ParamReader $paramReader, Request $request, ViolationFormatterInterface $violationFormatter, ValidatorInterface $validator = null)
     {
         $this->paramReader        = $paramReader;
         $this->request            = $request;
-        $this->validator          = $validator;
         $this->violationFormatter = $violationFormatter;
+        $this->validator          = $validator;
     }
 
     /**
@@ -167,6 +167,10 @@ class ParamFetcher implements ParamFetcherInterface
     public function cleanParamWithRequirements(Param $config, $param, $strict)
     {
         $default = $config->default;
+
+        if (null !== $config->requirements && null === $this->validator) {
+            throw new \RuntimeException('The ParamFetcher requirements feature requires the symfony/validator component.');
+        }
 
         if (null === $config->requirements || ($param === $default && null !== $default)) {
 

--- a/Resources/config/request.xml
+++ b/Resources/config/request.xml
@@ -16,8 +16,8 @@
         <service id="fos_rest.request.param_fetcher" class="%fos_rest.request.param_fetcher.class%" scope="request">
             <argument type="service" id="fos_rest.request.param_fetcher.reader"/>
             <argument type="service" id="request"/>
-            <argument type="service" id="validator"/>
             <argument type="service" id="fos_rest.violation_formatter"/>
+            <argument type="service" id="validator" on-invalid="null"/>
         </service>
 
         <service id="fos_rest.request.param_fetcher.reader" class="%fos_rest.request.param_fetcher.reader.class%">

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -485,6 +485,8 @@ Note: There is also ``$paramFetcher->all()`` to fetch all configured query param
 both ``$paramFetcher->get()`` and ``$paramFetcher->all()`` support and optional ``$strict`` parameter
 to throw a ``\RuntimeException`` on a validation error.
 
+Note: The ParamFetcher requirements feature requires the symfony/validator component.
+
 Optionally the listener can also already set all configured query parameters as request attributes
 
 ```yaml

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     "suggest": {
         "sensio/framework-extra-bundle":  "Add support for route annotations and the view response listener",
         "jms/serializer-bundle":          "Add support for advanced serialization capabilities, recommended, requires 0.12.*",
-        "symfony/serializer":             "Add support for basic serialization capabilities and xml decoding, requires ~2.2"
+        "symfony/serializer":             "Add support for basic serialization capabilities and xml decoding, requires ~2.2",
+        "symfony/validator":              "Add support for validation capabilities in the ParamFetcher, requires ~2.2"
     },
 
     "conflict": {


### PR DESCRIPTION
This way we can use the ParamFetcher if we don't use requirements, Fix #717
