### PR TITLE
Bump minimum php version to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -21,7 +20,7 @@ branches:
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
+    - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 5.6
       env: SYMFONY_VERSION='2.8.*'

--- a/DependencyInjection/Compiler/ExceptionWrapperHandlerPass.php
+++ b/DependencyInjection/Compiler/ExceptionWrapperHandlerPass.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\DependencyInjection\Compiler;
 
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -27,7 +28,7 @@ class ExceptionWrapperHandlerPass implements CompilerPassInterface
             return;
         }
 
-        if (interface_exists('JMS\Serializer\Handler\SubscribingHandlerInterface')) {
+        if (interface_exists(SubscribingHandlerInterface::class)) {
             return;
         }
 

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -440,7 +440,7 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
      */
     private function testExceptionExists($exception)
     {
-        if (!is_subclass_of($exception, '\Exception') && !is_a($exception, '\Exception', true)) {
+        if (!is_subclass_of($exception, \Exception::class) && !is_a($exception, \Exception::class, true)) {
             throw new \InvalidArgumentException("FOSRestBundle exception mapper: Could not load class '$exception' or the class does not extend from '\Exception'. Most probably this is a configuration problem.");
         }
     }

--- a/EventListener/ParamFetcherListener.php
+++ b/EventListener/ParamFetcherListener.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\EventListener;
 
 use FOS\RestBundle\FOSRestBundle;
+use FOS\RestBundle\Request\ParamFetcherInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
@@ -115,8 +116,7 @@ class ParamFetcherListener
         if (null === $type) {
             return false;
         }
-        $fetcherInterface = 'FOS\\RestBundle\\Request\\ParamFetcherInterface';
 
-        return $type->implementsInterface($fetcherInterface);
+        return $type->implementsInterface(ParamFetcherInterface::class);
     }
 }

--- a/Form/Extension/DisableCSRFExtension.php
+++ b/Form/Extension/DisableCSRFExtension.php
@@ -11,7 +11,9 @@
 
 namespace FOS\RestBundle\Form\Extension;
 
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -60,8 +62,8 @@ class DisableCSRFExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+        return method_exists(AbstractType::class, 'getBlockPrefix')
+            ? FormType::class
             : 'form' // SF <2.8 BC
             ;
     }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -405,15 +405,12 @@ class RestActionReader
         // ignore all query params
         $params = $this->paramReader->getParamsFromMethod($method);
 
-        // ignore type hinted arguments that are or extend from:
-        // * Symfony\Component\HttpFoundation\Request
-        // * FOS\RestBundle\Request\QueryFetcher
-        // * Symfony\Component\Validator\ConstraintViolationList
+        // ignore several type hinted arguments
         $ignoreClasses = [
-            'Symfony\Component\HttpFoundation\Request',
-            'FOS\RestBundle\Request\ParamFetcherInterface',
-            'Symfony\Component\Validator\ConstraintViolationListInterface',
-            'Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter',
+            \Symfony\Component\HttpFoundation\Request::class,
+            \FOS\RestBundle\Request\ParamFetcherInterface::class,
+            \Symfony\Component\Validator\ConstraintViolationListInterface::class,
+            \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter::class,
         ];
 
         $arguments = [];

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -12,6 +12,8 @@
 namespace FOS\RestBundle\Routing\Loader\Reader;
 
 use Doctrine\Common\Annotations\Reader;
+use FOS\RestBundle\Controller\Annotations;
+use FOS\RestBundle\Routing\ClassResourceInterface;
 use FOS\RestBundle\Routing\RestRouteCollection;
 use Symfony\Component\Config\Resource\FileResource;
 
@@ -62,26 +64,26 @@ class RestControllerReader
         $collection->addResource(new FileResource($reflectionClass->getFileName()));
 
         // read prefix annotation
