### PR TITLE
Pass additional variables in template system with lazy-loading

### DIFF
--- a/Resources/doc/2-the-view-layer.rst
+++ b/Resources/doc/2-the-view-layer.rst
@@ -52,6 +52,63 @@ which adds several convenience methods:
         }
     }
 
+If you need to pass more data in template, not for serialization, you can use ``setTemplateData`` method:
+
+.. code-block:: php
+
+    <?php
+
+    use FOS\RestBundle\Controller\FOSRestController;
+
+    class UsersController extends FOSRestController
+    {
+        public function getCategoryAction($categorySlug)
+        {
+            $category = $this->get('category_manager')->getBySlug($categorySlug);
+            $products = ...; // get data, in this case list of products.
+
+            $templateData = array('category' => $category);
+
+            $view = $this->view($products, 200)
+                ->setTemplate("MyBundle:Category:show.html.twig")
+                ->setTemplateVar('products')
+                ->setTemplateData($templateData);
+            ;
+
+            return $this->handleView($view);
+        }
+    }
+
+or it is possible to use lazy-loading:
+
+.. code-block:: php
+
+    <?php
+
+    use FOS\RestBundle\Controller\FOSRestController;
+
+    class UsersController extends FOSRestController
+    {
+        public function getProductsAction($categorySlug)
+        {
+            $products = ...; // get data, in this case list of products.
+            $categoryManager = $this->get('category_manager');
+
+            $view = $this->view($products, 200)
+                ->setTemplate("MyBundle:Category:show.html.twig")
+                ->setTemplateVar('products')
+                ->setTemplateData(function(ViewHandlerInterface $viewHandler, ViewInterface $view) use ($categoryManager, $categorySlug) {
+                    $category = $categoryManager->getBySlug($categorySlug);
+                    return array(
+                        'category' => $category
+                    )
+                });
+            ;
+
+            return $this->handleView($view);
+        }
+    }
+
 To simplify this even more: If you rely on the ``ViewResponseListener`` in
 combination with SensioFrameworkExtraBundle you can even omit the calls to
 ``$this->handleView($view)`` and directly return the view objects. See chapter
@@ -75,6 +132,7 @@ There are several more methods on the ``View`` class, here is a list of all
 the important ones for configuring the view:
 
 * ``setData($data)`` - Set the object graph or list of objects to serialize.
+* ``setTemplateData($templateData)`` - Set the template data array or anonymous function. Closure should return array.
 * ``setHeader($name, $value)`` - Set a header to put on the HTTP response.
 * ``setHeaders(array $headers)`` - Set multiple headers to put on the HTTP response.
 * ``setSerializationContext($context)`` - Set the serialization context to use.

