### PR TITLE
Only touch fos_rest.converter.request_body when body_converter is enabled

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -377,12 +377,18 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
     private function loadSerializer(array $config, ContainerBuilder $container)
     {
         if (!empty($config['serializer']['version'])) {
-            $container->getDefinition('fos_rest.converter.request_body')->replaceArgument(2, $config['serializer']['version']);
+            if (!empty($config['body_converter']['enabled'])) {
+                $container->getDefinition('fos_rest.converter.request_body')->replaceArgument(2, $config['serializer']['version']);
+            }
+            
             $container->getDefinition('fos_rest.view_handler.default')->addMethodCall('setExclusionStrategyVersion', array($config['serializer']['version']));
         }
 
         if (!empty($config['serializer']['groups'])) {
-            $container->getDefinition('fos_rest.converter.request_body')->replaceArgument(1, $config['serializer']['groups']);
+            if (!empty($config['body_converter']['enabled'])) {
+                $container->getDefinition('fos_rest.converter.request_body')->replaceArgument(1, $config['serializer']['groups']);
+            }
+
             $container->getDefinition('fos_rest.view_handler.default')->addMethodCall('setExclusionStrategyGroups', array($config['serializer']['groups']));
         }
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -309,6 +309,18 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load($config, $this->container);
         $this->assertFalse($this->container->has('fos_rest.validator'));
     }
+    
+    public function testBodyConvertorDisabledAndSerializerVersionGiven()
+    {
+        $config = ['fos_rest' => ['body_converter' => ['enabled' => false], 'serializer' => ['version' => '1.0']]];
+        $this->extension->load($config, $this->container);
+    }
+
+    public function testBodyConvertorDisabledAndSerializerGroupsGiven()
+    {
+        $config = ['fos_rest' => ['body_converter' => ['enabled' => false], 'serializer' => ['groups' => ['Default']]]];
+        $this->extension->load($config, $this->container);
+    }
 
     /**
      * Test that extension loads properly.


### PR DESCRIPTION
In my setup I have `body_converter` disabled but `serializer` enabled. 

```yml
fos_rest:
    serializer:
        groups: ['Default']
```

This would throw:
```
 [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]  
 The service definition "fos_rest.converter.request_body" does not exist.  
```

This PR fixes that.