### PR TITLE
Added new feature for nice error messages to ParamFetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 vendor
 composer.lock
 composer.phar
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ phpunit.xml
 vendor
 composer.lock
 composer.phar
-.idea/

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -173,7 +173,7 @@ class ParamFetcher implements ParamFetcherInterface
 
         return $this->cleanParamWithRequirements($config, $param, $strict);
     }
-    
+
     /**
      * @param Param  $config
      * @param string $param
@@ -223,7 +223,7 @@ class ParamFetcher implements ParamFetcherInterface
         }else{
             $constraint = new Regex(array(
                 'pattern' => '#^'.$config->requirements["rule"].'$#xsu',
-                'message' => $config->requirements["message"]
+                'message' => $config->requirements["error_message"]
             ));
         }
 
@@ -239,8 +239,8 @@ class ParamFetcher implements ParamFetcherInterface
 
         if (0 !== count($errors)) {
             if ($strict) {
-                if(isset($config->requirements["message"])){
-                    $errorMessage = $config->requirements["message"];
+                if(isset($config->requirements["error_message"])){
+                    $errorMessage = $config->requirements["error_message"];
                 }else{
                     $errorMessage = $this->violationFormatter->formatList($config, $errors);
                 }

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -204,7 +204,6 @@ class ParamFetcher implements ParamFetcherInterface
         $constraint = $config->requirements;
 
         if (is_scalar($constraint)) {
-
             if (is_array($param)) {
                 if ($strict) {
                     throw new BadRequestHttpException(
@@ -223,7 +222,7 @@ class ParamFetcher implements ParamFetcherInterface
                     $config->requirements
                 ),
             ));
-        } elseif(is_array($config->requirements) && isset($config->requirements["rule"]) && $config->requirements["error_message"]) {
+        } elseif (is_array($config->requirements) && isset($config->requirements["rule"]) && $config->requirements["error_message"]) {
             $constraint = new Regex(array(
                 'pattern' => '#^'.$config->requirements["rule"].'$#xsu',
                 'message' => $config->requirements["error_message"]

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -195,6 +195,8 @@ class ParamFetcher implements ParamFetcherInterface
             );
         }
 
+        $this->checkNotIncompatibleParams($config);
+
         if (null === $config->requirements || ($param === $default && null !== $default)) {
             return $param;
         }

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -223,7 +223,7 @@ class ParamFetcher implements ParamFetcherInterface
                     $config->requirements
                 ),
             ));
-        } else {
+        } elseif(is_array($config->requirements) && isset($config->requirements["rule"]) && $config->requirements["error_message"]) {
             $constraint = new Regex(array(
                 'pattern' => '#^'.$config->requirements["rule"].'$#xsu',
                 'message' => $config->requirements["error_message"]
@@ -242,7 +242,7 @@ class ParamFetcher implements ParamFetcherInterface
 
         if (0 !== count($errors)) {
             if ($strict) {
-                if (isset($config->requirements["error_message"])) {
+                if (is_array($config->requirements) && isset($config->requirements["error_message"])) {
                     $errorMessage = $config->requirements["error_message"];
                 } else {
                     $errorMessage = $this->violationFormatter->formatList($config, $errors);

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -174,16 +174,7 @@ class ParamFetcher implements ParamFetcherInterface
         return $this->cleanParamWithRequirements($config, $param, $strict);
     }
 
-    /**
-     * @param Param  $config
-     * @param string $param
-     * @param bool   $strict
-     *
-     * @return string
-     *
-     * @throws BadRequestHttpException
-     * @throws \RuntimeException
-     */
+    
     /**
      * @param Param  $config
      * @param string $param

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -203,16 +203,17 @@ class ParamFetcher implements ParamFetcherInterface
 
         $constraint = $config->requirements;
 
-        if (is_array($param)) {
-            if ($strict) {
-                throw new BadRequestHttpException(
-                    sprintf("%s parameter is an array", $paramType)
-                );
-            }
-            return $default;
-        }
-
         if (is_scalar($constraint)) {
+
+            if (is_array($param)) {
+                if ($strict) {
+                    throw new BadRequestHttpException(
+                        sprintf("%s parameter is an array", $paramType)
+                    );
+                }
+                return $default;
+            }
+
             $constraint = new Regex(array(
                 'pattern' => '#^'.$config->requirements.'$#xsu',
                 'message' => sprintf(

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -212,7 +212,6 @@ class ParamFetcher implements ParamFetcherInterface
                 }
                 return $default;
             }
-
             $constraint = new Regex(array(
                 'pattern' => '#^'.$config->requirements.'$#xsu',
                 'message' => sprintf(

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -222,7 +222,7 @@ class ParamFetcher implements ParamFetcherInterface
                     $config->requirements
                 ),
             ));
-        }else{
+        } else {
             $constraint = new Regex(array(
                 'pattern' => '#^'.$config->requirements["rule"].'$#xsu',
                 'message' => $config->requirements["error_message"]
@@ -241,9 +241,9 @@ class ParamFetcher implements ParamFetcherInterface
 
         if (0 !== count($errors)) {
             if ($strict) {
-                if(isset($config->requirements["error_message"])){
+                if (isset($config->requirements["error_message"])) {
                     $errorMessage = $config->requirements["error_message"];
-                }else{
+                } else {
                     $errorMessage = $this->violationFormatter->formatList($config, $errors);
                 }
                 throw new BadRequestHttpException($errorMessage);

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -173,7 +173,6 @@ class ParamFetcher implements ParamFetcherInterface
 
         return $this->cleanParamWithRequirements($config, $param, $strict);
     }
-
     
     /**
      * @param Param  $config

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -222,7 +222,7 @@ class ParamFetcher implements ParamFetcherInterface
                     $config->requirements
                 ),
             ));
-        } elseif (is_array($config->requirements) && isset($config->requirements["rule"]) && $config->requirements["error_message"]) {
+        } elseif (is_array($constraint) && isset($constraint["rule"]) && $constraint["error_message"]) {
             $constraint = new Regex(array(
                 'pattern' => '#^'.$config->requirements["rule"].'$#xsu',
                 'message' => $config->requirements["error_message"]


### PR DESCRIPTION
fix for https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1013

Example Usage: 
```php
@QueryParam(name="parent_id", requirements={"rule" = "\d+", "error_message" = "parent_id must be an integer"}, strict=true, nullable=true, description="Parent Id")
```

Error Message:
```json
{
    "code": 400,
    "message": "parent_id must be an integer"
}
```