### PR TITLE
allow symfony loader to load it's unrecognized routes

### DIFF
--- a/Resources/config/schema/routing-1.0.xsd
+++ b/Resources/config/schema/routing-1.0.xsd
@@ -1,64 +1,65 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <xsd:schema xmlns="http://symfony.com/schema/routing"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="http://symfony.com/schema/routing"
-            elementFormDefault="qualified">
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://symfony.com/schema/routing"
+    elementFormDefault="qualified">
 
-    <xsd:annotation>
-        <xsd:documentation><![CDATA[
+  <xsd:annotation>
+    <xsd:documentation><![CDATA[
       Symfony XML Routing Schema, version 1.0
       Authors: Fabien Potencier, Tobias Schultze
 
       This scheme defines the elements and attributes that can be used to define
       routes. A route maps an HTTP request to a set of configuration variables.
     ]]></xsd:documentation>
-    </xsd:annotation>
+  </xsd:annotation>
 
-    <xsd:element name="routes" type="routes" />
+  <xsd:element name="routes" type="routes" />
 
-    <xsd:complexType name="routes">
-        <xsd:choice minOccurs="0" maxOccurs="unbounded">
-            <xsd:element name="import" type="import" />
-            <xsd:element name="route" type="route" />
-        </xsd:choice>
-    </xsd:complexType>
+  <xsd:complexType name="routes">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="import" type="import" />
+      <xsd:element name="route" type="route" />
+    </xsd:choice>
+  </xsd:complexType>
 
-    <xsd:group name="configs">
-        <xsd:choice>
-            <xsd:element name="default" nillable="true" type="element" />
-            <xsd:element name="requirement" type="element" />
-            <xsd:element name="option" type="element" />
-        </xsd:choice>
-    </xsd:group>
+  <xsd:group name="configs">
+    <xsd:choice>
+      <xsd:element name="default" nillable="true" type="element" />
+      <xsd:element name="requirement" type="element" />
+      <xsd:element name="option" type="element" />
+      <xsd:element name="condition" type="xsd:string" />
+    </xsd:choice>
+  </xsd:group>
 
-    <xsd:complexType name="route">
-        <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
+  <xsd:complexType name="route">
+    <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
-        <xsd:attribute name="id" type="xsd:string" use="required" />
-        <xsd:attribute name="path" type="xsd:string" />
-        <xsd:attribute name="pattern" type="xsd:string" />
-        <xsd:attribute name="host" type="xsd:string" />
-        <xsd:attribute name="schemes" type="xsd:string" />
-        <xsd:attribute name="methods" type="xsd:string" />
-    </xsd:complexType>
+    <xsd:attribute name="id" type="xsd:string" use="required" />
+    <xsd:attribute name="path" type="xsd:string" />
+    <xsd:attribute name="pattern" type="xsd:string" />
+    <xsd:attribute name="host" type="xsd:string" />
+    <xsd:attribute name="schemes" type="xsd:string" />
+    <xsd:attribute name="methods" type="xsd:string" />
+  </xsd:complexType>
 
-    <xsd:complexType name="import">
-        <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
+  <xsd:complexType name="import">
+    <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
-        <xsd:attribute name="resource" type="xsd:string" use="required" />
-        <xsd:attribute name="type" type="xsd:string" />
-        <xsd:attribute name="prefix" type="xsd:string" />
-        <xsd:attribute name="host" type="xsd:string" />
-        <xsd:attribute name="schemes" type="xsd:string" />
-        <xsd:attribute name="methods" type="xsd:string" />
-    </xsd:complexType>
+    <xsd:attribute name="resource" type="xsd:string" use="required" />
+    <xsd:attribute name="type" type="xsd:string" />
+    <xsd:attribute name="prefix" type="xsd:string" />
+    <xsd:attribute name="host" type="xsd:string" />
+    <xsd:attribute name="schemes" type="xsd:string" />
+    <xsd:attribute name="methods" type="xsd:string" />
+  </xsd:complexType>
 
-    <xsd:complexType name="element">
-        <xsd:simpleContent>
-            <xsd:extension base="xsd:string">
-                <xsd:attribute name="key" type="xsd:string" use="required" />
-            </xsd:extension>
-        </xsd:simpleContent>
-    </xsd:complexType>
+  <xsd:complexType name="element">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="key" type="xsd:string" use="required" />
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
 </xsd:schema>

--- a/Resources/config/schema/routing/rest_routing-1.0.xsd
+++ b/Resources/config/schema/routing/rest_routing-1.0.xsd
@@ -14,15 +14,24 @@
     </xsd:choice>
   </xsd:complexType>
 
-  <xsd:complexType name="route">
-    <xsd:sequence>
-      <xsd:element name="default" type="element" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="requirement" type="element" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="option" type="element" minOccurs="0" maxOccurs="unbounded" />
-    </xsd:sequence>
+  <!-- configs and route should be kept in sync with symfony schema -->
+  <xsd:group name="configs">
+    <xsd:choice>
+        <xsd:element name="default" nillable="true" type="element" />
+        <xsd:element name="requirement" type="element" />
+        <xsd:element name="option" type="element" />
+    </xsd:choice>
+  </xsd:group>
 
-    <xsd:attribute name="id" type="xsd:string" />
+  <xsd:complexType name="route">
+    <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
+
+    <xsd:attribute name="id" type="xsd:string" use="required" />
+    <xsd:attribute name="path" type="xsd:string" />
     <xsd:attribute name="pattern" type="xsd:string" />
+    <xsd:attribute name="host" type="xsd:string" />
+    <xsd:attribute name="schemes" type="xsd:string" />
+    <xsd:attribute name="methods" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="import">

--- a/Routing/Loader/RestXmlCollectionLoader.php
+++ b/Routing/Loader/RestXmlCollectionLoader.php
@@ -157,6 +157,26 @@ class RestXmlCollectionLoader extends XmlFileLoader
             $node->appendChild($option);
         }
 
+        $length = $node->childNodes->length;
+        for ($i = 0; $i < $length; $i++) {
+            $loopNode = $node->childNodes->item($i);
+            if ($loopNode->nodeType == XML_TEXT_NODE) {
+                continue;
+            }
+
+            $newNode = $node->ownerDocument->createElementNS(
+                self::NAMESPACE_URI,
+                $loopNode->nodeName,
+                $loopNode->nodeValue
+            );
+
+            foreach ($loopNode->attributes as $value) {
+                $newNode->setAttribute($value->name, $value->value);
+            }
+
+            $node->appendChild($newNode);
+        }
+
         parent::parseRoute($collection, $node, $path);
     }
 

--- a/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
@@ -67,6 +67,7 @@ class RestXmlCollectionLoaderTest extends LoaderTest
 
         $this->assertEquals('/users.{_format}', $route->getPath());
         $this->assertEquals('json|xml|html', $route->getRequirement('_format'));
+        $this->assertEquals('FOSRestBundle:UsersController:getUsers', $route->getDefault('_controller'));
     }
 
     public function testManualRoutesWithoutIncludeFormat()

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -108,6 +108,7 @@ class RestYamlCollectionLoaderTest extends LoaderTest
 
         $this->assertEquals('/users.{_format}', $route->getPath());
         $this->assertEquals('json|xml|html', $route->getRequirement('_format'));
+        $this->assertEquals('FOSRestBundle:UsersController:getUsers', $route->getDefault('_controller'));
     }
 
     public function testManualRoutesWithoutIncludeFormat()


### PR DESCRIPTION
* sync xsd wit a symfony one
* allow symfony loader to load unrecognized routes (This works for yaml out of the box, but not for xml, because the routes reside in different namespace)

