### PR TITLE
[BodyListener] introducing "disable_routes" proof of concept

### DIFF
--- a/.idea/scopes/scope_settings.xml
+++ b/.idea/scopes/scope_settings.xml
@@ -1,0 +1,5 @@
+<component name="DependencyValidationManager">
+  <state>
+    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
+  </state>
+</component>

--- a/.idea/scopes/scope_settings.xml
+++ b/.idea/scopes/scope_settings.xml
@@ -1,5 +1,0 @@
-<component name="DependencyValidationManager">
-  <state>
-    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
-  </state>
-</component>

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -178,6 +178,9 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->scalarNode('array_normalizer')->defaultNull()->end()
+                        ->arrayNode('disabled_routes')
+                            ->prototype('scalar')->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -131,6 +131,7 @@ class FOSRestExtension extends Extension
             $loader->load('body_listener.xml');
 
             $container->setParameter($this->getAlias().'.throw_exception_on_unsupported_content_type', $config['body_listener']['throw_exception_on_unsupported_content_type']);
+            $container->setParameter($this->getAlias().'.disabled_routes', $config['body_listener']['disabled_routes']);
             $container->setParameter($this->getAlias().'.decoders', $config['body_listener']['decoders']);
 
             $arrayNormalizer = $config['body_listener']['array_normalizer'];

--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -84,7 +84,7 @@ class BodyListener
         $method = $request->getMethod();
         $route = $request->attributes->get('_route');
 
-        if($this->isDisabledRoute($route)) {
+        if ($this->isDisabledRoute($route)) {
             return;
         }
 

--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -82,6 +82,11 @@ class BodyListener
     {
         $request = $event->getRequest();
         $method = $request->getMethod();
+        $route = $request->attributes->get('_route');
+
+        if($this->isDisabledRoute($route)) {
+            return;
+        }
 
         if (!count($request->request->all())
             && in_array($method, array('POST', 'PUT', 'PATCH', 'DELETE'))
@@ -105,13 +110,11 @@ class BodyListener
                 return;
             }
 
-            $route = $request->attributes->get('_route');
-
             if (!empty($content)) {
                 $decoder = $this->decoderProvider->getDecoder($format);
                 $data = $decoder->decode($content, $format);
                 if (is_array($data)) {
-                    if (null !== $this->arrayNormalizer && !$this->isDisabledRoute($route)) {
+                    if (null !== $this->arrayNormalizer) {
                         try {
                             $data = $this->arrayNormalizer->normalize($data);
                         } catch (NormalizationException $e) {

--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -47,7 +47,6 @@ class BodyListener
      */
     private $disabledRoutes;
 
-
     /**
      * Constructor.
      *
@@ -138,7 +137,8 @@ class BodyListener
      * @param $route
      * @return bool
      */
-    private function isDisabledRoute($route){
+    private function isDisabledRoute($route)
+    {
         return in_array($route, $this->disabledRoutes);
     }
 }

--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -37,9 +37,6 @@
             <argument type="service" id="fos_rest.decoder_provider" />
             <argument>%fos_rest.throw_exception_on_unsupported_content_type%</argument>
             <argument>%fos_rest.disabled_routes%</argument>
-            <call method="setRouter">
-                <argument type="service" id="router" />
-            </call>
         </service>
 
     </services>

--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -36,6 +36,10 @@
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="10" />
             <argument type="service" id="fos_rest.decoder_provider" />
             <argument>%fos_rest.throw_exception_on_unsupported_content_type%</argument>
+            <argument>%fos_rest.disabled_routes%</argument>
+            <call method="setRouter">
+                <argument type="service" id="router" />
+            </call>
         </service>
 
     </services>


### PR DESCRIPTION
Resolve https://github.com/FriendsOfSymfony/FOSRestBundle/issues/760 

/cc https://github.com/FriendsOfSymfony/FOSRestBundle/issues/763

This is a proof of concept how we could avoid body listening on specific routes.
It definitely needs to be finalized, especially since `$request->attributes->get('_route')` didn't work (any hints)? For now it's just a hard coded url for demo purposes. 