### PR TITLE
Fix Typo in custom service listener example

### DIFF
--- a/Resources/doc/3-listener-support.rst
+++ b/Resources/doc/3-listener-support.rst
@@ -38,7 +38,7 @@ appropriate event:
         body_listener:
             service: my_body_listener
 
-    my.body_listener:
+    my_body_listener:
         class: Acme\BodyListener
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 10 }


### PR DESCRIPTION
The `fos_rest` config was referring `my_body_listener`, but the service was declared as `my.body_listener`.