### PR TITLE
fix BodyListener to skip Soap Request parsing

### DIFF
--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -163,9 +163,7 @@ class BodyListener
 
     private function isSoapRequest(Request $request)
     {
-        $soapAction = $request->headers->get('SoapAction');
-
-        $isSoap11 = $soapAction !== '';
+        $isSoap11 = $request->headers->has('SoapAction');
         $isSoap12 = false;
 
         $contentTypeParts = explode(';', $request->headers->get('Content-Type'));

--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -89,7 +89,12 @@ class BodyListener
         $method = $request->getMethod();
         $contentType = $request->headers->get('Content-Type');
         $isFormRequest = $this->isFormRequest($request);
+        $isSoapRequest = $this->isSoapRequest($request);
         $normalizeRequest = $this->normalizeForms && $isFormRequest;
+
+        if ($isSoapRequest) {
+            return;
+        }
 
         if (!$isFormRequest && in_array($method, array('POST', 'PUT', 'PATCH', 'DELETE'))) {
             $format = null === $contentType
@@ -151,6 +156,26 @@ class BodyListener
 
         if (isset($contentTypeParts[0])) {
             return in_array($contentTypeParts[0], array('multipart/form-data', 'application/x-www-form-urlencoded'));
+        }
+
+        return false;
+    }
+
+    private function isSoapRequest(Request $request)
+    {
+        $soapAction = $request->headers->get('SoapAction');
+
+        $isSoap11 = $soapAction !== '';
+        $isSoap12 = false;
+
+        $contentTypeParts = explode(';', $request->headers->get('Content-Type'));
+
+        if (isset($contentTypeParts[0])) {
+            $isSoap12 = in_array($contentTypeParts[0], array('application/soap+xml'));
+        }
+
+        if ($isSoap11 || $isSoap12){
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Hi FOS Team,

I implemented this fix to exclude parsing for SOAP 1.1 and SOAP 1.2 requests. It would be good if you integrate in FOS RestBundle.

Regards,
Asim