### PR TITLE
don't send code coverage reports on PHP 7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_script:
 script: phpunit --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 
 notifications:
   email:


### PR DESCRIPTION
Currently, PHP 7 doesn't come with the Xdebug extension and thus cannot
generate code coverage reports. Hence, sending them to Scrutinizer CI
must be disabled on such builds.