### PR TITLE
Add jms/serializer to required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/framework-bundle":       "~2.3",
         "doctrine/inflector":             "~1.0",
         "willdurand/negotiation":         "~1.2",
-        "willdurand/jsonp-callback-validator": "~1.0"
+        "willdurand/jsonp-callback-validator": "~1.0",
+        "jms/serializer":                 "~0.12"
     },
 
     "require-dev": {


### PR DESCRIPTION
`FOS\RestBundle\Serializer\ExceptionWrapperSerializeHandler`
implements `JMS\Serializer\Handler\SubscribingHandlerInterface`
and throws the following error if `jms/serializer` is not installed:

PHP Fatal error:  Interface 'JMS\\Serializer\\Handler\\SubscribingHandlerInterface' not found in vendor/friendsofsymfony/rest-bundle/FOS/RestBundle/Serializer/ExceptionWrapperSerializeHandler.php on line 13