### PR TITLE
fix ContainerBuilder mock generation in tests

### DIFF
--- a/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
@@ -25,7 +25,9 @@ class ConfigurationCheckPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldThrowRuntimeExceptionWhenFOSRestBundleAnnotations()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('has'))
+            ->getMock();
         $container->expects($this->at(0))
             ->method('has')
             ->with($this->equalTo('sensio_framework_extra.view.listener'))
@@ -46,7 +48,9 @@ class ConfigurationCheckPassTest extends \PHPUnit_Framework_TestCase
             'RuntimeException',
             'You need to enable the parameter converter listeners in SensioFrameworkExtraBundle when using the FOSRestBundle RequestBodyParamConverter'
         );
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('has'))
+            ->getMock();
         $container->expects($this->at(1))
             ->method('has')
             ->with($this->equalTo('fos_rest.converter.request_body'))

--- a/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
@@ -22,7 +22,9 @@ class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', array('addMethod'));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('hasDefinition', 'getDefinition', 'hasParameter', 'getParameter'))
+            ->getMock();
 
         $container->expects($this->exactly(3))
             ->method('hasDefinition')
@@ -62,7 +64,9 @@ class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', array('addMethod'));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('hasDefinition', 'getDefinition', 'hasParameter', 'getParameter'))
+            ->getMock();
 
         $container->expects($this->exactly(2))
             ->method('hasDefinition')

--- a/Tests/FOSRestBundleTest.php
+++ b/Tests/FOSRestBundleTest.php
@@ -22,7 +22,9 @@ class FOSRestBundleTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuild()
     {
-        $container = $this->getMock('\Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('addCompilerPass'))
+            ->getMock();
         $container->expects($this->exactly(3))
             ->method('addCompilerPass')
             ->with($this->isInstanceOf('\Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface'));

--- a/Tests/Routing/Loader/LoaderTest.php
+++ b/Tests/Routing/Loader/LoaderTest.php
@@ -61,6 +61,7 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
         if ($this->containerMock === null) {
             $this->containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
                 ->disableOriginalConstructor()
+                ->setMethods(array('get', 'has'))
                 ->getMock();
         }
         $l = $this->getMockBuilder('Symfony\Component\Config\FileLocator')

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -153,6 +153,7 @@ class RestYamlCollectionLoaderTest extends LoaderTest
         // We register the controller in the fake container by its class name
         $this->containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
             ->disableOriginalConstructor()
+            ->setMethods(array('has', 'get', 'enterScope', 'leaveScope'))
             ->getMock();
         $this->containerMock->expects($this->any())
             ->method('has')

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="./Tests/bootstrap.php" colors="true">
+    <php>
+        <!-- Disable E_USER_DEPRECATED until 3.0 -->
+        <!-- php -r 'echo -1 & ~E_USER_DEPRECATED;' -->
+        <ini name="error_reporting" value="-16385"/>
+    </php>
 
     <testsuites>
         <testsuite name="FOSRestBundle test suite">


### PR DESCRIPTION
By default, PHPUnit mocks all methods of the mocked class. This breaks
when one of the methods has an argument that is type-hinted with a
non-existing class or interface.
