### PR TITLE
[bugfix] Forward requirements and defaults in RestYamlCollectionLoader

### DIFF
--- a/Routing/Loader/RestYamlCollectionLoader.php
+++ b/Routing/Loader/RestYamlCollectionLoader.php
@@ -68,13 +68,15 @@ class RestYamlCollectionLoader extends YamlFileLoader
         // process routes and imports
         foreach ($config as $name => $config) {
             if (isset($config['resource'])) {
-                $resource   = $config['resource'];
-                $prefix     = isset($config['prefix'])      ? $config['prefix']         : null;
-                $namePrefix = isset($config['name_prefix']) ? $config['name_prefix']    : null;
-                $parent     = isset($config['parent'])      ? $config['parent']         : null;
-                $type       = isset($config['type'])        ? $config['type']           : null;
-                $options    = isset($config['options'])     ? $config['options']        : null;
-                $currentDir = dirname($path);
+                $resource     = $config['resource'];
+                $prefix       = isset($config['prefix'])       ? $config['prefix']         : null;
+                $namePrefix   = isset($config['name_prefix'])  ? $config['name_prefix']    : null;
+                $parent       = isset($config['parent'])       ? $config['parent']         : null;
+                $type         = isset($config['type'])         ? $config['type']           : null;
+                $requirements = isset($config['requirements']) ? $config['requirements']   : array();
+                $defaults     = isset($config['defaults'])     ? $config['defaults']       : array();
+                $options      = isset($config['options'])      ? $config['options']        : array();
+                $currentDir   = dirname($path);
 
                 $parents = array();
                 if (!empty($parent)) {
@@ -94,9 +96,9 @@ class RestYamlCollectionLoader extends YamlFileLoader
                     $this->collectionParents[$name] = $parents;
                 }
 
-                if ($options) {
-                    $imported->addOptions($options);
-                }
+                $imported->addRequirements($requirements);
+                $imported->addDefaults($defaults);
+                $imported->addOptions($options);
 
                 $imported->addPrefix($prefix);
                 $collection->addCollection($imported);

--- a/Tests/Fixtures/Routes/routes_with_options_requirements_and_defaults.xml
+++ b/Tests/Fixtures/Routes/routes_with_options_requirements_and_defaults.xml
@@ -7,5 +7,7 @@
     <route id="get_users" path="/users">
         <default key="_controller">FOSRestBundle:UsersController:getUsers</default>
         <option key="expose">true</option>
+        <requirement key="slug">[a-z]+</requirement>
+        <default key="slug">home</default>
     </route>
 </routes>

--- a/Tests/Fixtures/Routes/routes_with_options_requirements_and_defaults.yml
+++ b/Tests/Fixtures/Routes/routes_with_options_requirements_and_defaults.yml
@@ -3,3 +3,7 @@ users:
   resource: FOS\RestBundle\Tests\Fixtures\Controller\UsersController
   options:
     expose: true
+  requirements:
+    slug: "[a-z]+"
+  defaults:
+    slug: home

--- a/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
@@ -111,21 +111,14 @@ class RestXmlCollectionLoaderTest extends LoaderTest
         $this->assertEquals('xml', $route->getDefault('_format'));
     }
 
-    public function testForwardOptions()
+    public function testForwardOptionsRequirementsAndDefaults()
     {
-        $collection = $this->loadFromXmlCollectionFixture(
-            'routes_with_options.xml',
-            true,
-            array(
-                'json' => false,
-                'xml'  => false,
-                'html' => true,
-            ),
-            'xml'
-        );
+        $collection = $this->loadFromXmlCollectionFixture('routes_with_options_requirements_and_defaults.xml');
 
         foreach ($collection as $route) {
             $this->assertTrue('true' === $route->getOption('expose'));
+            $this->assertEquals('[a-z]+', $route->getRequirement('slug'));
+            $this->assertEquals('home', $route->getDefault('slug'));
         }
     }
     /**

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -95,12 +95,14 @@ class RestYamlCollectionLoaderTest extends LoaderTest
         $this->assertEquals(count($names), count(array_unique($names)));
     }
 
-    public function testForwardOptions()
+    public function testForwardOptionsRequirementsAndDefaults()
     {
-        $collection = $this->loadFromYamlCollectionFixture('routes_with_options.yml');
+        $collection = $this->loadFromYamlCollectionFixture('routes_with_options_requirements_and_defaults.yml');
 
         foreach ($collection as $route) {
             $this->assertTrue($route->getOption('expose'));
+            $this->assertEquals('[a-z]+', $route->getRequirement('slug'));
+            $this->assertEquals('home', $route->getDefault('slug'));
         }
     }
 


### PR DESCRIPTION
This pull request adds tests that the collection loaders (both XML and YAML) forward route requirements and defaults when importing a controller, like the forwarding of options already works.
This mirrors the behavior of the [symfony `YamlFileLoader`](https://github.com/symfony/symfony/blob/ac389b67145e26f99a59a06bad7346ab5e2ec097/src/Symfony/Component/Routing/Loader/YamlFileLoader.php#L172-173) and [`XmlFileLoader`](https://github.com/symfony/symfony/blob/ac389b67145e26f99a59a06bad7346ab5e2ec097/src/Symfony/Component/Routing/Loader/XmlFileLoader.php#L181-182)

Adding these tests uncovered a flaw in `RestYamlCollectionLoader`, which does not forward these requirements or defaults. The `RestXmlCollectionLoader` does not contain this flaw, because it calls the symfony `XmlFileLoader`.