### PR TITLE
Fix #770

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -179,7 +179,7 @@ class RestActionReader
         }
 
         // generated parameters
-        $routeName    = $this->namePrefix.strtolower($routeName);
+        $routeName    = strtolower($routeName);
         $pattern      = implode('/', $urlParts);
         $defaults     = array('_controller' => $method->getName());
         $requirements = array('_method' => strtoupper($httpMethod));
@@ -546,13 +546,15 @@ class RestActionReader
             $routeName = $routeName.$annotation->getName();
         }
 
+        $fullRouteName = $this->namePrefix.$routeName;
+
         if ($isCollection && !$isInflectable) {
-            $collection->add(self::COLLECTION_ROUTE_PREFIX.$routeName, $route);
-            if (!$collection->get($routeName)) {
-                $collection->add($routeName, clone $route);
+            $collection->add($this->namePrefix.self::COLLECTION_ROUTE_PREFIX.$routeName, $route);
+            if (!$collection->get($fullRouteName)) {
+                $collection->add($fullRouteName, clone $route);
             }
         } else {
-            $collection->add($routeName, $route);
+            $collection->add($fullRouteName, $route);
         }
     }
 }

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -267,6 +267,18 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
+     * @see https://github.com/FriendsOfSymfony/FOSRestBundle/issues/770
+     * @see https://github.com/FriendsOfSymfony/FOSRestBundle/pull/792
+     */
+    public function testNamePrefixIsPrependingCorrectly()
+    {
+        $collection = $this->loadFromControllerFixture('InformationController', 'prefix_');
+
+        $this->assertNotNull($collection->get('prefix_get_information'));
+        $this->assertNotNull($collection->get('prefix_cget_information'));
+    }
+
+    /**
      * Load routes collection from fixture class under Tests\Fixtures directory.
      *
      * @param string $fixtureName name of the class fixture


### PR DESCRIPTION
`RestActionReader` was placing the collection prefix before the global route prefix.
