### PR TITLE
Remove a deprecated call to ContainerInterface::get('request')

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -104,7 +104,8 @@ class ExceptionController extends ContainerAware
      */
     protected function getAndCleanOutputBuffering()
     {
-        $startObLevel = $this->container->get('request')->headers->get('X-Php-Ob-Level', -1);
+        $request = $this->container->get('request_stack')->getCurrentRequest();
+        $startObLevel = $request->headers->get('X-Php-Ob-Level', -1);
 
         // ob_get_level() never returns 0 on some Windows configurations, so if
         // the level is the same two times in a row, the loop should be stopped.


### PR DESCRIPTION
This PR fixes the last deprecated call to ``ContainerInterface::get('request')``.

It fixes #824 at the same time.