### PR TITLE
Fix deprecated form.type_extension tag alias option usage

### DIFF
--- a/Form/Extension/DisableCSRFExtension.php
+++ b/Form/Extension/DisableCSRFExtension.php
@@ -76,6 +76,9 @@ class DisableCSRFExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return 'form';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form' // SF <2.8 BC
+        ;
     }
 }

--- a/Resources/config/forms.xml
+++ b/Resources/config/forms.xml
@@ -12,7 +12,8 @@
 
     <services>
         <service id="fos_rest.form.extension.csrf_disable" class="%fos_rest.form.extension.csrf_disable.class%">
-            <tag name="form.type_extension" alias="form" />
+            <!-- "alias" option for SF <2.8 -->
+            <tag name="form.type_extension" alias="form" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument /> <!-- security.token_storage or security.context for Symfony < 2.6 -->
             <argument>%fos_rest.disable_csrf_role%</argument>
         </service>


### PR DESCRIPTION
See: https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form