### PR TITLE
Ignore ParamConverter for route generation

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -334,6 +334,7 @@ class RestActionReader
             'Symfony\Component\HttpFoundation\Request',
             'FOS\RestBundle\Request\ParamFetcherInterface',
             'Symfony\Component\Validator\ConstraintViolationListInterface',
+            'Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter'
         );
 
         $arguments = array();


### PR DESCRIPTION
Allows to remove route declaration when specifying ParamConverter https://github.com/FriendsOfSymfony/FOSRestBundle/issues/153
