### PR TITLE
due to an issue in LegacyValidator we disallow early 2.5.x releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,13 +41,14 @@
     },
 
     "suggest": {
-        "sensio/framework-extra-bundle":  "Add support for route annotations and the view response listener",
+        "sensio/framework-extra-bundle":  "Add support for route annotations and the view response listener, requires ~3.0",
         "jms/serializer-bundle":          "Add support for advanced serialization capabilities, recommended, requires ~0.12",
-        "symfony/serializer":             "Add support for basic serialization capabilities and xml decoding, requires ~2.2",
-        "symfony/validator":              "Add support for validation capabilities in the ParamFetcher, requires ~2.2"
+        "symfony/serializer":             "Add support for basic serialization capabilities and xml decoding, requires ~2.3",
+        "symfony/validator":              "Add support for validation capabilities in the ParamFetcher, requires ~2.3"
     },
 
     "conflict": {
+        "symfony/framework-bundle": ">=2.5,<2.5.5",
         "jms/serializer": "<0.12",
         "jms/serializer-bundle": "<0.11"
     },


### PR DESCRIPTION
fix for https://github.com/FriendsOfSymfony/FOSRestBundle/issues/973