### PR TITLE
Fix special charater bug in schema location

### DIFF
--- a/Routing/Loader/RestXmlCollectionLoader.php
+++ b/Routing/Loader/RestXmlCollectionLoader.php
@@ -208,9 +208,9 @@ class RestXmlCollectionLoader extends XmlFileLoader
     protected function validate(\DOMDocument $dom)
     {
         $restRoutinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing/rest_routing-1.0.xsd');
-        $restRoutinglocation = str_replace('\\', '/', $restRoutinglocation);
+        $restRoutinglocation = rawurlencode(str_replace('\\', '/', $restRoutinglocation));
         $routinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing-1.0.xsd');
-        $routinglocation = str_replace('\\', '/', $routinglocation);
+        $routinglocation = rawurlencode(str_replace('\\', '/', $routinglocation));
         $source = <<<EOF
 <?xml version="1.0" encoding="utf-8" ?>
 <xsd:schema xmlns="http://symfony.com/schema"


### PR DESCRIPTION
Bugfix to encode schema location pathes if the base path of the project contains special characters like blanks.

I'm not sure how to test this as we use `__DIR__` to locate the current library path.