### PR TITLE
Allow to use Symfony's serializer even with JMS Serializer enabled

### DIFF
--- a/DependencyInjection/Compiler/SerializerConfigurationPass.php
+++ b/DependencyInjection/Compiler/SerializerConfigurationPass.php
@@ -28,14 +28,20 @@ class SerializerConfigurationPass implements CompilerPassInterface
             return;
         }
 
+        if (!$container->has('serializer') && !$container->has('jms_serializer.serializer')) {
+            throw new \InvalidArgumentException('Neither a service called "jms_serializer.serializer" nor "serializer" is available and no serializer is explicitly configured. You must either enable the JMSSerializerBundle, enable the FrameworkBundle serializer or configure a custom serializer.');
+        }
+
         if ($container->has('jms_serializer.serializer')) {
             $container->setAlias('fos_rest.serializer', 'jms_serializer.serializer');
-            $container->removeDefinition('fos_rest.serializer.exception_wrapper_normalizer');
-        } elseif ($container->has('serializer')) {
-            $container->setAlias('fos_rest.serializer', 'serializer');
-            $container->removeDefinition('fos_rest.serializer.exception_wrapper_serialize_handler');
         } else {
-            throw new \InvalidArgumentException('Neither a service called "jms_serializer.serializer" nor "serializer" is available and no serializer is explicitly configured. You must either enable the JMSSerializerBundle, enable the FrameworkBundle serializer or configure a custom serializer.');
+            $container->removeDefinition('fos_rest.serializer.exception_wrapper_serialize_handler');
+        }
+
+        if ($container->has('serializer')) {
+            $container->setAlias('fos_rest.serializer', 'serializer');
+        } else {
+            $container->removeDefinition('fos_rest.serializer.exception_wrapper_normalizer');
         }
     }
 }

--- a/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
@@ -65,16 +65,15 @@ class SerializerConfigurationPassTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValueMap(array(
                 array('fos_rest.serializer', false),
                 array('jms_serializer.serializer', true),
-                array('serializer', true))));
+                array('serializer', true)
+            )));
 
-
-        $container->expects($this->once())
+        $container->expects($this->exactly(2))
             ->method('setAlias')
-            ->with($this->equalTo('fos_rest.serializer'), $this->equalTo('jms_serializer.serializer'));
-
-        $container->expects($this->once())
-            ->method('removeDefinition')
-            ->with('fos_rest.serializer.exception_wrapper_normalizer');
+            ->withConsecutive(
+                array($this->equalTo('fos_rest.serializer'), $this->equalTo('jms_serializer.serializer')),
+                array($this->equalTo('fos_rest.serializer'), $this->equalTo('serializer'))
+            );
 
         $compiler = new SerializerConfigurationPass();
         $compiler->process($container);


### PR DESCRIPTION
Right now, if we're using the Symfony serializer and there's the JMS's one registered too for any reason, we can't due to a serializer normalizer not removed:

```
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                                               
  The service "serializer" has a dependency on a non-existent service "fos_rest.serializer.exception_wrapper_normalizer".  
```

This PR fixes the problem.