### PR TITLE
Setting default format in RestRouteCollection.php only if not set already

### DIFF
--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -62,7 +62,10 @@ class RestRouteCollection extends RouteCollection
     public function setDefaultFormat($format)
     {
         foreach (parent::all() as $route) {
-            $route->setDefault('_format', $format);
+            // Set default format only if not set already (could be defined in annotation)
+            if(!$route->getDefault('_format')) {
+                $route->setDefault('_format', $format);
+            }
         }
     }
 

--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -63,7 +63,7 @@ class RestRouteCollection extends RouteCollection
     {
         foreach (parent::all() as $route) {
             // Set default format only if not set already (could be defined in annotation)
-            if(!$route->getDefault('_format')) {
+            if (!$route->getDefault('_format')) {
                 $route->setDefault('_format', $format);
             }
         }


### PR DESCRIPTION
Scenario:

`config.yml`:

    fos_rest:
        format_listener: true
        routing_loader:
            default_format: json

`ReportController.php` (simplified)

    /**
     * @Rest\Get("/report/export", defaults = {"_format": "xlsx"}, requirements = {"_format": "xlsx|csv|json|xml"})
     */
    public function exportAction(Report $report, HttpFoundation\Request $request) {
        return $this->get('report.exporter')->getReponse($report, $request->getRequestFormat('xlsx'));
    }

Annotation sets default format to `xlsx`, but `FOS\RestBundle\Routing\Loader\RestRouteLoader::load()` after reading all routes invokes `FOS\RestBundle\Routing\RestRouteCollection::setDefaultFormat()` which overrides it with global `default_format` from bundle config. When `/report/export` is accessed without format, global `default_format` is used even if there is custom default value in annotation.

This PR fixes it - default format is set only if it wasn't set already via annotation.