### PR TITLE
require only needed Symfony security components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
     - php: 5.4
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.5
-      env: SYMFONY_VERSION='2.8.*@dev symfony/security-acl:2.8.*@dev'
+      env: SYMFONY_VERSION='2.8.*@dev'
     - php: 5.5
-      env: SYMFONY_VERSION='3.0.*@dev symfony/security-acl:3.0.*@dev'
+      env: SYMFONY_VERSION='3.0.*@dev'
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/validator":              "^2.7|^3.0",
         "symfony/serializer":             "^2.7|^3.0",
         "symfony/yaml":                   "^2.7|^3.0",
-        "symfony/security":               "^2.7|^3.0",
+        "symfony/security-core":          "^2.7|^3.0",
         "symfony/browser-kit":            "^2.7|^3.0",
         "symfony/dependency-injection":   "^2.7|^3.0",
         "symfony/expression-language":    "~2.7|^3.0",


### PR DESCRIPTION
FOSRestBundle does not rely on the full Symfony Security component, but
only uses a few classes from the `symfony/security-core` package.