### PR TITLE
Updated installation instructions

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.md
+++ b/Resources/doc/1-setting_up_the_bundle.md
@@ -15,7 +15,7 @@ Step 1: Setting up the bundle
 Simply run assuming you have installed composer.phar or composer binary:
 
 ``` bash
-$ php composer.phar require friendsofsymfony/rest-bundle ~1.4
+$ composer require friendsofsymfony/rest-bundle
 ```
 
 ### B) Enable the bundle


### PR DESCRIPTION
In recent Composer versions, when you don't specify the dependency version, it installs the latest available stable version, so the command can be simplified.
