### PR TITLE
Allow use of placeholders as requirements in Query/RequestParam

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -344,7 +344,7 @@ class ParamFetcher extends ContainerAware implements ParamFetcherInterface
     private function resolve($value)
     {
         if (is_array($value)) {
-            foreach($value as $key => $val) {
+            foreach ($value as $key => $val) {
                 $value[$key] = $this->resolve($val);
             }
 

--- a/Resources/config/request.xml
+++ b/Resources/config/request.xml
@@ -11,6 +11,9 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="fos_rest.violation_formatter"/>
             <argument type="service" id="validator" on-invalid="null"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
         </service>
 
         <service id="fos_rest.request.param_fetcher.reader" class="FOS\RestBundle\Request\ParamReader">

--- a/Resources/doc/param_fetcher_listener.rst
+++ b/Resources/doc/param_fetcher_listener.rst
@@ -140,3 +140,33 @@ request attributes
 
             return array('articles' => $articles, 'page' => $page);
         }
+
+Container parameters can be used in requirements and default field.
+
+.. note::
+
+    The percent sign (%) in ``requirements`` and ``default`` field, must be
+    escaped with another percent sign
+
+
+.. code-block:: php
+
+    <?php
+
+    class FooController extends Controller
+    {
+        /**
+         * Use the "locale" parameter as the default value
+         * @QueryParam(name="language", default="%locale%")
+         * 
+         * The "baz" container parameter is used here as requirements
+         * Can be used for complex or auto-generated regex
+         * @QueryParam(name="foo", requirements="%baz%")
+         *
+         * The percent sign must be escaped
+         * @QueryParam(name="val", default="75 %%")
+         */
+        public function getArticlesAction(ParamFetcher $paramFetcher)
+        {
+            ...
+        }


### PR DESCRIPTION
See #1039 
Note: contains a BC break as the container has been injected into the ParamFetcher as a required argument