### PR TITLE
Surrounded requirements regex by parenthesis

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -213,7 +213,7 @@ class ParamFetcher implements ParamFetcherInterface
                 return $default;
             }
             $constraint = new Regex(array(
-                'pattern' => '#^'.$config->requirements.'$#xsu',
+                'pattern' => '#^(?:'.$config->requirements.')$#xsu',
                 'message' => sprintf(
                     "%s parameter value '%s', does not match requirements '%s'",
                     $paramType,
@@ -223,7 +223,7 @@ class ParamFetcher implements ParamFetcherInterface
             ));
         } elseif (is_array($constraint) && isset($constraint["rule"]) && $constraint["error_message"]) {
             $constraint = new Regex(array(
-                'pattern' => '#^'.$config->requirements["rule"].'$#xsu',
+                'pattern' => '#^(?:'.$config->requirements["rule"].')$#xsu',
                 'message' => $config->requirements["error_message"]
             ));
         }


### PR DESCRIPTION
Currently, the regex used for requirements is automatically surrounded by characters `^` and `$` (see [`ParamFetcher.php` code](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Request/ParamFetcher.php#L216)). It seems legit and very helpful, since wen can easily write `A+` to match at least one `A`, or even `A` if we expect only one occurence.

Unfortunately, this helper may introduce a misunderstanding of what really happens in the case where we want to match an `A` **or** a `B` character. Our first guess will be `A|B`, but is is **wrong**. This requirement will produce the regex `^A|B$`, matching all strings starting by `A` **or** finishing by `B`.

This behavior is absolutely normal, this is not a bug, but IMHO it is counter-intuitive (then, dangerous). In the previous example, I should use parenthesis to reach my goal: `^(A|B)$`. So here my proposal, to add by default these surrounding parenthesis, in order to make requirement string `A|B` to match exactly one `A`, or exactly one `B`.

According to my tests, even if you already used some `^` or `$` in your regex, this should be retro-compatible. Nevertheless, this is a breaking change as soon as you were really expecting the string `A|B` to match `Abc` (or `);TRUNCATE Users;#B`  :wink: )

I updated corresponding tests in this PR, I am looking forward for your feedback, and thanks for all the work done for this library :+1: 