### PR TITLE
Fixed some minor issues with the new RST doc

### DIFF
--- a/Resources/doc/1-setting_up_the_bundle.rst
+++ b/Resources/doc/1-setting_up_the_bundle.rst
@@ -9,7 +9,7 @@ following command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    $ composer require friendsofsymfony/rest-bundle "~1.4"
+    $ composer require friendsofsymfony/rest-bundle
 
 This command requires you to have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.

--- a/Resources/doc/3-listener-support.rst
+++ b/Resources/doc/3-listener-support.rst
@@ -6,7 +6,7 @@ various events from decoding the request content in the request (body listener),
 determining the correct response format (format listener), reading parameters
 from the request (parameter fetcher listener), to formatting the response either
 with a template engine like twig or to f.e. xml or json using a serializer (view
-response listener)) as well as automatically setting the accepted http methods
+response listener)) as well as automatically setting the accepted HTTP methods
 in the response (accept listener).
 
 With this in mind we now turn to explain each one of them.

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
@@ -322,7 +322,7 @@ Changing pluralization in generated routes
 ------------------------------------------
 
 If you want to change pluralization in generated routes, you can do this by
-replacing "fos_rest.inflector.doctrine" service with your own implementation.
+replacing ``fos_rest.inflector.doctrine`` service with your own implementation.
 Create a new class that implements ``FOS\RestBundle\Util\Inflector\InflectorInterface``.
 
 The example below will remove pluralization by implementing the interface and

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,12 +1,25 @@
 Getting Started With FOSRestBundle
 =====================================
 
+.. toctree::
+    :hidden:
+
+    1-setting_up_the_bundle
+    2-the-view-layer
+    3-listener-support
+    4-exception-controller-support
+    5-automatic-route-generation_single-restful-controller
+    6-automatic-route-generation_multiple-restful-controllers
+    7-manual-route-definition
+    annotations-reference
+    configuration-reference
+
 Installation
 ------------
 
 Installation is a quick (I promise!) one-step process:
 
-1. :doc:`Setting up the bundle <1-setting_up_the_bundle>`_
+1. :doc:`Setting up the bundle <1-setting_up_the_bundle>`
 
 Bundle usage
 ------------
@@ -18,19 +31,19 @@ tool to help you in the job of creating a REST API with Symfony2.
 
 FOSRestBundle provides several tools to assist in building REST applications:
 
-- :doc:`The view layer <2-the-view-layer>`_
-- :doc:`Listener support <3-listener-support>`_
-- :doc:`ExceptionController support <4-exception-controller-support>`_
-- :doc:`Automatic route generation: single RESTful controller <5-automatic-route-generation_single-restful-controller>`_ (for simple resources)
-- :doc:`Automatic route generation: multiple RESTful controllers <6-automatic-route-generation_multiple-restful-controllers>`_ (for resources with child/subresources)
-- :doc:`Manual definition of routes <7-manual-route-definition>`_
+- :doc:`The view layer <2-the-view-layer>`
+- :doc:`Listener support <3-listener-support>`
+- :doc:`ExceptionController support <4-exception-controller-support>`
+- :doc:`Automatic route generation: single RESTful controller <5-automatic-route-generation_single-restful-controller>` (for simple resources)
+- :doc:`Automatic route generation: multiple RESTful controllers <6-automatic-route-generation_multiple-restful-controllers>` (for resources with child/subresources)
+- :doc:`Manual definition of routes <7-manual-route-definition>`
 
 Config reference
 ----------------
 
-- :doc:`Configuration reference <configuration-reference>`_ for a reference on
+- :doc:`Configuration reference <configuration-reference>` for a reference on
   the available configuration options
-- :doc:`Annotations reference <annotations-reference>`_ for a reference on
+- :doc:`Annotations reference <annotations-reference>` for a reference on
   the available configurations through annotations
 
 Example applications


### PR DESCRIPTION
The main change of this PR is that the `index.rst` now includes a hidden TOC. This is mandatory to avoid Sphinx/reStructuredText errors.

In FOSUserBundle doc we added a [real visible TOC](https://github.com/javiereguiluz/FOSUserBundle/commit/70c20da51000ab30df520f5e50e177fa113a791f#diff-fdd764ee72f777e180ace83412a44158R459) because it makes sense in its doc. In FOSRestBundle case it doesn't make sense, so the trick is to include a hidden TOC.