### PR TITLE
Don't throw unprocessable media exception on empty content

### DIFF
--- a/Tests/EventListener/BodyListenerTest.php
+++ b/Tests/EventListener/BodyListenerTest.php
@@ -205,4 +205,9 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
         $this->testOnKernelRequest(false, new Request(array(), array(), array(), array(), array(), array(), 'foo'), 'POST', 'application/foo', array(), true);
     }
 
+    public function testDoNotThrowUnsupportedMediaTypeHttpExceptionOnEmptyContentRequest()
+    {
+        $this->testOnKernelRequest(false, new Request(), 'DELETE', 'application/x-www-form-urlencoded', array(), true);
+    }
+
 }


### PR DESCRIPTION
`BodyListener` was throwing `UnprocessableMediaHttpException` when request content was empty, the media verification was based on request's header `Content-Type`, but, this header is not mandatory when there is no content. So now media verification will be made when content is not empty.

@eriksencosta was the one that found this out, he just didn't a PR.
