### PR TITLE
Added useful configSerializationContext() in View class

### DIFF
--- a/View/View.php
+++ b/View/View.php
@@ -459,4 +459,22 @@ class View
 
         return $this->serializationContext;
     }
+
+    /**
+     * Useful method for configure serialization context without losing fluent interface.
+     * Usage:
+     *      $view->configSerializationContext(function(SerializationContext $context) {
+     *          $context->setGroups('group1');
+     *      })
+     *
+     * @param callable $configurator
+     *
+     * @return View
+     */
+    public function configSerializationContext(\Closure $configurator)
+    {
+        $configurator($this->getSerializationContext());
+
+        return $this;
+    }
 }


### PR DESCRIPTION
This PR adds useful configurator for serialization context in view class.
Before:
```php
return $this->handleView(
    $this->view($data)->setSerializationContext(
        SerializationContext::create()->setGroups('123')
    )
)
```

After:
```php
return $this->handleView(
    $this->view($data)->configSerializationContext(function(SerializationContext $context) {
        $context->setGroups('123')
    })
)
```