### PR TITLE
close #901, we can add a incompatibles attribute

### DIFF
--- a/Controller/Annotations/Param.php
+++ b/Controller/Annotations/Param.php
@@ -37,6 +37,8 @@ abstract class Param
     public $nullable = false;
     /** @var bool */
     public $allowBlank = true;
+    /** @var array */
+    public $incompatibles = array();
 
     /**
      * @return string

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -195,6 +195,8 @@ class ParamFetcher implements ParamFetcherInterface
             );
         }
 
+        $this->checkNotIncompatibleParams($config);
+
         if (null === $config->requirements || ($param === $default && null !== $default)) {
             return $param;
         }
@@ -280,5 +282,38 @@ class ParamFetcher implements ParamFetcherInterface
             new \ReflectionClass(ClassUtils::getClass($this->controller[0])),
             $this->controller[1]
         );
+    }
+
+    /**
+     * Check if current param is not in conflict with other parameters
+     * according to the "incompatibles" field
+     *
+     * @param Param $config the configuration for the param fetcher
+     *
+     * @throws BadRequestHttpException
+     */
+    private function checkNotIncompatibleParams(Param $config)
+    {
+
+        if (!$config instanceof QueryParam) {
+            return;
+        };
+
+        foreach ($config->incompatibles as $incompatibleParam) {
+            $isIncompatiblePresent = $this->request->query->get(
+                $incompatibleParam,
+                null
+            ) !== null;
+
+            if ($isIncompatiblePresent) {
+                $exceptionMessage = sprintf(
+                    "'%s' param is incompatible with %s param",
+                    $config->name,
+                    $incompatibleParam
+                );
+
+                throw new BadRequestHttpException($exceptionMessage);
+            }
+        }
     }
 }

--- a/Resources/doc/3-listener-support.rst
+++ b/Resources/doc/3-listener-support.rst
@@ -553,6 +553,17 @@ configured for the matched controller so that the user does not need to do this 
          *
          * @RequestParam(name="firstname", requirements="[a-z]+", description="Firstname.")
          *
+         * Imagine you have an api for a blog with to get Articles with two ways of filtering
+         *   1 by filtering the text
+         *   2 by filtering the author
+         * and you don't have yet implemented the possibility to filter by both at the same time.
+         * In order to prevent clients from doing a request with both (which will produce not the expected
+         * resut and is likely to be considered as a bug) you can precise the parameters can't be present
+         * at the same time by doing
+         *
+         * @RequestParam(name="search", requirements="[a-z]+", description="search")
+         * @RequestParam(name="byauthor", requirements="[a-z]+", description="by author", incompatibles={"search"})
+         *
          * If you want to work with array: ie. ?ids[]=1&ids[]=2&ids[]=1337, use:
          *
          * @QueryParam(array=true, name="ids", requirements="\d+", default="1", description="List of ids")

--- a/Resources/doc/annotations-reference.rst
+++ b/Resources/doc/annotations-reference.rst
@@ -16,6 +16,7 @@ QueryParam
      *   name="",
      *   key=null,
      *   requirements="",
+     *   incompatibles={},
      *   default=null,
      *   description="",
      *   strict=false,

--- a/Tests/Controller/Annotations/QueryParamTest.php
+++ b/Tests/Controller/Annotations/QueryParamTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Controller\Annotations;
+
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+
+/**
+ * RequestParamTest
+ *
+ * @author Eduardo Oliveira <entering@gmail.com>
+ */
+class QueryParamTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultIsNull()
+    {
+        $queryParam = new QueryParam();
+        $this->assertNull($queryParam->default, 'Expected QueryParam default property to be null');
+    }
+
+    public function testStrictIsTrue()
+    {
+        $queryParam = new QueryParam();
+        $this->assertFalse($queryParam->strict, 'Expected QueryParam strict property to be false');
+    }
+
+    public function testIncompatiblesIsEmptyArray()
+    {
+        $queryParam = new QueryParam();
+        $this->assertInternalType(
+            'array',
+            $queryParam->incompatibles,
+            'Expected QueryParam incompatibles property to be an array'
+        );
+        $this->assertEmpty(
+            $queryParam->incompatibles,
+            'Expected QueryParam incompatibles property to be empty'
+        );
+    }
+
+}
+

--- a/Tests/Request/ParamFetcherTest.php
+++ b/Tests/Request/ParamFetcherTest.php
@@ -128,6 +128,15 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $annotations['moo']->allowBlank = false;
         $annotations['moo']->description = 'A scalar param with an explicitly defined null default';
 
+        $annotations['i_cant_be_with_moo'] = new QueryParam();
+        $annotations['i_cant_be_with_moo']->name = 'its_likely_a_bug_from_client_side_if_i_m_with_moo';
+        $annotations['i_cant_be_with_moo']->key = 'i_cant_be_with_moo';
+        $annotations['i_cant_be_with_moo']->requirements = '\d+';
+        $annotations['i_cant_be_with_moo']->default = null;
+        $annotations['i_cant_be_with_moo']->nullable = true;
+        $annotations['i_cant_be_with_moo']->incompatibles = array('moo');
+        $annotations['i_cant_be_with_moo']->description = 'A scalar param that can not be present in the same request with a given other parameter';
+
         $this->paramReader
             ->expects($this->any())
             ->method('read')
