### PR TITLE
Add ability to to define rules that stop the format listener

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -200,6 +200,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('path')->defaultNull()->info('URL path info')->end()
                                     ->scalarNode('host')->defaultNull()->info('URL host name')->end()
                                     ->variableNode('methods')->defaultNull()->info('Method for URL')->end()
+                                    ->booleanNode('stop')->defaultFalse()->end()
                                     ->booleanNode('prefer_extension')->defaultTrue()->end()
                                     ->scalarNode('fallback_format')->defaultValue('html')->end()
                                     ->arrayNode('priorities')

--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -405,6 +405,25 @@ natively or it needs to be added as documented here or using the mime type
 listener explained in
 [the Symfony Cookbook entry](http://symfony.com/doc/current/cookbook/request/mime_type.html).
 
+#### Disabling the Format Listener via Rules
+
+Often when integrating this Bundle with existing applications, it might be useful
+to disable the format listener for some routes. In this case it is possible to define
+a rule that will stop the format listener from determining a format by setting
+``stop`` to ``true`` as a rule option. Any rule containing this setting and any rule
+following will not be considered and the Request format will remain unchanged.
+
+```yaml
+# app/config/config.yml
+fos_rest:
+    format_listener:
+        rules:
+            - { path: '^/api', priorities: ['json', 'xml'], fallback_format: json, prefer_extension: false }
+            - { path: '^/', stop: true }
+```
+
+#### Media Type Version Extraction
+
 The format listener can also determine the version of the selected media type
 based on a regular expression. The regular expression can be configured as
 follows. Setting it to an empty value will disable the behavior entirely.

--- a/Tests/EventListener/FormatListenerTest.php
+++ b/Tests/EventListener/FormatListenerTest.php
@@ -11,6 +11,9 @@
 
 namespace FOS\RestBundle\Tests\EventListener;
 
+use FOS\RestBundle\Util\FormatNegotiator;
+use FOS\RestBundle\Util\StopFormatListenerException;
+use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -41,6 +44,30 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
         $formatNegotiator->expects($this->once())
             ->method('getBestMediaType')
             ->will($this->returnValue('application/xml'));
+
+        $listener = new FormatListener($formatNegotiator);
+
+        $listener->onKernelRequest($event);
+
+        $this->assertEquals($request->getRequestFormat(), 'xml');
+    }
+
+    public function testOnKernelControllerNegotiationStopped()
+    {
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = new Request();
+        $request->setRequestFormat('xml');
+
+        $event->expects($this->once())
+            ->method('getRequest')
+            ->will($this->returnValue($request));
+
+        $formatNegotiator = new FormatNegotiator();
+        $formatNegotiator->add(new RequestMatcher('/'), array('stop' => true));
+        $formatNegotiator->add(new RequestMatcher('/'), array('fallback_format' => 'json'));
 
         $listener = new FormatListener($formatNegotiator);
 

--- a/Util/FormatNegotiator.php
+++ b/Util/FormatNegotiator.php
@@ -65,6 +65,10 @@ class FormatNegotiator implements MediaTypeNegotiatorInterface
                 $options = $elements[1];
             }
 
+            if (!empty($options['stop'])) {
+                throw new StopFormatListenerException('Stopped format listener');
+            }
+
             if (empty($options['priorities'])) {
                 if (!empty($options['fallback_format'])) {
                     return $request->getMimeType($options['fallback_format']);

--- a/Util/StopFormatListenerException.php
+++ b/Util/StopFormatListenerException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the FOSRest package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Util;
+
+/**
+ * Thrown to stop the format negotiator from continuing so that no format is set
+ */
+class StopFormatListenerException extends \Exception
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     ],
 
     "require": {
-        "php":                            ">=5.3.2",
+        "php":                            ">=5.3.3",
         "psr/log":                        "~1.0",
         "symfony/framework-bundle":       "~2.2",
-        "doctrine/inflector":             "1.0.*",
+        "doctrine/inflector":             "~1.0",
         "willdurand/negotiation":         "~1.2",
         "willdurand/jsonp-callback-validator": "~1.0"
     },
@@ -59,7 +59,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.4-dev"
+            "dev-master": "1.5-dev"
         }
     }
 }


### PR DESCRIPTION
Feels a lot like I am abusing Exceptions for control flow here. But imho returning `false` just makes the API messy.

Guess before this is merged I should also bump the dev version to 1.5
