### PR TITLE
Ignoring PSR7 request typehint in route loader

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -414,6 +414,7 @@ class RestActionReader
             'FOS\RestBundle\Request\ParamFetcherInterface',
             'Symfony\Component\Validator\ConstraintViolationListInterface',
             'Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter',
+            'Psr\Http\Message\MessageInterface',
         ];
 
         $arguments = [];

--- a/Tests/Fixtures/Controller/TypeHintedController.php
+++ b/Tests/Fixtures/Controller/TypeHintedController.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Controller\Annotations as Rest;
+use FOS\RestBundle\Controller\FOSRestController;
+use FOS\RestBundle\Routing\ClassResourceInterface;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Rest\RouteResource("Article")
+ */
+class TypeHintedController implements ClassResourceInterface
+{
+    public function cgetAction(Request $request)
+    {
+    }
+
+    public function cpostAction(MessageInterface $request)
+    {
+    }
+
+    public function getAction(Request $request, $id)
+    {
+    }
+
+    public function postAction(ServerRequestInterface $request, $id)
+    {
+    }
+}

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -343,6 +343,24 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
+     * RestActionReader::getMethodArguments should ignore certain types of
+     * parameters.
+     */
+    public function testRequestTypeHintsIgnoredCorrectly()
+    {
+        $collection = $this->loadFromControllerFixture('TypeHintedController');
+
+        $this->assertNotNull($collection->get('get_articles'), 'route for "get_articles" does not exist');
+        $this->assertEquals('/articles.{_format}', $collection->get('get_articles')->getPath());
+        $this->assertNotNull($collection->get('post_articles'), 'route for "post_articles" does not exist');
+        $this->assertEquals('/articles.{_format}', $collection->get('post_articles')->getPath());
+        $this->assertNotNull($collection->get('get_article'), 'route for "get_article" does not exist');
+        $this->assertEquals('/articles/{id}.{_format}', $collection->get('get_article')->getPath());
+        $this->assertNotNull($collection->get('post_article'), 'route for "post_article" does not exist');
+        $this->assertEquals('/articles/{id}.{_format}', $collection->get('post_article')->getPath());
+    }
+
+    /**
      * Load routes collection from fixture class under Tests\Fixtures directory.
      *
      * @param string $fixtureName name of the class fixture

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "symfony/css-selector":           "^2.7|^3.0",
         "phpoption/phpoption":            "^1.1",
         "jms/serializer-bundle":          "^1.0",
-        "sllh/php-cs-fixer-styleci-bridge": "^1.3"
+        "sllh/php-cs-fixer-styleci-bridge": "^1.3",
+        "psr/http-message":               "^1.0"
     },
 
     "suggest": {


### PR DESCRIPTION
I'm playing with symfony psr7 bridge and using `ServerRequestInterface` typehint instead of Symfony's `Request` in actions caused incorrect route generation. Collection routes get suffixed with `/{request}` param, item routes as well, when the `$request` param was the first.

This PR fixes that by adding `Psr\Http\Message\ServerRequestInterface` to ignored classed in `RestActionReader`. I also added a simple test case for PSR's and Symfony's request.