### PR TITLE
Fix old use of mime_types configuration

### DIFF
--- a/EventListener/MimeTypeListener.php
+++ b/EventListener/MimeTypeListener.php
@@ -48,7 +48,7 @@ class MimeTypeListener
         $request = $event->getRequest();
 
         if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
-            foreach ($this->mimeTypes as $format => $mimeType) {
+            foreach ($this->mimeTypes['formats'] as $format => $mimeType) {
                 $request->setFormat($format, $mimeType);
                 $this->formatNegotiator->registerFormat($format, (array) $mimeType, true);
             }

--- a/Tests/EventListener/MimeTypeListenerTest.php
+++ b/Tests/EventListener/MimeTypeListenerTest.php
@@ -31,7 +31,7 @@ class MimeTypeListenerTest extends \PHPUnit_Framework_TestCase
             ->with('jsonp', array('application/javascript+jsonp'), true)
             ->will($this->returnValue(null));
 
-        $listener = new MimeTypeListener(array('jsonp' => array('application/javascript+jsonp')), $formatNegotiator);
+        $listener = new MimeTypeListener(array('enabled' => true, 'formats' => array('jsonp' => array('application/javascript+jsonp'))), $formatNegotiator);
 
         $request = new Request();
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')


### PR DESCRIPTION
Wrong format. "enabled" value format due to new structure of configuration.