### PR TITLE
Add support of non-pluralized resource names

### DIFF
--- a/Controller/Annotations/RouteResource.php
+++ b/Controller/Annotations/RouteResource.php
@@ -13,11 +13,18 @@ namespace FOS\RestBundle\Controller\Annotations;
 
 /**
  * RouteResource annotation class.
+ *
  * @Annotation
  * @Target("CLASS")
  */
 class RouteResource
 {
-    /** @var string required */
+    /**
+     * @var string required
+     */
     public $resource;
+    /**
+     * @var bool
+     */
+    public $pluralize = true;
 }

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
@@ -160,7 +160,7 @@ following would work as well:
         // ...
     }
 
-Finally, it's possible to override the resource name derived from the Controller
+It's also possible to override the resource name derived from the Controller
 name via the ``@RouteResource`` annotation:
 
 
@@ -189,6 +189,38 @@ name via the ``@RouteResource`` annotation:
         // ...
         public function getCommentsAction($slug)
         {} // "get_user_comments"    [GET] /users/{slug}/comments
+
+        // ...
+    }
+
+Finally, it's possible to have a singular resource name thanks to the ``@RouteResource`` annotation:
+
+
+.. code-block:: php
+
+    <?php
+
+    use FOS\RestBundle\Controller\Annotations\RouteResource;
+
+    /**
+     * @RouteResource("User", pluralize=false)
+     */
+    class FooController
+    {
+        // ...
+
+        public function cgetAction()
+        {} // "cget_user"     [GET] /user
+
+        public function newAction()
+        {} // "new_user"     [GET] /user/new
+
+        public function getAction($slug)
+        {} // "get_user"      [GET] /user/{slug}
+
+        // ...
+        public function getCommentAction($slug)
+        {} // "cget_user_comment"    [GET] /user/{slug}/comment
 
         // ...
     }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -34,6 +34,7 @@ class RestActionReader
     private $includeFormat;
     private $routePrefix;
     private $namePrefix;
+    private $pluralize;
     private $parents = array();
     private $availableHTTPMethods = array('get', 'post', 'put', 'patch', 'delete', 'link', 'unlink', 'head', 'options');
     private $availableConventionalActions = array('new', 'edit', 'remove');