-        if ($annotation = $this->readClassAnnotation($reflectionClass, 'Prefix')) {
+        if ($annotation = $this->annotationReader->getClassAnnotation($reflectionClass, Annotations\Prefix::class)) {
             $this->actionReader->setRoutePrefix($annotation->value);
         }
 
         // read name-prefix annotation
-        if ($annotation = $this->readClassAnnotation($reflectionClass, 'NamePrefix')) {
+        if ($annotation = $this->annotationReader->getClassAnnotation($reflectionClass, Annotations\NamePrefix::class)) {
             $this->actionReader->setNamePrefix($annotation->value);
         }
 
         // read version annotation
-        if ($annotation = $this->readClassAnnotation($reflectionClass, 'Version')) {
+        if ($annotation = $this->annotationReader->getClassAnnotation($reflectionClass, Annotations\Version::class)) {
             $this->actionReader->setVersions($annotation->value);
         }
 
         $resource = [];
         // read route-resource annotation
-        if ($annotation = $this->readClassAnnotation($reflectionClass, 'RouteResource')) {
+        if ($annotation = $this->annotationReader->getClassAnnotation($reflectionClass, Annotations\RouteResource::class)) {
             $resource = explode('_', $annotation->resource);
             $this->actionReader->setPluralize($annotation->pluralize);
-        } elseif ($reflectionClass->implementsInterface('FOS\RestBundle\Routing\ClassResourceInterface')) {
+        } elseif ($reflectionClass->implementsInterface(ClassResourceInterface::class)) {
             $resource = preg_split(
                 '/([A-Z][^A-Z]*)Controller/', $reflectionClass->getShortName(), -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE
             );
@@ -107,22 +109,5 @@ class RestControllerReader
         $this->actionReader->setParents([]);
 
         return $collection;
-    }
-
-    /**
-     * Reads class annotations.
-     *
-     * @param \ReflectionClass $reflectionClass
-     * @param string           $annotationName
-     *
-     * @return object|null
-     */
-    private function readClassAnnotation(\ReflectionClass $reflectionClass, $annotationName)
-    {
-        $annotationClass = "FOS\\RestBundle\\Controller\\Annotations\\$annotationName";
-
-        if ($annotation = $this->annotationReader->getClassAnnotation($reflectionClass, $annotationClass)) {
-            return $annotation;
-        }
     }
 }

--- a/Serializer/ExceptionWrapperSerializeHandler.php
+++ b/Serializer/ExceptionWrapperSerializeHandler.php
@@ -29,13 +29,13 @@ class ExceptionWrapperSerializeHandler implements SubscribingHandlerInterface
             [
                 'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
                 'format' => 'json',
-                'type' => 'FOS\\RestBundle\\Util\\ExceptionWrapper',
+                'type' => ExceptionWrapper::class,
                 'method' => 'serializeToJson',
             ],
             [
                 'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
-                'type' => 'FOS\\RestBundle\\Util\\ExceptionWrapper',
+                'type' => ExceptionWrapper::class,
                 'method' => 'serializeToXml',
             ],
         ];

--- a/Tests/Context/Adapter/ArrayContextAdapterTest.php
+++ b/Tests/Context/Adapter/ArrayContextAdapterTest.php
@@ -11,8 +11,10 @@
 
 namespace FOS\RestBundle\Tests\Context;
 
+use FOS\RestBundle\Context\Adapter;
 use FOS\RestBundle\Context\Adapter\ArrayContextAdapter;
 use FOS\RestBundle\Context\Context;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * @author Ener-Getick <egetick@gmail.com>
@@ -22,13 +24,13 @@ class ArrayContextAdapterTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->adapter = new ArrayContextAdapter();
-        $this->serializer = $this->getMock('Symfony\Component\Serializer\SerializerInterface');
+        $this->serializer = $this->getMock(SerializerInterface::class);
     }
 
     public function testInterface()
     {
-        $this->assertInstanceOf('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface', $this->adapter);
-        $this->assertInstanceOf('FOS\RestBundle\Context\Adapter\DeserializationContextAdapterInterface', $this->adapter);
+        $this->assertInstanceOf(Adapter\SerializationContextAdapterInterface::class, $this->adapter);
+        $this->assertInstanceOf(Adapter\DeserializationContextAdapterInterface::class, $this->adapter);
     }
 
     public function testContextConversion()

--- a/Tests/Context/Adapter/ChainContextAdapterTest.php
+++ b/Tests/Context/Adapter/ChainContextAdapterTest.php
@@ -11,6 +11,11 @@
 
 namespace FOS\RestBundle\Tests\Context;
 
+use FOS\RestBundle\Context\Adapter\ChainContextAdapter;
+use FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface;
+use FOS\RestBundle\Context\Adapter\DeserializationContextAdapterInterface;
+use FOS\RestBundle\Context\ContextInterface;
+
 /**
  * @author Ener-Getick <egetick@gmail.com>
  */
@@ -20,18 +25,18 @@ class ChainContextAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->context = $this->getMock('FOS\RestBundle\Context\ContextInterface');
+        $this->context = $this->getMock(ContextInterface::class);
 
-        $this->adapter1 = $this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface');
-        $this->adapter2 = $this->getMock('FOS\RestBundle\Tests\Fixtures\Context\Adapter\SerializerAwareAdapter');
+        $this->adapter1 = $this->getMock(SerializationContextAdapterInterface::class);
+        $this->adapter2 = $this->getMock(\FOS\RestBundle\Tests\Fixtures\Context\Adapter\SerializerAwareAdapter::class);
 
-        $this->adapter = $this->getMock('FOS\RestBundle\Context\Adapter\ChainContextAdapter', null, [[$this->adapter1, $this->adapter2]]);
+        $this->adapter = new ChainContextAdapter([$this->adapter1, $this->adapter2]);
     }
 
     public function testInterface()
     {
-        $this->assertInstanceOf('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface', $this->adapter);
-        $this->assertInstanceOf('FOS\RestBundle\Context\Adapter\DeserializationContextAdapterInterface', $this->adapter);
+        $this->assertInstanceOf(SerializationContextAdapterInterface::class, $this->adapter);
+        $this->assertInstanceOf(DeserializationContextAdapterInterface::class, $this->adapter);
     }
 
     public function testSerializationContextConversion()
