### PR TITLE
ignore any number of leading underscores when converting from snake case to camel case

### DIFF
--- a/Normalizer/CamelKeysNormalizer.php
+++ b/Normalizer/CamelKeysNormalizer.php
@@ -69,7 +69,7 @@ class CamelKeysNormalizer implements ArrayNormalizerInterface
      *
      * @return string
      */
-    private function normalizeString($string)
+    protected function normalizeString($string)
     {
         if (false === strpos($string, '_')) {
             return $string;

--- a/Normalizer/CamelKeysNormalizer.php
+++ b/Normalizer/CamelKeysNormalizer.php
@@ -75,8 +75,17 @@ class CamelKeysNormalizer implements ArrayNormalizerInterface
             return $string;
         }
 
-        return preg_replace_callback('/_([a-zA-Z0-9])/', function ($matches) {
+        if (preg_match('/^(_+)(.*)/', $string, $matches)) {
+            $underscorePrefix = $matches[1];
+            $string = $matches[2];
+        } else {
+            $underscorePrefix = '';
+        }
+
+        $string = preg_replace_callback('/_([a-zA-Z0-9])/', function ($matches) {
             return strtoupper($matches[1]);
         }, $string);
+
+        return $underscorePrefix.$string;
     }
 }

--- a/Normalizer/CamelKeysNormalizerWithLeadingUnderscore.php
+++ b/Normalizer/CamelKeysNormalizerWithLeadingUnderscore.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Normalizer;
+
+/**
+ * Normalizes the array by changing its keys from underscore to camel case, while
+ * leaving leading underscores unchanged.
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class CamelKeysNormalizerWithLeadingUnderscore extends CamelKeysNormalizer
+{
+    /**
+     * Normalizes a string while leaving leading underscores unchanged.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    protected function normalizeString($string)
+    {
+        if (false === strpos($string, '_')) {
+            return $string;
+        }
+
+        $offset = strspn($string, '_');
+        if ($offset) {
+            $underscorePrefix = substr($string, 0, $offset);
+            $string = substr($string, $offset);
+        } else {
+            $underscorePrefix = '';
+        }
+
+        return $underscorePrefix.parent::normalizeString($string);
+    }
+}

--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -19,6 +19,8 @@
 
         <service id="fos_rest.normalizer.camel_keys" class="%fos_rest.normalizer.camel_keys.class%" />
 
+        <service id="fos_rest.normalizer.camel_keys_with_leading_underscore" class="FOS\RestBundle\Normalizer\CamelKeysNormalizerWithLeadingUnderscore" />
+
         <service id="fos_rest.decoder.json" class="%fos_rest.decoder.json.class%" />
 
         <service id="fos_rest.decoder.jsontoform" class="%fos_rest.decoder.jsontoform.class%" />

--- a/Resources/doc/body_listener.rst
+++ b/Resources/doc/body_listener.rst
@@ -56,6 +56,11 @@ to camel cased ones, you can use the ``camel_keys`` array normalizer:
         body_listener:
             array_normalizer: fos_rest.normalizer.camel_keys
 
+.. note::
+
+    If you want to ignore leading underscores, for example in ``_username`` you can
+    instead use the ``fos_rest.normalizer.camel_keys_with_leading_underscore`` service.
+
 Sometimes an array contains a key, which once normalized, will override an
 existing array key. For example ``foo_bar`` and ``foo_Bar`` will both lead to
 ``fooBar``. If the normalizer receives this data, the listener will throw a

--- a/Tests/Normalizer/CamelKeysNormalizerTest.php
+++ b/Tests/Normalizer/CamelKeysNormalizerTest.php
@@ -50,6 +50,8 @@ class CamelKeysNormalizerTest extends \PHPUnit_Framework_TestCase
                     'foo1ar' => array('foo_bar'),
                 ),
             ),
+            // ignore leading underscores
+            array(array('__username' => 'foo', '_password' => 'bar', '_foo_bar' => 'foobar'), array('__username' => 'foo', '_password' => 'bar', '_fooBar' => 'foobar')),
         );
     }
 }

--- a/Tests/Normalizer/CamelKeysNormalizerTest.php
+++ b/Tests/Normalizer/CamelKeysNormalizerTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\Normalizer;
 
 use FOS\RestBundle\Normalizer\CamelKeysNormalizer;
+use FOS\RestBundle\Normalizer\CamelKeysNormalizerWithLeadingUnderscore;
 
 class CamelKeysNormalizerTest extends \PHPUnit_Framework_TestCase
 {
@@ -50,8 +51,23 @@ class CamelKeysNormalizerTest extends \PHPUnit_Framework_TestCase
                     'foo1ar' => array('foo_bar'),
                 ),
             ),
-            // ignore leading underscores
-            array(array('__username' => 'foo', '_password' => 'bar', '_foo_bar' => 'foobar'), array('__username' => 'foo', '_password' => 'bar', '_fooBar' => 'foobar')),
         );
+    }
+
+    /**
+     * @dataProvider normalizeProvider
+     */
+    public function testNormalizeLeadingUnderscore(array $array, array $expected)
+    {
+        $normalizer = new CamelKeysNormalizerWithLeadingUnderscore();
+        $this->assertEquals($expected, $normalizer->normalize($array));
+    }
+
+    public function normalizeProviderLeadingUnderscore()
+    {
+        $array = $this->normalizeProvider();
+        $array[] = array(array('__username' => 'foo', '_password' => 'bar', '_foo_bar' => 'foobar'), array('__username' => 'foo', '_password' => 'bar', '_fooBar' => 'foobar'));
+
+        return $array;
     }
 }


### PR DESCRIPTION
ie. leave '_username' unchanged

fixes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1009