### PR TITLE
send coverage report to Scrutinizer CI only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,7 @@ before_install:
 
 install: composer update $COMPOSER_FLAGS --prefer-dist
 
-script: phpunit --coverage-clover=coverage.clover
+script: if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then phpunit --coverage-clover=coverage.clover; else phpunit; fi
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi


### PR DESCRIPTION
With this change, the code coverage report should only be sent once to
the Scrutinizer CI service (after the build with PHP 5.6 has finished).

This fixes #1163.