### PR TITLE
Annotation: Routing name is just appending to generic route name

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -537,7 +537,12 @@ class RestActionReader
     {
         if ($annotation && null !== $annotation->getName()) {
             $options = $annotation->getOptions();
-            $routeName = empty($options['method_prefix']) ? $annotation->getName() : $routeName.$annotation->getName();
+
+            if(isset($options['method_prefix']) && false === $options['method_prefix']) {
+                $routeName = $annotation->getName();
+            } else {
+                $routeName = $routeName.$annotation->getName();
+            }
         }
 
         $fullRouteName = $this->namePrefix.$routeName;

--- a/Tests/Fixtures/Controller/AnnotatedConditionalUsersController.php
+++ b/Tests/Fixtures/Controller/AnnotatedConditionalUsersController.php
@@ -136,10 +136,10 @@ class AnnotatedConditionalUsersController extends Controller
     {}
 
     /**
-     * @Link("/users1", name="multipleget_users_a_link_method", condition="context.getMethod() in ['LINK'] and request.headers.get('User-Agent') matches '/firefox/i'")
-     * @Get("/users2",  name="multipleget_users_a_get_method", condition="context.getMethod() in ['GET'] and request.headers.get('User-Agent') matches '/firefox/i'")
-     * @Get("/users3",  name="multipleget_users_an_other_get_method")
-     * @Post("/users4",  name="multipleget_users_a_post_method", condition="context.getMethod() in ['POST'] and request.headers.get('User-Agent') matches '/firefox/i'")
+     * @Link("/users1", name="_a_link_method", condition="context.getMethod() in ['LINK'] and request.headers.get('User-Agent') matches '/firefox/i'")
+     * @Get("/users2",  name="_a_get_method", condition="context.getMethod() in ['GET'] and request.headers.get('User-Agent') matches '/firefox/i'")
+     * @Get("/users3",  name="_an_other_get_method")
+     * @Post("/users4",  name="_a_post_method", condition="context.getMethod() in ['POST'] and request.headers.get('User-Agent') matches '/firefox/i'")
      *
      */
     public function multiplegetUsersAction()

--- a/Tests/Fixtures/Controller/AnnotatedUsersController.php
+++ b/Tests/Fixtures/Controller/AnnotatedUsersController.php
@@ -131,18 +131,18 @@ class AnnotatedUsersController extends Controller
     {}
 
     /**
-     * @Link("/users1", name="multipleget_users_a_link_method")
-     * @Get("/users2",  name="multipleget_users_a_get_method")
-     * @Get("/users3",  name="multipleget_users_an_other_get_method")
-     * @Post("/users4",  name="multipleget_users_a_post_method")
+     * @Link("/users1", name="_a_link_method")
+     * @Get("/users2",  name="_a_get_method")
+     * @Get("/users3",  name="_an_other_get_method")
+     * @Post("/users4",  name="_a_post_method")
      *
      */
     public function multiplegetUsersAction()
     {}
 
     /**
-     * @POST("/users1/{foo}", name="_foo", options={"method_prefix" = true })
-     * @POST("/users2/{foo}", name="_bar", options={"method_prefix" = true })
+     * @POST("/users1/{foo}", name="post_users_foo", options={ "method_prefix" = false })
+     * @POST("/users2/{foo}", name="post_users_bar", options={ "method_prefix" = false })
      *
      */
     public function multiplepostUsersAction()

--- a/Tests/Fixtures/Etalon/annotated_users_controller.yml
+++ b/Tests/Fixtures/Etalon/annotated_users_controller.yml
@@ -76,11 +76,11 @@ multipleget_users_a_link_method:
   controller:   ::multiplegetUsersAction
   requirements: {_method: LINK}
 
-multiplepost_users_foo:
+post_users_foo:
   pattern:      /users1/{foo}.{_format}
   controller:   ::multiplepostUsersAction
   requirements: {_method: POST}
-multiplepost_users_bar:
+post_users_bar:
   pattern:      /users2/{foo}.{_format}
   controller:   ::multiplepostUsersAction
   requirements: {_method: POST}

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -286,8 +286,8 @@ class RestRouteLoaderTest extends LoaderTest
     {
         $collection     = $this->loadFromControllerFixture('AnnotatedUsersController');
 
-        $this->assertNotNull($collection->get('multiplepost_users_foo'));
-        $this->assertNotNull($collection->get('multiplepost_users_bar'));
+        $this->assertNotNull($collection->get('post_users_foo'), 'route for "post_users_foo" does not exist');
+        $this->assertNotNull($collection->get('post_users_bar'), 'route for "post_users_bar" does not exist');
     }
 
     /**


### PR DESCRIPTION
This pr fix issue #878 

I have noticed, that if i use the annotation to declare a custom route the "name" attribute is just appended to the generic route name. 

``` php
/**
* @FOSRest\Get("/users/{user}", name="get_user", requirements={"user" = "\d+|me"})
*/
public function getUserAction(User $user) { /** */ }

```

Current result:

```
get_userget_user                   GET      ANY    ANY  /users/{user}.{_format}

```

New result:

```
get_user                           GET      ANY    ANY  /users/{user}.{_format}

```
