### PR TITLE
Allow controller as services, even when the service ID is the controller class name

### DIFF
--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -116,7 +116,14 @@ class RestRouteLoader extends Loader
             $controller = $this->findClass($file);
         }
 
-        if (class_exists($controller)) {
+        if ($this->container->has($controller)) {
+            // service_id
+            $prefix = $controller . ':';
+            $this->container->enterScope('request');
+            $this->container->set('request', new Request);
+            $class = get_class($this->container->get($controller));
+            $this->container->leaveScope('request');
+        } elseif (class_exists($controller)) {
             // full class name
             $class  = $controller;
             $prefix = $class . '::';
@@ -131,13 +138,6 @@ class RestRouteLoader extends Loader
                     sprintf('Can\'t locate "%s" controller.', $controller)
                 );
             }
-        } elseif ($this->container->has($controller)) {
-            // service_id
-            $prefix = $controller . ':';
-            $this->container->enterScope('request');
-            $this->container->set('request', new Request);
-            $class = get_class($this->container->get($controller));
-            $this->container->leaveScope('request');
         }
 
         if (empty($class)) {

--- a/Tests/Routing/Loader/LoaderTest.php
+++ b/Tests/Routing/Loader/LoaderTest.php
@@ -29,6 +29,11 @@ use FOS\RestBundle\Util\Inflector\DoctrineInflector;
 abstract class LoaderTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var \Symfony\Component\DependencyInjection\ContainerBuilder
+     */
+    protected $containerMock;
+
+    /**
      * Load routes etalon from yml fixture file under Tests\Fixtures directory.
      *
      * @param string $etalonName name of the YML fixture
@@ -50,9 +55,12 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
      */
     protected function getControllerLoader(array $formats = array())
     {
-        $c = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
+        // This check allows to override the container
+        if ($this->containerMock === null) {
+            $this->containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
         $l = $this->getMockBuilder('Symfony\Component\Config\FileLocator')
             ->disableOriginalConstructor()
             ->getMock();
@@ -67,6 +75,6 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
         $ar = new RestActionReader($annotationReader, $paramReader, $inflector, true, $formats);
         $cr = new RestControllerReader($ar, $annotationReader);
 
-        return new RestRouteLoader($c, $l, $p, $cr, 'html');
+        return new RestRouteLoader($this->containerMock, $l, $p, $cr, 'html');
     }
 }


### PR DESCRIPTION
The background behind this issue is here: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/604#issuecomment-40284026

The RestRouteLoader now first check if the resource is a service in the container before checking if it's a class name.

That allows to register controller as services in the container and use them in routes, even when we register them by their class name in the container.

The tests turned out to be a bit messy. I tried to keep it clean, but if you want me to remove it I can. I also confirm that the test was failing before the fix, and is now passing after the change in RestRouteLoader.
