### PR TITLE
Added exception to parameters for serializer in exception controller

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -237,10 +237,10 @@ class ExceptionController extends ContainerAware
             'status_text' => array_key_exists($code, Response::$statusTexts) ? Response::$statusTexts[$code] : "error",
             'currentContent' => $currentContent,
             'message' => $this->getExceptionMessage($exception),
+            'exception' => $exception,
         );
 
         if ($viewHandler->isFormatTemplating($format)) {
-            $parameters['exception'] = $exception;
             $parameters['logger'] = $logger;
         }
 


### PR DESCRIPTION
This simple change will allow the user to create a custom exception wrapper to show things like a stack trace if they want. Discussed in #766. Currently the exception is only available to a template, not a serialized response.
