### PR TITLE
DataTransformer to transform serialized objects containing an id to it's entity

### DIFF
--- a/Form/Transformer/EntityToIdObjectTransformer.php
+++ b/Form/Transformer/EntityToIdObjectTransformer.php
@@ -34,6 +34,7 @@ class EntityToIdObjectTransformer implements DataTransformerInterface {
 
     /**
      * @param ObjectManager $om
+     * @param String $entityName
      */
     public function __construct(ObjectManager $om, $entityName)
     {

--- a/Form/Transformer/EntityToIdObjectTransformer.php
+++ b/Form/Transformer/EntityToIdObjectTransformer.php
@@ -54,11 +54,11 @@ class EntityToIdObjectTransformer implements DataTransformerInterface {
             return "";
         }
 
-        return $object->getId();
+        return array_values($this->om->getClassMetadata($this->entityName)->getIdentifierValues($object))[0];
     }
 
     /**
-     * Transforms an array including an id to an object.
+     * Transforms an array including an identifier to an object.
      *
      * @param  array $idObject
      *
@@ -68,21 +68,22 @@ class EntityToIdObjectTransformer implements DataTransformerInterface {
      */
     public function reverseTransform($idObject)
     {
-        if (!is_array($idObject) || !array_key_exists("id", $idObject) || !$idObject['id']) {
+        if (!is_array($idObject)) {
             return null;
         }
 
-        $id = $idObject['id'];
+        $identifier = array_values($this->om->getClassMetadata($this->entityName)->getIdentifier())[0];
+        $id = $idObject[$identifier];
 
         $object = $this->om
             ->getRepository($this->entityName)
-            ->findOneBy(array('id' => $id))
+            ->findOneBy(array($identifier => $id))
         ;
 
         if (null === $object) {
             throw new TransformationFailedException(sprintf(
-                'An object with id "%s" does not exist!',
-                $id
+                'An object with identifier key "%s" and value "%d" does not exist!',
+                $identifier, $id
             ));
         }
 

--- a/Form/Transformer/EntityToIdObjectTransformer.php
+++ b/Form/Transformer/EntityToIdObjectTransformer.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Form\Transformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Doctrine\Common\Persistence\ObjectManager;
+
+/**
+ * Class EntityToIdObjectTransformer
+ *
+ * @author Marc Juchli <mail@marcjuch.li>
+ */
+class EntityToIdObjectTransformer implements DataTransformerInterface {
+
+    /**
+     * @var ObjectManager
+     */
+    private $om;
+
+    /**
+     * @var String
+     */
+    private $entityName;
+
+    /**
+     * @param ObjectManager $om
+     */
+    public function __construct(ObjectManager $om, $entityName)
+    {
+        $this->entityName = $entityName;
+        $this->om = $om;
+    }
+
+    /**
+     * Do nothing.
+     *
+     * @param  Object|null $object
+     * @return Object
+     */
+    public function transform($object)
+    {
+        if (null === $object) {
+            return "";
+        }
+
+        return $object->getId();
+    }
+
+    /**
+     * Transforms an array including an id to an object.
+     *
+     * @param  array $idObject
+     *
+     * @return Object|null
+     *
+     * @throws TransformationFailedException if object is not found.
+     */
+    public function reverseTransform($idObject)
+    {
+        if (!$idObject || !$idObject['id']) {
+            return null;
+        }
+
+        $id = $idObject['id'];
+
+        $object = $this->om
+            ->getRepository($this->entityName)
+            ->findOneBy(array('id' => $id))
+        ;
+
+        if (null === $object) {
+            throw new TransformationFailedException(sprintf(
+                'An object with id "%s" does not exist!',
+                $id
+            ));
+        }
+
+        return $object;
+    }
+} 

--- a/Form/Transformer/EntityToIdObjectTransformer.php
+++ b/Form/Transformer/EntityToIdObjectTransformer.php
@@ -45,7 +45,7 @@ class EntityToIdObjectTransformer implements DataTransformerInterface {
      * Do nothing.
      *
      * @param  Object|null $object
-     * @return Object
+     * @return string
      */
     public function transform($object)
     {
@@ -67,7 +67,7 @@ class EntityToIdObjectTransformer implements DataTransformerInterface {
      */
     public function reverseTransform($idObject)
     {
-        if (!$idObject || !$idObject['id']) {
+        if (!is_array($idObject) || !array_key_exists("id", $idObject) || !$idObject['id']) {
             return null;
         }
 
@@ -87,4 +87,4 @@ class EntityToIdObjectTransformer implements DataTransformerInterface {
 
         return $object;
     }
-} 
+}

--- a/Resources/doc/2-the-view-layer.rst
+++ b/Resources/doc/2-the-view-layer.rst
@@ -253,9 +253,9 @@ an example. The serialized Task object will looks as follows:
     
     {"task_form":{"name":"Task1", "person":{"id":1, "name":"Fabien"}}}
 
-In a traditional Symfony2 application the related form builder would look as
-follows, where we simply define the property of the related class and it would
-perfectly assign the person to our task - in this case based on the id:
+In a traditional Symfony2 application we simply define the property of the
+related class and it would perfectly assign the person to our task - in this
+case based on the id:
 
 .. code-block:: php
     
@@ -268,8 +268,9 @@ perfectly assign the person to our task - in this case based on the id:
         ))
 
 Unfortunately, this form builder does not accept our serialized object as it is
-- even though it contains the necessary id. In fact, the object would have to be
-serialized as follows to be accepted by the form validtion process:
+- even though it contains the necessary id. In fact, the object would have to
+contain the id directly assigned to the person field to be be accepted by the
+form validtion process:
 
 .. code-block:: json
     
@@ -280,7 +281,7 @@ person but also do not want to do some client side trick to extract the id
 before updating the data, right? Instead, we rather update the data the same way
 as we received it in our GET request and thus, extend the form builder with a
 data transformer. Furtunately the FOSRestBundle comes with an
-``EntityToIdObjectTransformer``, which can be applied as follows:
+``EntityToIdObjectTransformer``, which can be applied to any form builder:
 
 .. code-block:: php
     

--- a/Resources/doc/2-the-view-layer.rst
+++ b/Resources/doc/2-the-view-layer.rst
@@ -251,14 +251,14 @@ an example. The serialized Task object will looks as follows:
 
 .. code-block:: json
     
-    {"task_form":{name:"Task1", "person":{"id":1, "name":"Fabien"}}}
+    {"task_form":{"name":"Task1", "person":{"id":1, "name":"Fabien"}}}
 
 In a traditional Symfony2 application the related form builder would look as
 follows, where we simply define the property of the related class and it would
 perfectly assign the person to our task - in this case based on the id:
 
 .. code-block:: php
-
+    
     $builder
         ->add('name', 'text')
         ...
@@ -269,11 +269,11 @@ perfectly assign the person to our task - in this case based on the id:
 
 Unfortunately, this form builder does not accept our serialized object as it is
 - even though it contains the necessary id. In fact, the object would have to be
-  serialized as follows to be accepted by the form validtion process:
+serialized as follows to be accepted by the form validtion process:
 
 .. code-block:: json
     
-    {"task_form":{name:"Task1", "person":1}}
+    {"task_form":{"name":"Task1", "person":1}}
 
 Well, this is somewhat useless since we not only want to display the name of the
 person but also do not want to do some client side trick to extract the id
@@ -283,7 +283,7 @@ data transformer. Furtunately the FOSRestBundle comes with an
 ``EntityToIdObjectTransformer``, which can be applied as follows:
 
 .. code-block:: php
-
+    
     $personTransformer = new EntityToIdObjectTransformer($this->om, "AcmeDemoBundle:Person");
     $builder
         ->add('name', 'text')


### PR DESCRIPTION
According to the issue (https://github.com/FriendsOfSymfony/FOSRestBundle/issues/984) I created a transformer that can handle serialized objects containing an id and map it to the entity.

The use of this transfomer within a form type would look as follows:
```php
$transformer = new EntityToIdObjectTransformer($this->om, "AcmeDemoBundle:MyEntity");
$builder->add($builder->create('myfield', 'text')->addModelTransformer($transformer))
```
This way, the selialization process stays untouched.

Not sure if this it's generic enough, otherwise it's documented here at least.