### PR TITLE
Use standard bundle installation template

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.rst
+++ b/Resources/doc/1-setting_up_the_bundle.rst
@@ -1,8 +1,18 @@
 Step 1: Setting up the bundle
 =============================
 
-A) Install FOSRestBundle
-------------------------
+A) Download the Bundle
+----------------------
+
+Open a command console, enter your project directory and execute the
+following command to download the latest stable version of this bundle:
+
+.. code-block:: bash
+
+    $ composer require friendsofsymfony/rest-bundle "~1.4"
+
+This command requires you to have Composer installed globally, as explained
+in the `installation chapter`_ of the Composer documentation.
 
 .. note::
 
@@ -14,36 +24,31 @@ A) Install FOSRestBundle
     But in this case, you need to manually set it up and configure FOSRestBundle
     to use it via the ``service`` section in the app config
 
-Simply run assuming you have installed ``composer.phar`` or ``composer`` binary:
-
-.. code-block:: bash
-
-    $ composer require friendsofsymfony/rest-bundle
-
-B) Enable the bundle
+B) Enable the Bundle
 --------------------
 
-Finally, enable the bundle in the kernel:
+Then, enable the bundle by adding the following line in the ``app/AppKernel.php``
+file of your project:
 
 .. code-block:: php
 
-    <?php
     // app/AppKernel.php
-
-    public function registerBundles()
+    class AppKernel extends Kernel
     {
-        $bundles = array(
+        public function registerBundles()
+        {
+            $bundles = array(
+                // ...
+                new FOS\RestBundle\FOSRestBundle(),
+            );
+        
             // ...
-            new FOS\RestBundle\FOSRestBundle(),
-
-            // if you choose to use JMSSerializer, make sure that it is registered in your application
-
-            // new JMS\SerializerBundle\JMSSerializerBundle(),
-        );
+        }
     }
 
 That was it!
 
+.. _`installation chapter`: https://getcomposer.org/doc/00-intro.md
 .. _`JMSSerializer`: https://github.com/schmittjoh/serializer
 .. _`JMSSerializerBundle`: https://github.com/schmittjoh/JMSSerializerBundle
 .. _`Symfony Serializer`: https://github.com/symfony/Serializer


### PR DESCRIPTION
*The Symfony Documenators started an initiative to make all bundle installation documentation consistent and  easy to understand for beginners. That'll improve the DX for starters using 3rd party bundles. The template can be found here: http://symfony.com/doc/current/cookbook/bundles/best_practices.html#installation-instructions*

I would like to ask you to use this template in your documentation.

If you have any comments on the template, please open an issue in the `symfony/symfony-docs` repository. Feedback will brings us to the ultimate template.