### PR TITLE
Removed useless ini_set in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.6
   - nightly
   - hhvm
+  - hhvm-nightly
 
 branches:
   only:
@@ -23,6 +24,9 @@ matrix:
       env: SYMFONY_VERSION=2.6.*
     - php: 5.5
       env: SYMFONY_VERSION='2.7.*@dev'
+  allow_failures:
+    - php: nightly
+    - php: hhvm-nightly
 
 before_script:
   - composer self-update
@@ -38,4 +42,3 @@ after_script:
 notifications:
   email:
     - friendsofsymfony-dev@googlegroups.com
-

--- a/Tests/Functional/SerializerErrorTest.php
+++ b/Tests/Functional/SerializerErrorTest.php
@@ -71,8 +71,6 @@ XML;
      */
     public function testSerializeInvalidFormJson($testCase, $expectedContent)
     {
-        $this->iniSet('error_log', file_exists('/dev/null') ? '/dev/null' : 'nul');
-
         $client = $this->createClient(array('test_case' => $testCase));
         $client->request('GET', '/serializer-error/invalid-form.json');
 
@@ -92,8 +90,6 @@ XML;
      */
     public function testSerializeInvalidFormXml($testCase, $expectedContent)
     {
-        $this->iniSet('error_log', file_exists('/dev/null') ? '/dev/null' : 'nul');
-
         $client = $this->createClient(array('test_case' => $testCase));
         $client->request('GET', '/serializer-error/invalid-form.xml');
 


### PR DESCRIPTION
These lines were copied by mistake from the above tests.

They are needed to hide the logged exception messages when running the tests but useless here because no exception is thrown when submitting the invalid form.