### PR TITLE
StyleCI / PHP-CS-Fixer bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 vendor
 composer.lock
 composer.phar
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,21 @@
+<?php
+
+require_once './vendor/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
+
+$header = <<<EOF
+This file is part of the FOSRestBundle package.
+
+(c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOF;
+
+HeaderCommentFixer::setHeader($header);
+
+return ConfigBridge::create()
+    ->setUsingCache(true)
+;

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/expression-language":    "~2.7",
         "symfony/css-selector":           "^2.7",
         "phpoption/phpoption":            "^1.1",
-        "jms/serializer-bundle":          "^1.0"
+        "jms/serializer-bundle":          "^1.0",
+        "sllh/php-cs-fixer-styleci-bridge": "^1.3"
     },
 
     "suggest": {


### PR DESCRIPTION
This bridge permits contributors to fix CS using PHP-CS-Fixer command line while keeping same configuration as `.styleci.yml` file.