### PR TITLE
allow paramfetcher to try and fetch parameters from forward call

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -97,6 +97,9 @@ class ParamFetcher implements ParamFetcherInterface
             $param = $this->request->request->get($config->getKey(), $default);
         } elseif ($config instanceof QueryParam) {
             $param = $this->request->query->get($config->getKey(), $default);
+            if (is_null($param)) {
+                $param = $this->request->get($config->name, $default);
+            }
         } else {
             $param = null;
         }


### PR DESCRIPTION
Hi, it seems this is needed to be able to fetch parameters, coming in via a controller forward, eg:

```
$this->forward('AcmeApiBundle:Entity:get', array('id' => 'd22484bf-1d48-11e4-a4e4-a45d36c13021'));
```

is coming in as :

```
object(FOS\RestBundle\Controller\Annotations\QueryParam)[501]
  public 'name' => string 'id' (length=2)
  public 'key' => null
  public 'requirements' => null
  public 'default' => null
  public 'description' => string 'Get an object by id. Format: uuid .' (length=35)
  public 'strict' => boolean false
  public 'array' => boolean false
  public 'nullable' => boolean false
```

am i doing something wrong ?   why is it coming in as a QueryParam, should this be a requestparam ? 

Thx in advance.
