### PR TITLE
[FORMAT_LISTENER] - rules for profiler

### DIFF
--- a/DependencyInjection/Compiler/FormatListenerRulesPass.php
+++ b/DependencyInjection/Compiler/FormatListenerRulesPass.php
@@ -24,19 +24,27 @@ class FormatListenerRulesPass implements CompilerPassInterface
 {
     private $alias;
 
-    public function __construct($alias)
+    public function __construct($alias = 'fos_rest')
     {
         $this->alias = $alias;
     }
 
     public function process(ContainerBuilder $container)
     {
-        $fosRestConfig = $container->getExtensionConfig('fos_rest');
+        if (!$container->hasDefinition($this->alias.'.format_listener')) {
+            return;
+        }
+
+        $fosRestConfig = $container->getExtensionConfig($this->alias);
         $profilerConfig = $container->getExtensionConfig('web_profiler');
 
         $devRules = $this->getDevelopmentRules($fosRestConfig, $profilerConfig);
-        $fosRestConfig['format_listener']['rules'] = array_merge($fosRestConfig['format_listener']['rules'], $devRules);
-        foreach ($fosRestConfig['format_listener']['rules'] as $rule) {
+        $fosRestConfig[0]['format_listener']['rules'] = array_merge(
+            $fosRestConfig[0]['format_listener']['rules'],
+            $devRules
+        );
+
+        foreach ($fosRestConfig[0]['format_listener']['rules'] as $rule) {
             $this->addRule($rule, $container);
         }
     }

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -11,14 +11,12 @@
 
 namespace FOS\RestBundle\DependencyInjection;
 
-use FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
-
 use FOS\RestBundle\Util\Codes;
 
 use FOS\RestBundle\FOSRestBundle;
@@ -144,7 +142,6 @@ class FOSRestExtension extends Extension
 
         if (!empty($config['format_listener']['rules'])) {
             $loader->load('format_listener.xml');
-            $container->addCompilerPass(new FormatListenerRulesPass($this->getAlias()));
 
             if (!empty($config['format_listener']['media_type']['version_regex'])) {
                 $container->setParameter(

--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use FOS\RestBundle\DependencyInjection\Compiler\ConfigurationCheckPass;
+use FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass;
 
 /**
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
@@ -28,5 +29,6 @@ class FOSRestBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new ConfigurationCheckPass());
+        $container->addCompilerPass(new FormatListenerRulesPass('fos_rest'));
     }
 }

--- a/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
@@ -19,25 +19,24 @@ use FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass;
  */
 class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
 {
-    const EXTENSION_ALIAS = 'test';
+    const EXTENSION_ALIAS = 'fos_rest_test';
 
     public function testRulesAreAddedWhenFormatListenerAndProfilerToolbarAreEnabled()
     {
-        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
-        $definition->method('addMethodCall');
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', array('addMethod'));
 
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
-        $container->expects($this->at(0))
-            ->method('getExtensionConfig')
-            ->with('fos_rest')
-            ->will($this->returnValue(array('format_listener' => array('rules' => array()))));
-
         $container->expects($this->at(1))
+            ->method('getExtensionConfig')
+            ->with(self::EXTENSION_ALIAS)
+            ->will($this->returnValue(array(array('format_listener' => array('rules' => array())))));
+
+        $container->expects($this->at(2))
             ->method('getExtensionConfig')
             ->with('web_profiler')
             ->will($this->returnValue(array(array('toolbar' => true, 'intercept_redirects' => false))));
 
-        $container->expects($this->exactly(2))
+        $container->expects($this->exactly(3))
             ->method('hasDefinition')
             ->will($this->returnValue(true));
 
@@ -56,17 +55,17 @@ class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
         $definition->method('addMethodCall');
 
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
-        $container->expects($this->at(0))
-            ->method('getExtensionConfig')
-            ->with('fos_rest')
-            ->will($this->returnValue(array('format_listener' => array('rules' => array()))));
 
+        $container->expects($this->once())->method('hasDefinition')->will($this->returnValue(true));
         $container->expects($this->at(1))
+            ->method('getExtensionConfig')
+            ->with(self::EXTENSION_ALIAS)
+            ->will($this->returnValue(array(array('format_listener' => array('rules' => array())))));
+
+        $container->expects($this->at(2))
             ->method('getExtensionConfig')
             ->with('web_profiler')
             ->will($this->returnValue(array(array('toolbar' => false, 'intercept_redirects' => false))));
-
-        $container->expects($this->never())->method('hasDefinition');
 
         $container->expects($this->never())->method('getDefinition');
 

--- a/Tests/FOSRestBundleTest.php
+++ b/Tests/FOSRestBundleTest.php
@@ -23,7 +23,7 @@ class FOSRestBundleTest extends \PHPUnit_Framework_TestCase
     public function testBuild()
     {
         $container = $this->getMock('\Symfony\Component\DependencyInjection\ContainerBuilder');
-        $container->expects($this->once())
+        $container->expects($this->exactly(2))
             ->method('addCompilerPass')
             ->with($this->isInstanceOf('\Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface'));
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #652 |
| License | MIT |

---

There is one thing I'd like to review. This rules **assume** the `/api/` route. This may not be true for a given project. How can that be addressed?
