### PR TITLE
Removed parameter for exception normalizer class

### DIFF
--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -12,7 +12,6 @@
         <parameter key="fos_rest.view_handler.default.class">FOS\RestBundle\View\ViewHandler</parameter>
         <parameter key="fos_rest.view_handler.jsonp.class">FOS\RestBundle\View\JsonpHandler</parameter>
         <parameter key="fos_rest.serializer.exception_wrapper_serialize_handler.class">FOS\RestBundle\Serializer\ExceptionWrapperSerializeHandler</parameter>
-        <parameter key="fos_rest.serializer.exception_wrapper_normalizer.class">FOS\RestBundle\Serializer\ExceptionWrapperNormalizer</parameter>
     </parameters>
 
     <services>
@@ -48,7 +47,7 @@
             <tag name="jms_serializer.subscribing_handler" />
         </service>
 
-        <service id="fos_rest.serializer.exception_wrapper_normalizer" class="%fos_rest.serializer.exception_wrapper_normalizer.class%">
+        <service id="fos_rest.serializer.exception_wrapper_normalizer" class="FOS\RestBundle\Serializer\ExceptionWrapperNormalizer">
             <argument type="service" id="translator" />
             <tag name="serializer.normalizer" />
         </service>

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -570,6 +570,16 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('%fos_rest.view.exception_wrapper_handler%', $exceptionWrapperHandler->getClass());
     }
 
+    public function testSerializerExceptionNormalizer()
+    {
+        $this->extension->load(array('fos_rest' => array('view' => true)), $this->container);
+
+        $this->assertTrue($this->container->has('fos_rest.serializer.exception_wrapper_normalizer'));
+
+        $definition = $this->container->getDefinition('fos_rest.serializer.exception_wrapper_normalizer');
+        $this->assertEquals('FOS\RestBundle\Serializer\ExceptionWrapperNormalizer', $definition->getClass());
+    }
+
     /**
      * @expectedException \LogicException
      */


### PR DESCRIPTION
As per @xabbuh's comment https://github.com/FriendsOfSymfony/FOSRestBundle/pull/975#discussion_r25566085, we should follow Symfony and not include class parameters for new services classes.

This PR removes the class parameter introduced here https://github.com/FriendsOfSymfony/FOSRestBundle/pull/975