### PR TITLE
Re-add support for formats as priorities

### DIFF
--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -86,7 +86,9 @@ class FormatNegotiator extends BaseNegotiator
                 }
             }
 
-            $mimeTypes = empty($priorities) ? $options['priorities'] : $priorities;
+            $mimeTypes = $this->normalizePriorities(
+                empty($priorities) ? $options['priorities'] : $priorities
+            );
             $mimeType = parent::getBest($header, $mimeTypes);
             if ($mimeType !== null) {
                 return $mimeType;
@@ -102,5 +104,25 @@ class FormatNegotiator extends BaseNegotiator
                 return new Accept($request->getMimeType($options['fallback_format']));
             }
         }
+    }
+
+    /**
+     * Transform the format (json, html, ...) to their mimeType form (application/json, text/html, ...).
+     *
+     * @param array $priorities
+     *
+     * @return array formated priorities
+     */
+    private function normalizePriorities(array $priorities)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        foreach ($priorities as &$priority) {
+            if (($mimeType = $request->getMimeType($priority)) !== null) {
+                $priority = $mimeType;
+            }
+        }
+
+        return $priorities;
     }
 }

--- a/Tests/Negotiation/FormatNegotiatorTest.php
+++ b/Tests/Negotiation/FormatNegotiatorTest.php
@@ -66,7 +66,15 @@ class FormatNegotiatorTest extends \PHPUnit_Framework_TestCase
         $priorities = ['text/html; charset=UTF-8', 'application/json'];
         $this->addRequestMatcher(true, ['priorities' => $priorities]);
 
-        $this->assertEquals(new Accept('text/html; charset=UTF-8'), $this->negotiator->getBest(''));
+        $this->assertEquals(
+            new Accept('text/html; charset=UTF-8'),
+            $this->negotiator->getBest('')
+        );
+
+        $this->assertEquals(
+            new Accept('text/html'),
+            $this->negotiator->getBest('', ['html', 'json'])
+        );
     }
 
     public function testGetBestFallback()


### PR DESCRIPTION
This PR re-add a basic support for formats as priorities.
For the moment only one mime type is supported per format.

Relates to #1151 and #1149 