### PR TITLE
 Failed to locate a schema at location #685 #739 The Tests are red/failu...

### DIFF
--- a/Routing/Loader/RestXmlCollectionLoader.php
+++ b/Routing/Loader/RestXmlCollectionLoader.php
@@ -177,9 +177,9 @@ class RestXmlCollectionLoader extends XmlFileLoader
     protected function validate(\DOMDocument $dom)
     {
         $restRoutinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing/rest_routing-1.0.xsd');
-	$restRoutinglocation =  str_replace('\\', '/', $restRoutinglocation);
+        $restRoutinglocation =  str_replace('\\', '/', $restRoutinglocation);
         $routinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing-1.0.xsd');
-	$routinglocation =  str_replace('\\', '/', $routinglocation);
+        $routinglocation =  str_replace('\\', '/', $routinglocation);
         $source = <<<EOF
 <?xml version="1.0" encoding="utf-8" ?>
 <xsd:schema xmlns="http://symfony.com/schema"


### PR DESCRIPTION
...re in windows since v1.2. Solve.

---

Final solution :

---

On windows systems FriendsOfSymfony/FOSRestBundle Tests  are red : Failures!
All versions of of fos restbundle above 1.1.\* are concerned 1.2, 1.3, ... This is due to the use of php realpath() and schemaValidateSource() functions. On windows, directory separator is \,on linux / and realpath use one of them as appropriate.
schemaValidateSource() accept only / slashes as directory separators and not basckslashes.
In **FOS\RestBundle\Routing\Loader\RestXmlCollectionLoader.php**  we have :
$restRoutinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing/rest_routing-1.0.xsd');
$source = <<<EOF.....
import namespace="http://friendsofsymfony.github.com/schema/rest" schemaLocation="$restRoutinglocation" ....
EOF;
And after the dom test : if (!$dom->schemaValidateSource($source)). So there is no errors in linux systems. But we have errors on windows system as schemaValidateSource() expected /(slashes) as directory separator in file path while realpath use \ in windows ($restrouting=realpath...).

So the solution is : after realpath() we have to replace backslashes with slashes in paths before the use of schemaValidateSource() .
In our case that is in FOSRestBundle / Routing / Loader / RestXmlCollectionLoader.php
        $restRoutinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing/rest_routing-1.0.xsd');
we must add after this line :
        $restRoutinglocation =  str_replace('\', '/', $restRoutinglocation);
Linux system are not affected only windows path so I've made a pr.

---

Notice that there is an error for the second path in this file :
$routinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing/routing-1.0.xsd');
This path doesn't exist and we have to replace it with :
$routinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing-1.0.xsd');
and add just after :
$Routinglocation =  str_replace('\', '/', $Routinglocation);

---
