### PR TITLE
Normalized `rules` array

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -201,6 +201,18 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('rule', 'rules')
                     ->addDefaultsIfNotSet()
                     ->canBeUnset()
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) {
+                            // check if we got an assoc array in rules
+                            return isset($v['rules'])
+                                && is_array($v['rules'])
+                                && array_keys($v['rules']) !== range(0, count($v['rules']) - 1);
+                        })
+                        ->then(function($v) {
+                            $v['rules'] = array($v['rules']);
+                            return $v;
+                        })
+                    ->end()                    
                     ->children()
                         ->arrayNode('rules')
                             ->cannotBeOverwritten()


### PR DESCRIPTION
If you try to use the example from http://symfony.com/doc/master/bundles/FOSRestBundle/configuration-reference.html to customize your config (eg just c&p the 'format_listener' part to your local `config.yml`) you'll end up here:

`Invalid type for path "fos_rest.format_listener.rules.stop". Expected array, but got boolean`

This PR will make the example work again.