### PR TITLE
[master] csrf getExtendedType with BC for < 2.8

### DIFF
--- a/Form/Extension/DisableCSRFExtension.php
+++ b/Form/Extension/DisableCSRFExtension.php
@@ -60,6 +60,9 @@ class DisableCSRFExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return 'form';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form' // SF <2.8 BC
+            ;
     }
 }

--- a/Resources/config/forms.xml
+++ b/Resources/config/forms.xml
@@ -6,7 +6,8 @@
 
     <services>
         <service id="fos_rest.form.extension.csrf_disable" class="FOS\RestBundle\Form\Extension\DisableCSRFExtension">
-            <tag name="form.type_extension" alias="form" />
+            <!-- "alias" option for SF <2.8 -->
+            <tag name="form.type_extension" alias="form" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="security.token_storage" />
             <argument /> <!-- disable CSRF role -->
             <argument type="service" id="security.authorization_checker" />


### PR DESCRIPTION
This BC for getExtendedType has to be included if the master branch is going to support 2.7 and up.