### PR TITLE
to use format from request if it was set

### DIFF
--- a/EventListener/FormatListener.php
+++ b/EventListener/FormatListener.php
@@ -50,7 +50,7 @@ class FormatListener
             $request = $event->getRequest();
 
             $format = null;
-            if (is_null($request->getRequestFormat(null))) {
+            if (null === $request->getRequestFormat(null)) {
                 if ($this->formatNegotiator instanceof MediaTypeNegotiatorInterface) {
                     $mediaType = $this->formatNegotiator->getBestMediaType($request);
                     if ($mediaType) {

--- a/Tests/EventListener/FormatListenerTest.php
+++ b/Tests/EventListener/FormatListenerTest.php
@@ -101,4 +101,46 @@ class FormatListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onKernelRequest($event);
     }
+
+    /**
+     * Test FormatListener won't overwrite request format when it was already specified
+     *
+     * @dataProvider useSpecifiedFormatDataProvider
+     */
+    public function testUseSpecifiedFormat($format, $result)
+    {
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $request = new Request();
+        if ($format) {
+            $request->setRequestFormat($format);
+        }
+
+        $event->expects($this->once())
+            ->method('getRequest')
+            ->will($this->returnValue($request));
+
+        $formatNegotiator = $this->getMockBuilder('FOS\RestBundle\Util\FormatNegotiator')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $formatNegotiator->expects($this->any())
+            ->method('getBestMediaType')
+            ->will($this->returnValue('application/xml'));
+
+        $listener = new FormatListener($formatNegotiator);
+
+        $listener->onKernelRequest($event);
+
+        $this->assertEquals($request->getRequestFormat(), $result);
+    }
+
+    public function useSpecifiedFormatDataProvider()
+    {
+        return array(
+            array(null, 'xml'),
+            array('json', 'json'),
+        );
+    }
 }


### PR DESCRIPTION
This is about last question in comment https://github.com/FriendsOfSymfony/FOSRestBundle/issues/310#issuecomment-26479952 and a few issues more.

It was very helpful sometimes to specify format in forward method. But now FormatListener ignores format in request. I offer first to check if the format was manualy set for request (for example, as an attribute in forward method), and use it, rather than trying to guess it.
