### PR TITLE
build against Symfony 2.6 instead of Symfony 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.4
   - 5.5
   - hhvm
-  
+
 branches:
   only:
     - master
@@ -18,7 +18,9 @@ matrix:
     - php: 5.5
       env: SYMFONY_VERSION=2.4.*
     - php: 5.5
-      env: SYMFONY_VERSION='dev-master'
+      env: SYMFONY_VERSION='2.6.*@dev'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.7.*@dev'
 
 before_script:
   - composer self-update


### PR DESCRIPTION
After the `2.6` branch has been created on the Symfony repository, the
`master` branch has become the development branch for `3.0`. However,
builds should still happen for `2.6@dev` instead of `3.0@dev` for now.
