### PR TITLE
remove unusable handler when JMS serializer is not present

### DIFF
--- a/DependencyInjection/Compiler/ExceptionWrapperHandlerPass.php
+++ b/DependencyInjection/Compiler/ExceptionWrapperHandlerPass.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Checks if the JMS serializer is available to be able to use the ExceptionWrapperSerializeHandler.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class ExceptionWrapperHandlerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('fos_rest.serializer.exception_wrapper_serialize_handler')) {
+            return;
+        }
+
+        if (interface_exists('JMS\Serializer\Handler\SubscribingHandlerInterface')) {
+            return;
+        }
+
+        $container->removeDefinition('fos_rest.serializer.exception_wrapper_serialize_handler');
+    }
+}

--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use FOS\RestBundle\DependencyInjection\Compiler\SerializerConfigurationPass;
 use FOS\RestBundle\DependencyInjection\Compiler\ConfigurationCheckPass;
+use FOS\RestBundle\DependencyInjection\Compiler\ExceptionWrapperHandlerPass;
 use FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass;
 use FOS\RestBundle\DependencyInjection\Compiler\TwigExceptionPass;
 
@@ -33,5 +34,6 @@ class FOSRestBundle extends Bundle
         $container->addCompilerPass(new ConfigurationCheckPass());
         $container->addCompilerPass(new FormatListenerRulesPass());
         $container->addCompilerPass(new TwigExceptionPass());
+        $container->addCompilerPass(new ExceptionWrapperHandlerPass());
     }
 }

--- a/Tests/FOSRestBundleTest.php
+++ b/Tests/FOSRestBundleTest.php
@@ -25,7 +25,7 @@ class FOSRestBundleTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
             ->setMethods(array('addCompilerPass'))
             ->getMock();
-        $container->expects($this->exactly(4))
+        $container->expects($this->exactly(5))
             ->method('addCompilerPass')
             ->with($this->isInstanceOf('\Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface'));
 


### PR DESCRIPTION
This compiler pass removes the `ExceptionWrapperSerializeHandler` if the JMS serializer is not present.