### PR TITLE
[Issue 822] Removed logic error in checking for custom view before serializing groups

### DIFF
--- a/EventListener/ViewResponseListener.php
+++ b/EventListener/ViewResponseListener.php
@@ -86,7 +86,7 @@ class ViewResponseListener extends TemplateListener
             if ($configuration->getStatusCode() && (null === $view->getStatusCode() || Codes::HTTP_OK === $view->getStatusCode())) {
                 $view->setStatusCode($configuration->getStatusCode());
             }
-            if ($configuration->getSerializerGroups() && !$customViewDefined) {
+            if ($configuration->getSerializerGroups() && $customViewDefined) {
                 $context = $view->getSerializationContext() ?: new SerializationContext();
                 $context->setGroups($configuration->getSerializerGroups());
                 $view->setSerializationContext($context);


### PR DESCRIPTION
There was a check for a custom view (`$customViewDefined`) added in `1.3.0` in `ViewResponseListener`. The following was the conditional for whether or not to serialize groups:
```
if ($configuration->getSerializerGroups() && !$customViewDefined)
```  
I simply removed the `!` to fix the logic:
```
if ($configuration->getSerializerGroups() && $customViewDefined)
```