### PR TITLE
Fix an error

### DIFF
--- a/DependencyInjection/Compiler/FormatListenerRulesPass.php
+++ b/DependencyInjection/Compiler/FormatListenerRulesPass.php
@@ -73,9 +73,11 @@ class FormatListenerRulesPass implements CompilerPassInterface
         $container->getDefinition('fos_rest.format_negotiator')
             ->addMethodCall('add', [$matcher, $rule]);
 
-        $rule['fallback_format'] = $exceptionFallbackFormat;
-        $container->getDefinition('fos_rest.exception_format_negotiator')
-            ->addMethodCall('add', [$matcher, $rule]);
+        if ($container->hasDefinition('fos_rest.exception_format_negotiator')) {
+            $rule['fallback_format'] = $exceptionFallbackFormat;
+            $container->getDefinition('fos_rest.exception_format_negotiator')
+                ->addMethodCall('add', [$matcher, $rule]);
+        }
     }
 
     protected function createRequestMatcher(ContainerBuilder $container, $path = null, $host = null, $methods = null)

--- a/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
@@ -26,7 +26,7 @@ class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['hasDefinition', 'getDefinition', 'hasParameter', 'getParameter'])
             ->getMock();
 
-        $container->expects($this->exactly(3))
+        $container->expects($this->exactly(5))
             ->method('hasDefinition')
             ->will($this->returnValue(true));
 
@@ -72,7 +72,7 @@ class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['hasDefinition', 'getDefinition', 'hasParameter', 'getParameter'])
             ->getMock();
 
-        $container->expects($this->exactly(2))
+        $container->expects($this->exactly(3))
             ->method('hasDefinition')
             ->will($this->returnValue(true));
 


### PR DESCRIPTION
This pr fixes an error.
See https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1179#issuecomment-149923127

>
Here is the debug output :
>
```
[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
  The service definition "fos_rest.exception_format_negotiator" does not exist.
>
Exception trace:
 () at C:\Program Files\Wamp Server\www\Unanimita\API\vendor\symfony\symfony\src\Symfony\Component\DependencyInjection\ContainerBuilder.php:868
 Symfony\Component\DependencyInjection\ContainerBuilder->getDefinition() at C:\Program Files\Wamp Server\www\Unanimita\API\vendor\friendsofsymfony\rest-bundle\DependencyInjection\Compiler\FormatListenerRulesPass.php:77
 FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass->addRule() at C:\Program Files\Wamp Server\www\Unanimita\API\vendor\friendsofsymfony\rest-bundle\DependencyInjection\Compiler\FormatListenerRulesPass.php:51
 FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass->process() at C:\Program Files\Wamp Server\www\Unanimita\API\vendor\symfony\symfony\src\Symfony\Component\DependencyInjection\Compiler\Compiler.php:117
 Symfony\Component\DependencyInjection\Compiler\Compiler->compile() at C:\Program Files\Wamp Server\www\Unanimita\API\vendor\symfony\symfony\src\Symfony\Component\DependencyInjection\ContainerBuilder.php:614
 Symfony\Component\DependencyInjection\ContainerBuilder->compile() at C:\Program Files\Wamp Server\www\Unanimita\API\app\bootstrap.php.cache:2633
 Symfony\Component\HttpKernel\Kernel->initializeContainer() at C:\Program Files\Wamp Server\www\Unanimita\API\app\bootstrap.php.cache:2411
 Symfony\Component\HttpKernel\Kernel->boot() at C:\Program Files\Wamp Server\www\Unanimita\API\vendor\symfony\symfony\src\Symfony\Bundle\FrameworkBundle\Console\Application.php:70
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at C:\Program Files\Wamp Server\www\Unanimita\API\vendor\symfony\symfony\src\Symfony\Component\Console\Application.php:126
 Symfony\Component\Console\Application->run() at C:\Program Files\Wamp Server\www\Unanimita\API\app\console:27
```
