### PR TITLE
Array validator - pass value with key

### DIFF
--- a/Controller/Annotations/Param.php
+++ b/Controller/Annotations/Param.php
@@ -34,6 +34,8 @@ abstract class Param
     /** @var bool */
     public $array = false;
     /** @var bool */
+    public $withKeys = false;
+    /** @var bool */
     public $nullable = false;
     /** @var bool */
     public $allowBlank = true;

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -147,8 +147,13 @@ class ParamFetcher implements ParamFetcherInterface
             }
 
             $self = $this;
-            array_walk($param, function (&$data) use ($config, $strict, $self) {
-                $data = $self->cleanParamWithRequirements($config, $data, $strict);
+            array_walk($param, function (&$data, &$key) use ($config, $strict, $self) {
+                if ($config->withKeys) {
+                    $returnValue = $self->cleanParamWithRequirements($config, array($key => $data), $strict);
+                    $data = $returnValue[$key];
+                } else {
+                    $data = $self->cleanParamWithRequirements($config, $data, $strict);
+                }
             });
 
             return $param;
@@ -174,11 +179,11 @@ class ParamFetcher implements ParamFetcherInterface
     }
 
     /**
-     * @param Param  $config
-     * @param string $param
-     * @param bool   $strict
+     * @param Param        $config
+     * @param string|array $param
+     * @param bool         $strict
      *
-     * @return string
+     * @return string|array
      *
      * @throws BadRequestHttpException
      * @throws \RuntimeException


### PR DESCRIPTION
Hi!

I try to use this query param constraint validator with example filters:

```php
[
    'tags' => [1, 2],
    'name' => 'Some name'
]
```
From doc:
```@QueryParam(array=true, name="filters", requirements=@MyComplexConstraint, description="List of complex filters")```

But currently MyComplexConstraint to validator is passed only value - there is no possibility of checking a given key and value.
This PR allow to test key with value in constraint, so i have a option to test e.g. available tags or name in filters.