### PR TITLE
Fixed error when name prefix ignored in yaml. Issue #1029

### DIFF
--- a/Routing/Loader/RestYamlCollectionLoader.php
+++ b/Routing/Loader/RestYamlCollectionLoader.php
@@ -92,6 +92,7 @@ class RestYamlCollectionLoader extends YamlFileLoader
                 if ($imported instanceof RestRouteCollection) {
                     $parents[]  = ($prefix ? $prefix.'/' : '').$imported->getSingularName();
                     $prefix     = null;
+                    $namePrefix = null;
 
                     $this->collectionParents[$name] = $parents;
                 }
@@ -101,6 +102,10 @@ class RestYamlCollectionLoader extends YamlFileLoader
                 $imported->addOptions($options);
 
                 $imported->addPrefix($prefix);
+
+                // Add name prefix from parent config files
+                $imported = $this->addParentNamePrefix($imported, $namePrefix);
+
                 $collection->addCollection($imported);
             } elseif (isset($config['pattern']) || isset($config['path'])) {
                 // the YamlFileLoader of the Routing component only checks for
@@ -143,5 +148,30 @@ class RestYamlCollectionLoader extends YamlFileLoader
         return is_string($resource) &&
             'yml' === pathinfo($resource, PATHINFO_EXTENSION) &&
             'rest' === $type;
+    }
+
+    /**
+     * Adds a name prefix to the route name of all collection routes.
+     *
+     * @param RouteCollection $collection    Route collection
+     * @param array $namePrefix              NamePrefix to add in each route name of the route collection
+     *
+     * @return RouteCollection
+     */
+    public function addParentNamePrefix(RouteCollection $collection, $namePrefix)
+    {
+        if (!isset($namePrefix) || ($namePrefix = trim($namePrefix)) === "") {
+            return $collection;
+        }
+
+        $iterator = $collection->getIterator();
+
+        foreach($iterator as $key1 => $route1)
+        {
+            $collection->add($namePrefix.$key1, $route1);
+            $collection->remove($key1);
+        }
+
+        return $collection;
     }
 }

--- a/Tests/Fixtures/Etalon/base_named_prefixed_reports_collection.yml
+++ b/Tests/Fixtures/Etalon/base_named_prefixed_reports_collection.yml
@@ -1,0 +1,29 @@
+base_api_get_billing_spendings:
+  path:      /base/billing/spendings.{_format}
+  controller:   ::getBillingSpendingsAction
+  method: GET
+
+base_api_get_billing_spendings_by_campaign:
+  path:      /base/billing/spendings/{campaign}.{_format}
+  controller:   ::getBillingSpendingsByCampaignAction
+  method: GET
+
+base_api_get_billing_payments:
+  path:      /base/billing/payments.{_format}
+  controller:   ::getBillingPaymentsAction
+  method: GET
+
+base_api_get_billing_earnings:
+  path:      /base/billing/earnings.{_format}
+  controller:   ::getBillingEarningsAction
+  method: GET
+
+base_api_get_billing_earnings_by_platform:
+  path:      /base/billing/earnings/{platform}.{_format}
+  controller:   ::getBillingEarningsByPlatformAction
+  method: GET
+
+base_api_get_billing_withdrawals:
+  path:      /base/billing/withdrawals.{_format}
+  controller:   ::getBillingWithdrawalsAction
+  method: GET

--- a/Tests/Fixtures/Routes/base_named_prefixed_reports_collection.yml
+++ b/Tests/Fixtures/Routes/base_named_prefixed_reports_collection.yml
@@ -1,0 +1,5 @@
+report:
+    type: rest
+    resource: named_prefixed_reports_collection.yml
+    prefix:   /base
+    name_prefix: base_

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -225,4 +225,26 @@ class RestYamlCollectionLoaderTest extends LoaderTest
 
         return $collectionLoader->load($fixtureName, 'rest');
     }
+
+    /**
+     * Test that YAML collection with named prefixes gets parsed correctly with inheritance.
+     */
+    public function testNamedPrefixedBaseReportsFixture()
+    {
+        $collection     = $this->loadFromYamlCollectionFixture('base_named_prefixed_reports_collection.yml');
+        $etalonRoutes   = $this->loadEtalonRoutesInfo('base_named_prefixed_reports_collection.yml');
+
+        foreach ($etalonRoutes as $name => $params) {
+            $route = $collection->get($name);
+            $methods = $route->getMethods();
+
+            $this->assertNotNull($route, $name);
+            $this->assertEquals($params['path'], $route->getPath(), $name);
+            $this->assertEquals($params['method'], $methods[0], $name);
+            $this->assertContains($params['controller'], $route->getDefault('_controller'), $name);
+        }
+
+        $name = 'api_get_billing_payments';
+        $this->assertArrayNotHasKey($name, $etalonRoutes);
+    }
 }


### PR DESCRIPTION
Fixed error when name prefix ignored in yaml. Issue #1029.

I check the example from Issue #1029, and I think the problem is inheritance class don't save parent name_prefix. I have the same problem, and my solution in this pull request.
With an app/console router:debug, we have:
```
 get_first                         GET      ANY    ANY  /api/v1/first
 get_second                        GET      ANY    ANY  /api/v1/second
```
If we save parent name prefix the result will be:
```
 api_v1_get_first                         GET      ANY    ANY  /api/v1/first
 api_v1_get_second                        GET      ANY    ANY  /api/v1/second
```