### PR TITLE
enable jms max depth exclusion strategy

### DIFF
--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="fos_rest.serializer.exclusion_strategy.version" />
         <parameter key="fos_rest.serializer.exclusion_strategy.groups"/>
+        <parameter key="fos_rest.serializer.exclusion_strategy.max_depth"/>
         <parameter key="fos_rest.view_handler.jsonp.callback_param"/>
         <parameter key="fos_rest.view.exception_wrapper_handler" />
         <parameter key="fos_rest.view_handler.default.class">FOS\RestBundle\View\ViewHandler</parameter>
@@ -31,6 +32,9 @@
             </call>
             <call method="setSerializeNullStrategy">
                 <argument>%fos_rest.serializer.serialize_null%</argument>
+            </call>
+            <call method="setExclusionStrategyMaxDepth">
+                <argument>%fos_rest.serializer.exclusion_strategy.max_depth%</argument>
             </call>
             <call method="setContainer">
                 <argument type="service" id="service_container" />

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -92,6 +92,11 @@ class ViewHandler extends ContainerAware implements ConfigurableViewHandlerInter
     protected $exclusionStrategyVersion;
 
     /**
+     * @var string
+     */
+    protected $exclusionStrategyMaxDepth;
+
+    /**
      * @var bool
      */
     protected $serializeNullStrategy;
@@ -140,6 +145,16 @@ class ViewHandler extends ContainerAware implements ConfigurableViewHandlerInter
     public function setExclusionStrategyVersion($version)
     {
         $this->exclusionStrategyVersion = $version;
+    }
+
+    /**
+     * If true should enable the max depth strategy
+     *
+     * @param bool $isEnabled
+     */
+    public function setExclusionStrategyMaxDepth($isEnabled)
+    {
+        $this->exclusionStrategyMaxDepth = $isEnabled;
     }
 
     /**
@@ -264,6 +279,10 @@ class ViewHandler extends ContainerAware implements ConfigurableViewHandlerInter
 
         if (null === $context->shouldSerializeNull() && null !== $this->serializeNullStrategy) {
             $context->setSerializeNull($this->serializeNullStrategy);
+        }
+
+        if (true === $this->exclusionStrategyMaxDepth) {
+            $context->enableMaxDepthChecks();
         }
 
         return $context;


### PR DESCRIPTION
It adds a call to the ViewHandler to enable the max depth strategy exclusion in jms serializer context.

Best regards
