### PR TITLE
Moved JmsSerializerBundle to required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/framework-bundle":       "~2.2",
         "doctrine/inflector":             "1.0.*",
         "willdurand/negotiation":         "~1.2",
-        "willdurand/jsonp-callback-validator": "~1.0"
+        "willdurand/jsonp-callback-validator": "~1.0",
+        "jms/serializer-bundle":          "0.12.*"
     },
 
     "require-dev": {
@@ -35,8 +36,7 @@
         "symfony/validator":              "~2.2",
         "symfony/serializer":             "~2.2",
         "symfony/yaml":                   "~2.2",
-        "symfony/security":               "~2.2",
-        "jms/serializer-bundle":          "0.12.*"
+        "symfony/security":               "~2.2"
     },
 
     "suggest": {


### PR DESCRIPTION
When registering the FosRestBundle without JmsSerializerBundle, there will be an error:

> [2/2] InvalidArgumentException: Unable to replace alias "jms_serializer.serializer" with "fos_rest.serializer".
> [1/2] InvalidArgumentException: The service definition "jms_serializer.serializer" does not exist.