@@ -193,21 +202,21 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
             array( // check that non-strict missing params take default value
                 'foo',
                 '1',
-                array('foo' => '1', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(),  'moo' => null),
+                array('foo' => '1', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(),  'moo' => null, 'i_cant_be_with_moo' => null),
                 array(),
                 array('bar' => '2', 'baz' => '4', 'arr' => array()),
             ),
             array( // pass Param in GET
                 'foo',
                 '42',
-                array('foo' => '42', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '42', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('foo' => '42'),
                 array('bar' => '2', 'baz' => '4', 'arr' => array()),
             ),
             array( // check that invalid non-strict params take default value
                 'foo',
                 '1',
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('foo' => 'bar'),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
                 function (\PHPUnit_Framework_MockObject_MockObject $validator, \PHPUnit_Framework_TestCase $self) {
@@ -229,21 +238,21 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
             array( // nullable array with strict
                 'arr_null_strict',
                 array(),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array(),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
             array( // invalid array
                 'buzz',
                 array(1),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => 'invaliddata'),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
             array( // invalid array (multiple depth)
                 'buzz',
                 array(1),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(array(1))),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
@@ -251,14 +260,14 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
             array( // multiple array
                 'buzz',
                 array(2, 3, 4),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 3, 4)),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
             array( // multiple array with one invalid value
                 'buzz',
                 array(2, 1, 4),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 1, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 1, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 'invaliddata', 4)),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
                 function (\PHPUnit_Framework_MockObject_MockObject $validator, \PHPUnit_Framework_TestCase $self) {
@@ -280,45 +289,53 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
             array(  // Array not provided in GET query
                 'boo',
                 array(),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 3, 4)),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
             array(  // QueryParam provided in GET query but as a scalar
                 'boo',
                 array(),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array(), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 3, 4), 'boo' => 'scalar'),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
             array(  // QueryParam provided in GET query with valid values
                 'boo',
                 array('1', 'foo', 5),
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5)),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
             array(  // QueryParam provided in GET query with valid values
                 'boozz',
                 null,
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => null, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5)),
                 array('bar' => '1', 'baz' => '4', 'arr' => array()),
             ),
             array(  // QueryParam provided in GET query with valid values
                 'boozz',
                 5,
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => null, 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5),
                 array('bar' => '1', 'baz' => '4', 'boozz' => 5, 'arr' => array()),
             ),
             array(  // QueryParam provided in GET query with valid values
                 'moo',
                 'string',
-                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => 'string'),
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => 'string', 'i_cant_be_with_moo' => null),
                 array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5, 'moo' => 'string'),
                 array('bar' => '1', 'baz' => '4', 'boozz' => 5, 'arr' => array()),
+            ),
+            array(  // QueryParam provided in GET query with valid values
+                'i_cant_be_with_moo',
+                5,
+                array('foo' => '1', 'bar' => '1', 'baz' => '4', 'buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5, 'biz' => null, 'arr' => array(), 'arr_null_strict' => array(),'moo' => null, 'i_cant_be_with_moo' => 5),
+                array('buzz' => array(2, 3, 4), 'boo' => array('1', 'foo', 5), 'boozz' => 5, 'i_cant_be_with_moo' => 5),
+                array('bar' => '1', 'baz' => '4', 'boozz' => 5, 'arr' => array()),
             )
+
         );
     }
 
@@ -334,7 +351,7 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $queryFetcher->addParam($runtimeParam);
 
         $this->assertEquals(10, $queryFetcher->get('bub'));
-        $this->assertEquals(array('foo' => '1', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'bub' => 10, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => ''), $queryFetcher->all());
+        $this->assertEquals(array('foo' => '1', 'bar' => '2', 'baz' => '4', 'buzz' => array(1), 'boo' => array(), 'boozz' => null, 'biz' => null, 'bub' => 10, 'arr' => array(), 'arr_null_strict' => array(), 'moo' => '', 'i_cant_be_with_moo' => null), $queryFetcher->all());
     }
 
     public function testValidatesConfiguredParamStrictly()
@@ -407,6 +424,11 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
                 array('boozz' => 'foo'),
                 array('bar' => 'foo', 'baz' => 'foo'),
                 'arr',
+            ),
+            array( // test param present with an other param declared as incompatible
+                array('i_cant_be_with_moo' => 42, 'moo' => 'plop'),
+                array(),
+                'i_cant_be_with_moo',
             ),
             array( // test missing strict param
                 array(),


### PR DESCRIPTION
to QueryParam to detect parameters that can't appears
together in the same API call