### PR TITLE
Allow the user to typehint using `ParamFetcherInterface`

### DIFF
--- a/EventListener/ParamFetcherListener.php
+++ b/EventListener/ParamFetcherListener.php
@@ -77,7 +77,7 @@ class ParamFetcherListener
     /**
      * Determines which attribute the ParamFetcher should be injected as.
      *
-     * @param array $controller The controller action an an "array" callable.
+     * @param array $controller The controller action as an "array" callable.
      *
      * @return string
      */
@@ -109,7 +109,7 @@ class ParamFetcherListener
         if (null === $type) {
             return false;
         }
-
-        return 'FOS\\RestBundle\\Request\\ParamFetcher' === $type->getName();
+        $fetcherInterface = 'FOS\\RestBundle\\Request\\ParamFetcherInterface';
+        return $type->implementsInterface($fetcherInterface);
     }
 }

--- a/Tests/EventListener/ParamFetcherListenerTest.php
+++ b/Tests/EventListener/ParamFetcherListenerTest.php
@@ -138,6 +138,9 @@ class ParamFetcherListenerTest extends \PHPUnit_Framework_TestCase
             // the parameter name is.
             array('byTypeAction', 'pf'),
 
+            // The user can typehint using ParamFetcherInterface, too.
+            array('byInterfaceAction', 'pfi'),
+
             // If there is no controller argument for the ParamFetcher, it
             // should be injected as the default name.
             array('notProvidedAction', 'paramFetcher'),

--- a/Tests/Fixtures/Controller/ParamFetcherController.php
+++ b/Tests/Fixtures/Controller/ParamFetcherController.php
@@ -3,6 +3,7 @@
 namespace FOS\RestBundle\Tests\Fixtures\Controller;
 
 use FOS\RestBundle\Request\ParamFetcher;
+use FOS\RestBundle\Request\ParamFetcherInterface;
 
 /**
  * Fixture for testing whether the ParamFetcher can be injected into
@@ -20,6 +21,13 @@ class ParamFetcherController
      * Make sure the ParamFetcher can be injected according to the typehint.
      */
     public function byTypeAction(ParamFetcher $pf)
+    {}
+
+    /**
+     * Make sure the ParamFetcher can be injected if the typehint is for
+     * the interface.
+     */
+    public function byInterfaceAction(ParamFetcherInterface $pfi)
     {}
 
     /**


### PR DESCRIPTION
This (finally) addresses @stof's comment about [my previous PR](https://github.com/FriendsOfSymfony/FOSRestBundle/pull/745https://github.com/FriendsOfSymfony/FOSRestBundle/pull/745).