@@ -114,7 +119,7 @@ class ChainContextAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializerTransmission()
     {
-        $serializer = $this->getMock('JMS\Serializer\Serializer', [], [], '', false);
+        $serializer = $this->getMock(\JMS\Serializer\Serializer::class, [], [], '', false);
         $this->adapter->setSerializer($serializer);
         $this->adapter2
              ->expects($this->exactly(4))

--- a/Tests/Context/Adapter/JMSContextAdapterTest.php
+++ b/Tests/Context/Adapter/JMSContextAdapterTest.php
@@ -12,6 +12,9 @@
 namespace FOS\RestBundle\Tests\Context;
 
 use FOS\RestBundle\Context\Adapter\JMSContextAdapter;
+use FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface;
+use FOS\RestBundle\Context\Adapter\SerializerAwareInterface;
+use FOS\RestBundle\Context\Adapter\DeserializationContextAdapterInterface;
 use FOS\RestBundle\Context\Context;
 
 /**
@@ -24,16 +27,16 @@ class JMSContextAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->serializer = $this->getMock('JMS\Serializer\SerializerInterface');
+        $this->serializer = $this->getMock(\JMS\Serializer\SerializerInterface::class);
         $this->adapter = new JMSContextAdapter();
         $this->adapter->setSerializer($this->serializer);
     }
 
     public function testInterface()
     {
-        $this->assertInstanceOf('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface', $this->adapter);
-        $this->assertInstanceOf('FOS\RestBundle\Context\Adapter\DeserializationContextAdapterInterface', $this->adapter);
-        $this->assertInstanceOf('FOS\RestBundle\Context\Adapter\SerializerAwareInterface', $this->adapter);
+        $this->assertInstanceOf(SerializationContextAdapterInterface::class, $this->adapter);
+        $this->assertInstanceOf(DeserializationContextAdapterInterface::class, $this->adapter);
+        $this->assertInstanceOf(SerializerAwareInterface::class, $this->adapter);
     }
 
     public function testSerializationContextConversion()
@@ -48,7 +51,7 @@ class JMSContextAdapterTest extends \PHPUnit_Framework_TestCase
         $context->setSerializeNull(true);
 
         $JMSContext = $this->adapter->convertSerializationContext($context);
-        $this->assertInstanceOf('JMS\Serializer\SerializationContext', $JMSContext);
+        $this->assertInstanceOf(\JMS\Serializer\SerializationContext::class, $JMSContext);
         $this->assertEquals('bar', $JMSContext->attributes->get('foo')->get());
         $this->assertEquals(['a', 'b', 'c'], $JMSContext->attributes->get('groups')->get());
         $this->assertEquals(1.3, $JMSContext->attributes->get('version')->get());
@@ -66,7 +69,7 @@ class JMSContextAdapterTest extends \PHPUnit_Framework_TestCase
         $context->setSerializeNull(false);
 
         $JMSContext = $this->adapter->convertDeserializationContext($context);
-        $this->assertInstanceOf('JMS\Serializer\DeserializationContext', $JMSContext);
+        $this->assertInstanceOf(\JMS\Serializer\DeserializationContext::class, $JMSContext);
         $this->assertEquals('foo', $JMSContext->attributes->get('bar')->get());
         $this->assertEquals(['e', 'f'], $JMSContext->attributes->get('groups')->get());
         $this->assertEquals(1.4, $JMSContext->attributes->get('version')->get());

--- a/Tests/Context/ContextTest.php
+++ b/Tests/Context/ContextTest.php
@@ -11,6 +11,8 @@
 
 namespace FOS\RestBundle\Tests\Context;
 
+use FOS\RestBundle\Context;
+
 /**
  * @author Ener-Getick <egetick@gmail.com>
  */
@@ -20,16 +22,16 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->context = $this->getMock('FOS\RestBundle\Context\Context', null);
+        $this->context = $this->getMock(Context\Context::class, null);
     }
 
     public function testInterfaces()
     {
-        $this->assertInstanceOf('FOS\RestBundle\Context\ContextInterface', $this->context);
-        $this->assertInstanceOf('FOS\RestBundle\Context\GroupableContextInterface', $this->context);
-        $this->assertInstanceOf('FOS\RestBundle\Context\VersionableContextInterface', $this->context);
-        $this->assertInstanceOf('FOS\RestBundle\Context\MaxDepthContextInterface', $this->context);
-        $this->assertInstanceOf('FOS\RestBundle\Context\SerializeNullContextInterface', $this->context);
+        $this->assertInstanceOf(Context\ContextInterface::class, $this->context);
+        $this->assertInstanceOf(Context\GroupableContextInterface::class, $this->context);
+        $this->assertInstanceOf(Context\VersionableContextInterface::class, $this->context);
+        $this->assertInstanceOf(Context\MaxDepthContextInterface::class, $this->context);
+        $this->assertInstanceOf(Context\SerializeNullContextInterface::class, $this->context);
     }
 
     public function testDefaultValues()
