### PR TITLE
added version annotation

### DIFF
--- a/Controller/Annotations/Version.php
+++ b/Controller/Annotations/Version.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Version Route annotation class.
+ *
+ * @Annotation
+ * @Target("CLASS")
+ */
+class Version extends Annotation
+{
+}

--- a/Resources/doc/format_listener.rst
+++ b/Resources/doc/format_listener.rst
@@ -210,3 +210,25 @@ Note that this version mechanism is configurable by your own by changing the reg
 :ref:`media type version regex configuration <media-type-version-extraction>`.
 
 .. _`mime type listener`: http://symfony.com/doc/current/cookbook/request/mime_type.html
+
+Furthermore you can use conditions on your request to check for the version that was determined:
+
+.. code-block:: yaml
+
+    my_route:
+        ...
+        condition: "request.attributes.get('version') == 'v2'"
+
+When using the :doc:`automatic route generation <5-automatic-route-generation_single-restful-controller>`,
+you can also use the ``@Version`` annotation to set the above condition automatically on all methods
+in the given controller.
+
+.. code-block:: php
+
+    use FOS\RestBundle\Controller\Annotations\Version;
+
+    /**
+     * @Version("v2")
+     */
+    class MyController
+    {

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -35,6 +35,7 @@ class RestActionReader
     private $includeFormat;
     private $routePrefix;
     private $namePrefix;
+    private $version;
     private $pluralize;
     private $parents = [];
     private $availableHTTPMethods = ['get', 'post', 'put', 'patch', 'delete', 'link', 'unlink', 'head', 'options'];
@@ -96,6 +97,26 @@ class RestActionReader
     public function getNamePrefix()
     {
         return $this->namePrefix;
+    }
+
+    /**
+     * Sets route names version.
+     *
+     * @param string $version Route names version
+     */
+    public function setVersion($version = null)
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * Returns version.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
     }
 
     /**
@@ -232,7 +253,7 @@ class RestActionReader
                 $defaults = array_merge($defaults, $annotation->getDefaults());
                 $host = $annotation->getHost();
                 $schemes = $annotation->getSchemes();
-                $condition = $annotation->getCondition();
+                $condition = $this->getCondition($method, $annotation);
 
                 $this->includeFormatIfNeeded($path, $requirements);
 
@@ -253,6 +274,26 @@ class RestActionReader
             );
             $this->addRoute($collection, $routeName, $route, $isCollection, $isInflectable);
         }
+    }
+
+    /**
+     * Determine the Route condition by combining Route annotations with Version annotation.
+     *
+     * @param \ReflectionMethod $method
+     * @param RouteAnnotation   $annotation
+     *
+     * @return string
+     */
+    private function getCondition(\ReflectionMethod $method, RouteAnnotation $annotation)
+    {
+        $condition = $annotation->getCondition();
+
+        if (null !== $this->version) {
+            $versionCondition = "request.attributes.get('version') == '".$this->version."'";
+            $condition = $condition ? '('.$condition.') and '.$versionCondition : $versionCondition;
+        }
+
+        return $condition;
     }
 
     /**

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -71,6 +71,11 @@ class RestControllerReader
             $this->actionReader->setNamePrefix($annotation->value);
         }
 
+        // read version annotation
+        if ($annotation = $this->readClassAnnotation($reflectionClass, 'Version')) {
+            $this->actionReader->setVersion($annotation->value);
+        }
+
         $resource = [];
         // read route-resource annotation
         if ($annotation = $this->readClassAnnotation($reflectionClass, 'RouteResource')) {
@@ -97,6 +102,7 @@ class RestControllerReader
 
         $this->actionReader->setRoutePrefix(null);
         $this->actionReader->setNamePrefix(null);
+        $this->actionReader->setVersion(null);
         $this->actionReader->setPluralize(null);
         $this->actionReader->setParents([]);
 

--- a/Tests/Fixtures/Controller/AnnotatedVersionUserController.php
+++ b/Tests/Fixtures/Controller/AnnotatedVersionUserController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Controller\Annotations\Version;
+use FOS\RestBundle\Controller\Annotations\Get;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @Version("v1")
+ */
+class AnnotatedVersionUserController extends Controller
+{
+    /**
+     * [GET, HEAD]     /users/{slug}/v2.
+     *
+     * @Get()
+     */
+    public function v1UserAction()
+    {
+    }
+
+    /**
+     * [GET, HEAD]     /users/{slug}/conditional.
+     *
+     * @Get(condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'")
+     */
+    public function conditionalUserAction()
+    {
+    }
+}

--- a/Tests/Fixtures/Etalon/annotated_version_controller.yml
+++ b/Tests/Fixtures/Etalon/annotated_version_controller.yml
@@ -1,0 +1,11 @@
+v1_user:
+  path:      /users/v1.{_format}
+  controller:   ::v1UserAction
+  methods: [GET]
+  condition: "request.attributes.get('version') == 'v1'"
+
+conditional_user:
+  path:      /users/conditional.{_format}
+  controller:   ::conditionalUserAction
+  methods: [GET]
+  condition: "(context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i') and request.attributes.get('version') == 'v1'"

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -165,6 +165,35 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
+     * Test that annotated UsersController RESTful class gets parsed correctly with condition option (expression-language).
+     */
+    public function testAnnotatedVersionUserFixture()
+    {
+        $collection = $this->loadFromControllerFixture('AnnotatedVersionUserController');
+        $etalonRoutes = $this->loadEtalonRoutesInfo('annotated_version_controller.yml');
+
+        $this->assertTrue($collection instanceof RestRouteCollection);
+        $this->assertEquals(2, count($collection->all()));
+
+        foreach ($etalonRoutes as $name => $params) {
+            $route = $collection->get($name);
+
+            $this->assertNotNull($route, "no route found for '$name'");
+            $this->assertEquals($params['path'], $route->getPath(), 'path failed to match for '.$name);
+
+            $params['requirements'] = isset($params['requirements']) ? $params['requirements'] : array();
+            $requirements = $route->getRequirements();
+            unset($requirements['_method']);
+            $this->assertEquals($params['requirements'], $requirements, 'requirements failed to match for '.$name);
+
+            $this->assertContains($params['controller'], $route->getDefault('_controller'), 'controller failed to match for '.$name);
+            if (isset($params['condition'])) {
+                $this->assertEquals($params['condition'], $route->getCondition(), 'condition failed to match for '.$name);
+            }
+        }
+    }
+
+    /**
      * Test that a custom format annotation is not overwritten.
      */
     public function testCustomFormatRequirementIsKept()


### PR DESCRIPTION
Makes it possible to set a route condition checking the matched version:

```
use FOS\RestBundle\Controller\Annotations\Version;

/**
 * @Version("v2")
 */
class MyController
{
```

will add a condition to all routes, ie.:
```
my_route:
    ...
    condition: "request.attributes.get('version') == 'v2'"
```