### PR TITLE
Change private access to protected

### DIFF
--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -98,7 +98,7 @@ class RestRouteLoader extends Loader
      *
      * @throws \InvalidArgumentException
      */
-    private function getControllerLocator($controller)
+    protected function getControllerLocator($controller)
     {
         $class  = null;
         $prefix = null;


### PR DESCRIPTION
The class cannot be extended without copying the 'getControllerLocator' method.