@@ -56,7 +58,7 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
     public function testGroupsAddition()
     {
-        $context = $this->getMock('FOS\RestBundle\Context\Context', ['addGroup']);
+        $context = $this->getMock(Context\Context::class, ['addGroup']);
         $context
             ->expects($this->exactly(2))
             ->method('addGroup')

--- a/Tests/Controller/Annotations/AbstractParamTest.php
+++ b/Tests/Controller/Annotations/AbstractParamTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\Tests\Controller\Annotations;
 
+use FOS\RestBundle\Controller\Annotations;
 use Symfony\Component\Validator\Constraints;
 
 /**
@@ -22,12 +23,12 @@ class AbstractParamTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->param = $this->getMockForAbstractClass('FOS\RestBundle\Controller\Annotations\AbstractParam');
+        $this->param = $this->getMockForAbstractClass(Annotations\AbstractParam::class);
     }
 
     public function testInterface()
     {
-        $this->assertInstanceOf('FOS\RestBundle\Controller\Annotations\ParamInterface', $this->param);
+        $this->assertInstanceOf(Annotations\ParamInterface::class, $this->param);
     }
 
     public function testDefaultValues()

--- a/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\DependencyInjection\Compiler;
 
 use FOS\RestBundle\DependencyInjection\Compiler\ConfigurationCheckPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * ConfigurationCheckPass test.
@@ -25,7 +26,7 @@ class ConfigurationCheckPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldThrowRuntimeExceptionWhenFOSRestBundleAnnotations()
     {
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['has'])
             ->getMock();
         $container->expects($this->at(0))
@@ -48,7 +49,7 @@ class ConfigurationCheckPassTest extends \PHPUnit_Framework_TestCase
             'RuntimeException',
             'You need to enable the parameter converter listeners in SensioFrameworkExtraBundle when using the FOSRestBundle RequestBodyParamConverter'
         );
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['has'])
             ->getMock();
         $container->expects($this->at(1))

--- a/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
@@ -12,6 +12,8 @@
 namespace FOS\RestBundle\Tests\DependencyInjection\Compiler;
 
 use FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @author Eduardo Gulias Davis <me@egulias.com>
@@ -20,9 +22,9 @@ class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testRulesAreAddedWhenFormatListenerAndProfilerToolbarAreEnabled()
     {
-        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', ['addMethod']);
+        $definition = $this->getMock(Definition::class, ['addMethod']);
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['hasDefinition', 'getDefinition', 'hasParameter', 'getParameter'])
             ->getMock();
 
@@ -66,9 +68,9 @@ class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
 
     public function testNoRulesAreAddedWhenProfilerToolbarAreDisabled()
     {
-        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', ['addMethod']);
+        $definition = $this->getMock(Definition::class, ['addMethod']);
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['hasDefinition', 'getDefinition', 'hasParameter', 'getParameter'])
             ->getMock();
 

--- a/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\DependencyInjection\Compiler;
 
 use FOS\RestBundle\DependencyInjection\Compiler\SerializerConfigurationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * SerializerConfigurationPassTest test.
@@ -20,7 +21,7 @@ class SerializerConfigurationPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testShouldDoNothingIfSerializerIsFound()
     {
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['has'])
             ->getMock();
 
@@ -41,7 +42,7 @@ class SerializerConfigurationPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldThrowInvalidArgumentExceptionWhenNoSerializerIsFound()
     {
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['has'])
             ->getMock();
 
@@ -57,7 +58,7 @@ class SerializerConfigurationPassTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldConfigureJMSSerializer()
     {
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['has', 'setAlias', 'removeDefinition'])
             ->getMock();
 
@@ -81,7 +82,7 @@ class SerializerConfigurationPassTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldConfigureCoreSerializer()
     {
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['has', 'setAlias', 'removeDefinition'])
             ->getMock();
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -14,6 +14,7 @@ namespace FOS\RestBundle\Tests\DependencyInjection;
 use FOS\RestBundle\DependencyInjection\FOSRestExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -103,7 +104,7 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load($config, $this->container);
         $normalizerArgument = $this->container->getDefinition('fos_rest.body_listener')->getArgument(2);
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $normalizerArgument);
+        $this->assertInstanceOf(Reference::class, $normalizerArgument);
         $this->assertEquals('fos_rest.normalizer.camel_keys', (string) $normalizerArgument);
     }
 
@@ -123,7 +124,7 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $normalizeForms = $bodyListener->getArgument(3);
 
         $this->assertCount(4, $bodyListener->getArguments());
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $normalizerArgument);
+        $this->assertInstanceOf(Reference::class, $normalizerArgument);
         $this->assertEquals('fos_rest.normalizer.camel_keys', (string) $normalizerArgument);
         $this->assertEquals(false, $normalizeForms);
     }
@@ -145,7 +146,7 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $normalizeForms = $bodyListener->getArgument(3);
 
         $this->assertCount(4, $bodyListener->getArguments());
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $normalizerArgument);
+        $this->assertInstanceOf(Reference::class, $normalizerArgument);
         $this->assertEquals('fos_rest.normalizer.camel_keys', (string) $normalizerArgument);
         $this->assertEquals(true, $normalizeForms);
     }
@@ -598,7 +599,7 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->container->has('fos_rest.view_handler'));
 
         $viewHandler = $this->container->getDefinition('fos_rest.view_handler');
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $viewHandler);
+        $this->assertInstanceOf(DefinitionDecorator::class, $viewHandler);
     }
 
     public function testCheckExceptionWrapperHandler()
@@ -646,14 +647,14 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[0][0]);
         $requestMatcherFirstId = (string) $addRequestMatcherCalls[0][1][0];
         $requestMatcherFirst = $this->container->getDefinition($requestMatcherFirstId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherFirst);
+        $this->assertInstanceOf(DefinitionDecorator::class, $requestMatcherFirst);
         $this->assertEquals('/api/*', $requestMatcherFirst->getArgument(0));
 
         // Second zone
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[1][0]);
         $requestMatcherSecondId = (string) $addRequestMatcherCalls[1][1][0];
         $requestMatcherSecond = $this->container->getDefinition($requestMatcherSecondId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherSecond);
+        $this->assertInstanceOf(DefinitionDecorator::class, $requestMatcherSecond);
         $this->assertEquals('/^second', $requestMatcherSecond->getArgument(0));
         $this->assertEquals(array('127.0.0.1'), $requestMatcherSecond->getArgument(3));
     }

--- a/Tests/EventListener/BodyListenerTest.php
+++ b/Tests/EventListener/BodyListenerTest.php
@@ -12,11 +12,15 @@
 namespace FOS\RestBundle\Tests\EventListener;
 
 use FOS\RestBundle\Decoder\ContainerDecoderProvider;
+use FOS\RestBundle\Decoder\DecoderInterface;
+use FOS\RestBundle\Decoder\DecoderProviderInterface;
 use FOS\RestBundle\EventListener\BodyListener;
 use FOS\RestBundle\FOSRestBundle;
+use FOS\RestBundle\Normalizer\ArrayNormalizerInterface;
 use FOS\RestBundle\Normalizer\Exception\NormalizationException;
 use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
  * Request listener test.
@@ -38,7 +42,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelRequest($decode, Request $request, $method, $expectedParameters, $contentType = null, $throwExceptionOnUnsupportedContentType = false)
     {
-        $decoder = $this->getMockBuilder('FOS\RestBundle\Decoder\DecoderInterface')->disableOriginalConstructor()->getMock();
+        $decoder = $this->getMockBuilder(DecoderInterface::class)->disableOriginalConstructor()->getMock();
         $decoder->expects($this->any())
             ->method('decode')
             ->will($this->returnValue($request->getContent()));
@@ -64,7 +68,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
             $request->headers = new HeaderBag(['Content-Type' => $contentType]);
         }
 
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+        $event = $this->getMockBuilder(GetResponseEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
         $event->expects($this->once())
@@ -95,19 +99,19 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
         $data = ['foo_bar' => 'foo_bar'];
         $normalizedData = ['fooBar' => 'foo_bar'];
 
-        $decoder = $this->getMock('FOS\RestBundle\Decoder\DecoderInterface');
+        $decoder = $this->getMock(DecoderInterface::class);
         $decoder
             ->expects($this->never())
             ->method('decode')
             ->will($this->returnValue($data));
 
-        $decoderProvider = $this->getMock('FOS\RestBundle\Decoder\DecoderProviderInterface');
+        $decoderProvider = $this->getMock(DecoderProviderInterface::class);
         $decoderProvider
             ->expects($this->never())
             ->method('getDecoder')
             ->will($this->returnValue($decoder));
 
-        $normalizer = $this->getMock('FOS\RestBundle\Normalizer\ArrayNormalizerInterface');
+        $normalizer = $this->getMock(ArrayNormalizerInterface::class);
         $normalizer
             ->expects($this->never())
             ->method('normalize')
@@ -118,7 +122,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set(FOSRestBundle::ZONE_ATTRIBUTE, false);
         $request->setMethod('POST');
 
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+        $event = $this->getMockBuilder(GetResponseEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -137,13 +141,13 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
         $data = ['foo_bar' => 'foo_bar'];
         $normalizedData = ['fooBar' => 'foo_bar'];
 
-        $decoder = $this->getMock('FOS\RestBundle\Decoder\DecoderInterface');
+        $decoder = $this->getMock(DecoderInterface::class);
         $decoder
             ->expects($this->any())
             ->method('decode')
             ->will($this->returnValue($data));
 
-        $decoderProvider = $this->getMock('FOS\RestBundle\Decoder\DecoderProviderInterface');
+        $decoderProvider = $this->getMock(DecoderProviderInterface::class);
         $decoderProvider
             ->expects($this->any())
             ->method('getDecoder')
@@ -154,7 +158,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
             ->method('supports')
             ->will($this->returnValue(true));
 
-        $normalizer = $this->getMock('FOS\RestBundle\Normalizer\ArrayNormalizerInterface');
+        $normalizer = $this->getMock(ArrayNormalizerInterface::class);
         $normalizer
             ->expects($this->once())
             ->method('normalize')
@@ -164,7 +168,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
         $request = new Request([], [], [], [], [], [], 'foo');
         $request->setMethod('POST');
 
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+        $event = $this->getMockBuilder(GetResponseEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -185,9 +189,9 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = ['foo_bar' => 'foo_bar'];
         $normalizedData = ['fooBar' => 'foo_bar'];
-        $decoderProvider = $this->getMock('FOS\RestBundle\Decoder\DecoderProviderInterface');
+        $decoderProvider = $this->getMock(DecoderProviderInterface::class);
 
-        $normalizer = $this->getMock('FOS\RestBundle\Normalizer\ArrayNormalizerInterface');
+        $normalizer = $this->getMock(ArrayNormalizerInterface::class);
 
         if ($mustBeNormalized) {
             $normalizer
@@ -205,7 +209,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
         $request->headers->set('Content-Type', $contentType);
         $request->setMethod($method);
 
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+        $event = $this->getMockBuilder(GetResponseEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -243,13 +247,13 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelRequestNormalizationException()
     {
-        $decoder = $this->getMock('FOS\RestBundle\Decoder\DecoderInterface');
+        $decoder = $this->getMock(DecoderInterface::class);
         $decoder
             ->expects($this->any())
             ->method('decode')
             ->will($this->returnValue([]));
 
-        $decoderProvider = $this->getMock('FOS\RestBundle\Decoder\DecoderProviderInterface');
+        $decoderProvider = $this->getMock(DecoderProviderInterface::class);
         $decoderProvider
             ->expects($this->any())
             ->method('getDecoder')
@@ -260,7 +264,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
             ->method('supports')
             ->will($this->returnValue(true));
 
-        $normalizer = $this->getMock('FOS\RestBundle\Normalizer\ArrayNormalizerInterface');
+        $normalizer = $this->getMock(ArrayNormalizerInterface::class);
         $normalizer
             ->expects($this->once())
             ->method('normalize')
@@ -269,7 +273,7 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
         $request = new Request([], [], [], [], [], [], 'foo');
         $request->setMethod('POST');
 
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+        $event = $this->getMockBuilder(GetResponseEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Tests/FOSRestBundleTest.php
+++ b/Tests/FOSRestBundleTest.php
@@ -12,6 +12,8 @@
 namespace FOS\RestBundle\Tests;
 
 use FOS\RestBundle\FOSRestBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 /**
  * FOSRestBundle test.
@@ -22,12 +24,12 @@ class FOSRestBundleTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuild()
     {
-        $container = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
+        $container = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['addCompilerPass'])
             ->getMock();
         $container->expects($this->exactly(5))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf('\Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface'));
+            ->with($this->isInstanceOf(CompilerPassInterface::class));
 
         $bundle = new FOSRestBundle();
         $bundle->build($container);

--- a/Tests/Request/ParamFetcherTest.php
+++ b/Tests/Request/ParamFetcherTest.php
@@ -11,8 +11,14 @@
 
 namespace FOS\RestBundle\Tests\Request;
 
-use Symfony\Component\HttpFoundation\Request;
 use Doctrine\Common\Util\ClassUtils;
+use FOS\RestBundle\Request\ParamFetcher;
+use FOS\RestBundle\Request\ParamReaderInterface;
+use FOS\RestBundle\Validator\ViolationFormatterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * ParamFetcher test.
@@ -28,22 +34,22 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
     private $controller;
 
     /**
-     * @var \FOS\RestBundle\Request\ParamReaderInterface
+     * @var ParamReaderInterface
      */
     private $paramReader;
 
     /**
-     * @var ParamFetcherTest|\Symfony\Component\Validator\ValidatorInterface
+     * @var ParamFetcherTest|ValidatorInterface
      */
     private $validator;
 
     /**
-     * @var \FOS\RestBundle\Util\ViolationFormatterInterface
+     * @var ViolationFormatterInterface
      */
     private $violationFormatter;
 
     /**
-     * @var \Symfony\Component\HttpFoundation\RequestStack
+     * @var RequestStack
      */
     private $requestStack;
 
@@ -55,20 +61,20 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $this->controller = [new \stdClass(), 'fooAction'];
 
         $this->params = [];
-        $this->paramReader = $this->getMock('FOS\RestBundle\Request\ParamReaderInterface');
+        $this->paramReader = $this->getMock(ParamReaderInterface::class);
 
-        $this->validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $this->validator = $this->getMock(ValidatorInterface::class);
 
-        $this->violationFormatter = $this->getMock('FOS\RestBundle\Validator\ViolationFormatterInterface');
+        $this->violationFormatter = $this->getMock(ViolationFormatterInterface::class);
 
         $this->request = new Request();
-        $this->requestStack = $this->getMock('Symfony\Component\HttpFoundation\RequestStack', array());
+        $this->requestStack = $this->getMock(RequestStack::class, array());
         $this->requestStack
             ->expects($this->any())
             ->method('getCurrentRequest')
             ->willReturn($this->request);
 
-        $this->paramFetcherBuilder = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher');
+        $this->paramFetcherBuilder = $this->getMockBuilder(ParamFetcher::class);
         $this->paramFetcherBuilder
             ->setConstructorArgs(array(
                 $this->paramReader,
@@ -143,7 +149,7 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
 
     public function testReturnBeforeGettingConstraints()
     {
-        $param = $this->getMock('FOS\RestBundle\Controller\Annotations\ParamInterface');
+        $param = $this->getMock(\FOS\RestBundle\Controller\Annotations\ParamInterface::class);
         $param
             ->expects($this->once())
             ->method('getDefault')
@@ -209,7 +215,7 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $param = $this->createMockedParam('foo', 'default', [], false, null, ['constraint']);
         list($fetcher, $method) = $this->getFetcherToCheckValidation($param);
 
-        $errors = $this->getMock('Symfony\Component\Validator\ConstraintViolationListInterface');
+        $errors = $this->getMock(ConstraintViolationListInterface::class);
         $errors
             ->expects($this->once())
             ->method('count')
@@ -233,7 +239,7 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $param = $this->createMockedParam('foo', null, [], false, null, ['constraint']);
         list($fetcher, $method) = $this->getFetcherToCheckValidation($param);
 
-        $errors = $this->getMock('Symfony\Component\Validator\ConstraintViolationListInterface');
+        $errors = $this->getMock(ConstraintViolationListInterface::class);
         $errors
             ->expects($this->once())
             ->method('count')

--- a/Tests/Request/ParamReaderTest.php
+++ b/Tests/Request/ParamReaderTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\Tests\Request;
 
+use FOS\RestBundle\Controller\Annotations\ParamInterface;
 use FOS\RestBundle\Controller\Annotations\NamePrefix;
 use FOS\RestBundle\Request\ParamReader;
 use Doctrine\Common\Annotations\AnnotationReader;
@@ -30,7 +31,7 @@ class ParamReaderTest extends \PHPUnit_Framework_TestCase
      */
     public function setup()
     {
-        $annotationReader = $this->getMock('Doctrine\Common\Annotations\Reader');
+        $annotationReader = $this->getMock(AnnotationReader::class, array());
 
         $methodAnnotations = [];
         $foo = $this->createMockedParam();
@@ -90,7 +91,7 @@ class ParamReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(4, $annotations);
 
         foreach ($annotations as $name => $annotation) {
-            $this->assertInstanceOf('FOS\RestBundle\Controller\Annotations\ParamInterface', $annotation);
+            $this->assertInstanceOf(ParamInterface::class, $annotation);
             $this->assertEquals($annotation->getName(), $name);
         }
     }
@@ -147,6 +148,6 @@ class ParamReaderTest extends \PHPUnit_Framework_TestCase
 
     protected function createMockedParam()
     {
-        return $this->getMock('FOS\RestBundle\Controller\Annotations\ParamInterface');
+        return $this->getMock(ParamInterface::class);
     }
 }

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\Tests\Request;
 
+use FOS\RestBundle\Context\ContextInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -56,7 +57,7 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
 
         $getterMethod = new \ReflectionMethod($converter, 'getDeserializationContext');
         $getterMethod->setAccessible(true);
-        $this->assertInstanceOf('FOS\RestBundle\Context\ContextInterface', $getterMethod->invoke($converter, $this->createRequest()));
+        $this->assertInstanceOf(ContextInterface::class, $getterMethod->invoke($converter, $this->createRequest()));
     }
 
     public function testContextMergeDuringExecution()
@@ -77,7 +78,7 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('configureDeserializationContext')
             ->with($this->anything(), ['groups' => ['foo', 'bar'], 'foobar' => 'foo', 'version' => 'fooversion'])
-            ->willReturn($this->getMock('FOS\RestBundle\Context\ContextInterface'));
+            ->willReturn($this->getMock(ContextInterface::class));
         $this->launchExecution($converter, null, $configuration);
     }
 
@@ -163,11 +164,6 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
 
     public function testValidatorParameters()
     {
-        if (!interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'skipping testValidatorParameters due to an incompatible version of the Symfony validator component'
-            );
-        }
         $this->serializer
              ->expects($this->once())
              ->method('deserialize')

--- a/Tests/Routing/Loader/LoaderTest.php
+++ b/Tests/Routing/Loader/LoaderTest.php
@@ -17,6 +17,7 @@ use FOS\RestBundle\Request\ParamReader;
 use FOS\RestBundle\Routing\Loader\Reader\RestActionReader;
 use FOS\RestBundle\Routing\Loader\Reader\RestControllerReader;
 use FOS\RestBundle\Routing\Loader\RestRouteLoader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -27,7 +28,7 @@ use Symfony\Component\Yaml\Yaml;
 abstract class LoaderTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerBuilder
+     * @var ContainerBuilder
      */
     protected $containerMock;
 
@@ -59,7 +60,7 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
     {
         // This check allows to override the container
         if ($this->containerMock === null) {
-            $this->containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            $this->containerMock = $this->getMockBuilder(ContainerBuilder::class)
                 ->disableOriginalConstructor()
                 ->setMethods(['get', 'has'])
                 ->getMock();

--- a/Tests/Validator/ViolationFormatterTest.php
+++ b/Tests/Validator/ViolationFormatterTest.php
@@ -26,7 +26,7 @@ class ViolationFormatterTest extends \PHPUnit_Framework_TestCase
 {
     public function testViolationIsWellFormatted()
     {
-        $violation = $this->getMockBuilder('Symfony\Component\Validator\ConstraintViolation')
+        $violation = $this->getMockBuilder(ConstraintViolation::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Tests/View/JsonpHandlerTest.php
+++ b/Tests/View/JsonpHandlerTest.php
@@ -11,9 +11,11 @@
 
 namespace FOS\RestBundle\Tests\View;
 
+use FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface;
 use FOS\RestBundle\View\JsonpHandler;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -34,9 +36,9 @@ class JsonpHandlerTest extends \PHPUnit_Framework_TestCase
         $viewHandler = new ViewHandler(['jsonp' => false]);
         $jsonpHandler = new JsonpHandler(key($query));
         $viewHandler->registerHandler('jsonp', [$jsonpHandler, 'createResponse']);
-        $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
+        $viewHandler->setSerializationContextAdapter($this->getMock(SerializationContextAdapterInterface::class));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get', 'getParameter']);
+        $container = $this->getMock(ContainerInterface::class);
         $serializer = $this->getMock('stdClass', ['serialize', 'setVersion']);
         $serializer
             ->expects($this->once())
@@ -86,9 +88,9 @@ class JsonpHandlerTest extends \PHPUnit_Framework_TestCase
         $viewHandler = new ViewHandler(['jsonp' => false]);
         $jsonpHandler = new JsonpHandler('callback');
         $viewHandler->registerHandler('jsonp', [$jsonpHandler, 'createResponse']);
-        $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
+        $viewHandler->setSerializationContextAdapter($this->getMock(SerializationContextAdapterInterface::class));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get', 'getParameter']);
+        $container = $this->getMock(ContainerInterface::class);
         $serializer = $this->getMock('stdClass', ['serialize', 'setVersion']);
         $serializer
             ->expects($this->once())

--- a/Tests/View/ViewHandlerTest.php
+++ b/Tests/View/ViewHandlerTest.php
@@ -77,7 +77,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetStatusCode($expected, $data, $isSubmitted, $isValid, $isSubmittedCalled, $isValidCalled, $noContentCode)
     {
-        $reflectionMethod = new \ReflectionMethod('FOS\RestBundle\View\ViewHandler', 'getStatusCode');
+        $reflectionMethod = new \ReflectionMethod(ViewHandler::class, 'getStatusCode');
         $reflectionMethod->setAccessible(true);
 
         $form = $this->getMock('Symfony\Component\Form\Form', ['isSubmitted', 'isValid'], [], '', false);
@@ -140,7 +140,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
     public function testCreateResponseWithLocationAndData()
     {
         $testValue = ['naviter' => 'oudie'];
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
         $this->setupMockedSerializer($container, $testValue);
 
         $viewHandler = new ViewHandler(['json' => false]);
@@ -159,7 +159,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateResponseWithRoute()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
 
         $doRoute = function ($name, $parameters) {
             $route = '/';
@@ -244,7 +244,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         $viewHandler = new ViewHandler(['html' => true, 'json' => false]);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
         if ('html' === $format) {
             $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\PhpEngine')
                 ->setMethods(['render'])
@@ -343,7 +343,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
     public function testSerializeNull($expected, $serializeNull)
     {
         $viewHandler = new ViewHandler(['json' => false], 404, 200, $serializeNull);
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
 
         $viewHandler->setContainer($container);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
@@ -394,7 +394,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         $viewHandler = new ViewHandler(['json' => false], 404, 200);
         $viewHandler->setSerializeNullStrategy($serializeNull);
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
 
         $viewHandler->setContainer($container);
         $contextMethod = new \ReflectionMethod($viewHandler, 'getSerializationContext');
@@ -449,7 +449,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
         $container
             ->expects($this->exactly(2))
             ->method('get')
@@ -470,7 +470,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
         $container
             ->expects($this->once())
             ->method('get')
@@ -494,7 +494,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
         $container
             ->expects($this->once())
             ->method('get')
@@ -642,7 +642,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
             ->build();
         $adapter = $this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container = $this->getMock(Container::class, ['get']);
         $container
             ->expects($this->any())
             ->method('get')
@@ -675,7 +675,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
             })
             ->build();
 
-        $container2 = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
+        $container2 = $this->getMock(Container::class, ['get']);
         $container2
             ->expects($this->any())
             ->method('get')

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
 
     "require": {
-        "php":                            ">=5.4.0",
+        "php":                            ">=5.5.9",
         "psr/log":                        "^1.0",
         "symfony/framework-bundle":       "^2.7|^3.0",
         "symfony/routing":                "^2.7|^3.0",


### PR DESCRIPTION
This PR change the minimum version of php required to use FOSRestBundle.
It also updates many class paths to the new syntax sugar ``Foo::class``