### PR TITLE
Allows to define several versions

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -35,7 +35,7 @@ class RestActionReader
     private $includeFormat;
     private $routePrefix;
     private $namePrefix;
-    private $version;
+    private $versions;
     private $pluralize;
     private $parents = [];
     private $availableHTTPMethods = ['get', 'post', 'put', 'patch', 'delete', 'link', 'unlink', 'head', 'options'];
@@ -100,23 +100,23 @@ class RestActionReader
     }
 
     /**
-     * Sets route names version.
+     * Sets route names versions.
      *
-     * @param string $version Route names version
+     * @param array|string|null $versions Route names versions
      */
-    public function setVersion($version = null)
+    public function setVersions($versions = null)
     {
-        $this->version = $version;
+        $this->versions = (array) $versions;
     }
 
     /**
-     * Returns version.
+     * Returns versions.
      *
-     * @return string
+     * @return array|null
      */
-    public function getVersion()
+    public function getVersions()
     {
-        return $this->version;
+        return $this->versions;
     }
 
     /**
@@ -288,8 +288,17 @@ class RestActionReader
     {
         $condition = $annotation->getCondition();
 
-        if (null !== $this->version) {
-            $versionCondition = "request.attributes.get('version') == '".$this->version."'";
+        if (!empty($this->versions)) {
+            $versionCondition = "request.attributes.get('version') == (";
+            $first = true;
+            foreach ($this->versions as $version) {
+                if (!$first) {
+                    $versionCondition .= ' or ';
+                }
+                $versionCondition .= '\''.$version.'\'';
+                $first = false;
+            }
+            $versionCondition .= ')';
             $condition = $condition ? '('.$condition.') and '.$versionCondition : $versionCondition;
         }
 

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -73,7 +73,7 @@ class RestControllerReader
 
         // read version annotation
         if ($annotation = $this->readClassAnnotation($reflectionClass, 'Version')) {
-            $this->actionReader->setVersion($annotation->value);
+            $this->actionReader->setVersions($annotation->value);
         }
 
         $resource = [];
@@ -102,7 +102,7 @@ class RestControllerReader
 
         $this->actionReader->setRoutePrefix(null);
         $this->actionReader->setNamePrefix(null);
-        $this->actionReader->setVersion(null);
+        $this->actionReader->setVersions(null);
         $this->actionReader->setPluralize(null);
         $this->actionReader->setParents([]);
 

--- a/Tests/Fixtures/Controller/AnnotatedVersionUserController.php
+++ b/Tests/Fixtures/Controller/AnnotatedVersionUserController.php
@@ -16,7 +16,7 @@ use FOS\RestBundle\Controller\Annotations\Get;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 /**
- * @Version("v1")
+ * @Version({"v1", "v3"})
  */
 class AnnotatedVersionUserController extends Controller
 {

--- a/Tests/Fixtures/Etalon/annotated_version_controller.yml
+++ b/Tests/Fixtures/Etalon/annotated_version_controller.yml
@@ -2,10 +2,10 @@ v1_user:
   path:      /users/v1.{_format}
   controller:   ::v1UserAction
   methods: [GET]
-  condition: "request.attributes.get('version') == 'v1'"
+  condition: "request.attributes.get('version') == ('v1' or 'v3')"
 
 conditional_user:
   path:      /users/conditional.{_format}
   controller:   ::conditionalUserAction
   methods: [GET]
-  condition: "(context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i') and request.attributes.get('version') == 'v1'"
+  condition: "(context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i') and request.attributes.get('version') == ('v1' or 'v3')"


### PR DESCRIPTION
This PR allows to define multiple versions for a single controller:
```php
<?php
use FOS\RestBundle\Controller\Annotations\Version;

/**
 * @Version({"v1", "v2"})
 * or
 * @Version("v3")
*/
class Foo {}
```