### PR TITLE
A note about which version support this option/configuration

### DIFF
--- a/Resources/doc/3-listener-support.md
+++ b/Resources/doc/3-listener-support.md
@@ -419,7 +419,7 @@ fos_rest:
     format_listener:
         rules:
             - { path: '^/api', priorities: ['json', 'xml'], fallback_format: json, prefer_extension: false }
-            - { path: '^/', stop: true }
+            - { path: '^/', stop: true } # Available for version >= 1.5
 ```
 
 #### Media Type Version Extraction


### PR DESCRIPTION
Disable the listener is a quite common need. Would be nice to have an "official" example to disable this feature for version previous to 1.5
