### PR TITLE
syntax error in documentation

### DIFF
--- a/Resources/doc/param_fetcher_listener.rst
+++ b/Resources/doc/param_fetcher_listener.rst
@@ -40,7 +40,7 @@ configured for the matched controller so that the user does not need to do this 
          *
          * Will check if a blank value, e.g an empty string is passed and if so, it will set to the default of asc.
          *
-         * @QueryParam(name="sort", requirements="(asc|desc)+", allowBlank=false, default="asc" description="Sort direction")
+         * @QueryParam(name="sort", requirements="(asc|desc)+", allowBlank=false, default="asc", description="Sort direction")
          *
          * Will look for a firstname request parameters, ie. firstname=foo in POST data.
          * If not passed it will error out when read out of the ParamFetcher since RequestParam defaults to strict=true


### PR DESCRIPTION
you forgot a comma in the documentation.