@@ -94,6 +95,26 @@ class RestActionReader
     public function getNamePrefix()
     {
         return $this->namePrefix;
+    }
+
+    /**
+     * Sets pluralize.
+     *
+     * @param bool|null $pluralize Specify if resource name must be pluralized
+     */
+    public function setPluralize($pluralize)
+    {
+        $this->pluralize = $pluralize;
+    }
+
+    /**
+     * Returns pluralize.
+     *
+     * @return bool|null
+     */
+    public function getPluralize()
+    {
+        return $this->pluralize;
     }
 
     /**
@@ -311,9 +332,9 @@ class RestActionReader
         }
 
         if ($isCollection && !empty($resource)) {
-            $resourcePluralized = $this->inflector->pluralize(end($resource));
+            $resourcePluralized = $this->generateResourceName(end($resource));
             $isInflectable = ($resourcePluralized != $resource[count($resource) - 1]);
-            $resource[count($resource)-1] = $resourcePluralized;
+            $resource[count($resource) - 1] = $resourcePluralized;
         }
 
         $resources = array_merge($resource, $resources);
@@ -366,6 +387,22 @@ class RestActionReader
     }
 
     /**
+     * Generates final resource name.
+     *
+     * @param string|bool $resource
+     *
+     * @return string
+     */
+    private function generateResourceName($resource)
+    {
+        if (false === $this->pluralize) {
+            return $resource;
+        }
+
+        return $this->inflector->pluralize($resource);
+    }
+
+    /**
      * Generates route name from resources list.
      *
      * @param string[] $resources
@@ -408,7 +445,7 @@ class RestActionReader
             if (isset($arguments[$i])) {
                 if (null !== $resource) {
                     $urlParts[] =
-                        strtolower($this->inflector->pluralize($resource))
+                        strtolower($this->generateResourceName($resource))
                         .'/{'.$arguments[$i]->getName().'}';
                 } else {
                     $urlParts[] = '{'.$arguments[$i]->getName().'}';
@@ -418,7 +455,7 @@ class RestActionReader
                     || 'new' === $httpMethod
                     || 'post' === $httpMethod
                 ) {
-                    $urlParts[] = $this->inflector->pluralize(strtolower($resource));
+                    $urlParts[] = $this->generateResourceName(strtolower($resource));
                 } else {
                     $urlParts[] = strtolower($resource);
                 }
@@ -522,7 +559,6 @@ class RestActionReader
         $annotationClass = "FOS\\RestBundle\\Controller\\Annotations\\$annotationName";
 
         if ($annotations_new = $this->annotationReader->getMethodAnnotations($reflectionMethod)) {
-
             foreach ($annotations_new as $annotation) {
                 if ($annotation instanceof $annotationClass) {
                     $annotations[] = $annotation;

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -75,6 +75,7 @@ class RestControllerReader
         // read route-resource annotation
         if ($annotation = $this->readClassAnnotation($reflectionClass, 'RouteResource')) {
             $resource = explode('_', $annotation->resource);
+            $this->actionReader->setPluralize($annotation->pluralize);
         } elseif ($reflectionClass->implementsInterface('FOS\RestBundle\Routing\ClassResourceInterface')) {
             $resource  = preg_split(
                 '/([A-Z][^A-Z]*)Controller/', $reflectionClass->getShortName(), -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
@@ -96,6 +97,7 @@ class RestControllerReader
 
         $this->actionReader->setRoutePrefix(null);
         $this->actionReader->setNamePrefix(null);
+        $this->actionReader->setPluralize(null);
         $this->actionReader->setParents(array());
 
         return $collection;

--- a/Tests/Fixtures/Controller/AnnotatedNonPluralizedArticleController.php
+++ b/Tests/Fixtures/Controller/AnnotatedNonPluralizedArticleController.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Controller\FOSRestController;
+use FOS\RestBundle\Controller\Annotations as Rest;
+
+/**
+ *  @Rest\RouteResource("Article", pluralize=false)
+ */
+class AnnotatedNonPluralizedArticleController extends FosRestController
+{
+    public function cgetAction()
+    {} // [GET] /article
+
+    public function getAction($slug)
+    {} // [GET] /article/{slug}
+
+    public function cgetCommentAction($slug)
+    {} // [GET] /article/{slug}/comment
+
+    public function getCommentAction($slug, $comment)
+    {} // [GET] /article/{slug}/comment/{slug}
+}

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -120,6 +120,19 @@ class RestRouteLoaderTest extends LoaderTest
         }
     }
 
+    public function testDisabledPluralization()
+    {
+        $collection = $this->loadFromControllerFixture('AnnotatedNonPluralizedArticleController');
+
+        $this->assertEquals('/article.{_format}', $collection->get('cget_article')->getPath());
+
+        $this->assertEquals('/article/{slug}.{_format}', $collection->get('get_article')->getPath());
+
+        $this->assertEquals('/article/{slug}/comment.{_format}', $collection->get('cget_article_comment')->getPath());
+
+        $this->assertEquals('/article/{slug}/comment/{comment}.{_format}', $collection->get('get_article_comment')->getPath());
+    }
+
     /**
      * Test that annotated UsersController RESTful class gets parsed correctly with condition option (expression-language).
      */


### PR DESCRIPTION
I decided to create a new PR about #294 because #531 seems to be abandoned.

This PR add the support of non-pluralized resource names as described in #294.

You can use it like that:
```php
<?php

/**
 *  @Rest\RouteResource(resource="Article", pluralize=false)
 */
class FooController extends FosRestController
{

    public function cgetAction()
    {} // [GET] /article

    public function getAction($slug)
    {} // [GET] /article/{slug}

    public function cgetCommentAction($slug)
    {} // [GET] /article/{slug}/comment
    
}
```