--- a/Tests/View/ViewTest.php
+++ b/Tests/View/ViewTest.php
@@ -91,6 +91,25 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider setTemplateDataDataProvider
+     */
+    public function testSetTemplateData($templateData)
+    {
+        $view = new View();
+        $view->setTemplateData($templateData);
+        $this->assertEquals($templateData, $view->getTemplateData());
+    }
+
+    public static function setTemplateDataDataProvider()
+    {
+        return array(
+            'null as data' => array(null),
+            'array as data' => array(array('foo' => 'bar')),
+            'function as data' => array(function() {})
+        );
+    }
+
     public function testSetEngine()
     {
         $view = new View();

--- a/View/View.php
+++ b/View/View.php
@@ -25,6 +25,7 @@ use JMS\Serializer\SerializationContext;
 class View
 {
     private $data;
+    private $templateData;
     private $template;
     private $templateVar;
     private $engine;
@@ -127,6 +128,21 @@ class View
     public function setData($data)
     {
         $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set template variable
+     *
+     * @param $variableName
+     * @param $data
+     *
+     * @return View
+     */
+    public function setTemplateData($variableName, $data)
+    {
+        $this->templateData[$variableName] = $data;
 
         return $this;
     }
@@ -315,6 +331,16 @@ class View
     public function getData()
     {
         return $this->data;
+    }
+
+    /**
+     * Gets the template data.
+     *
+     * @return mixed|null
+     */
+    public function getTemplateData()
+    {
+        return $this->templateData;
     }
 
     /**

--- a/View/View.php
+++ b/View/View.php
@@ -25,7 +25,7 @@ use JMS\Serializer\SerializationContext;
 class View
 {
     private $data;
-    private $templateData;
+    private $templateData = array();
     private $template;
     private $templateVar;
     private $engine;

--- a/View/View.php
+++ b/View/View.php
@@ -135,14 +135,13 @@ class View
     /**
      * Set template variable
      *
-     * @param $variableName
-     * @param $data
+     * @param  array|callable $data
      *
      * @return View
      */
-    public function setTemplateData($variableName, $data)
+    public function setTemplateData($data = array())
     {
-        $this->templateData[$variableName] = $data;
+        $this->templateData = $data;
 
         return $this;
     }

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -380,29 +380,24 @@ class ViewHandler extends ContainerAware implements ConfigurableViewHandlerInter
     public function prepareTemplateParameters(View $view)
     {
         $data = $view->getData();
-        $templateData = $view->getTemplateData();
-        if ($data instanceof FormInterface) {
-            $preparedData = array_merge(
-                array($view->getTemplateVar() => $data->getData(), 'form' => $data->createView()),
-                $templateData
-            );
-            return $preparedData;
-        }
 
-        if (empty($data) || !is_array($data) || is_numeric((key($data)))) {
-            $preparedData = array_merge(
-                array($view->getTemplateVar() => $data),
-                $templateData
-            );
-            return $preparedData;
+        if ($data instanceof FormInterface) {
+            $data = array($view->getTemplateVar() => $data->getData(), 'form' => $data);
+
+        } elseif (empty($data) || !is_array($data) || is_numeric((key($data)))) {
+            $data = array($view->getTemplateVar() => $data);
         }
 
         if (isset($data['form']) && $data['form'] instanceof FormInterface) {
             $data['form'] = $data['form']->createView();
-            $data = array_merge($data, $templateData);
         }
 
-        return $data;
+        $templateData = $view->getTemplateData();
+        if (is_callable($templateData)) {
+            $templateData = call_user_func($templateData, $this, $view);
+        }
+
+        return array_merge($data, $templateData);
     }
 
     /**

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -380,16 +380,26 @@ class ViewHandler extends ContainerAware implements ConfigurableViewHandlerInter
     public function prepareTemplateParameters(View $view)
     {
         $data = $view->getData();
+        $templateData = $view->getTemplateData();
         if ($data instanceof FormInterface) {
-            return array($view->getTemplateVar() => $data->getData(), 'form' => $data->createView());
+            $preparedData = array_merge(
+                array($view->getTemplateVar() => $data->getData(), 'form' => $data->createView()),
+                $templateData
+            );
+            return $preparedData;
         }
 
         if (empty($data) || !is_array($data) || is_numeric((key($data)))) {
-            return array($view->getTemplateVar() => $data);
+            $preparedData = array_merge(
+                array($view->getTemplateVar() => $data),
+                $templateData
+            );
+            return $preparedData;
         }
 
         if (isset($data['form']) && $data['form'] instanceof FormInterface) {
             $data['form'] = $data['form']->createView();
+            $data = array_merge($data, $templateData);
         }
 
         return $data;


### PR DESCRIPTION
This is an alternative way of adding template variable to views (see also #936).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #936
| License       | MIT
| Doc PR        |

TODO:
- [x] code and testing
- [ ] documentation;
- [x] squash commits.

In short, the `View` now have `setTemplateData` along with `setData`, so that additional data can be passed to templating formats, without affecting other format (e.g. serializer).

`setTemplateData` can either be an associative array, or a callable which return the array.

Example using a simple array:
```php
$viewData = array('category' => $category);
$viewData['other_template_data'] = $otherTemplateData;

return $this->view($products, 200)
    ->setTemplate("AcmeDemoBundle:Category:show.html.twig")
    ->setTemplateVar('products')
    ->setTemplateData($viewData)
;
```

Example using lazy loaded array (preferred):
```php
return $this->view($products, 200)
    ->setTemplate("AcmeDemoBundle:Category:show.html.twig")
    ->setTemplateVar('products')
    ->setTemplateData(function (ViewHandlerInterface $viewHandler, ViewInterface $view) use ($category, $container) {
        // $viewHandler->isFormatTemplating($view->getFormat()) === true
        $viewData = array('category' => $category);
        /* more code using services & co */
        $viewData['other_template_data'] = $otherTemplateData;
        // adding 'products' key not recommended :)
        return $viewData;
    })
;
```

Credit for the initial works goes to @Cript :)