### PR TITLE
Change docblock return value to 'static'

### DIFF
--- a/View/View.php
+++ b/View/View.php
@@ -51,7 +51,7 @@ class View
      * @param int   $statusCode
      * @param array $headers
      *
-     * @return \FOS\RestBundle\View\View
+     * @return static
      */
     public static function create($data = null, $statusCode = null, array $headers = array())
     {
@@ -66,7 +66,7 @@ class View
      * @param int    $statusCode
      * @param array  $headers
      *
-     * @return View
+     * @return static
      */
     public static function createRedirect($url, $statusCode = Codes::HTTP_FOUND, array $headers = array())
     {
@@ -85,7 +85,7 @@ class View
      * @param int    $statusCode
      * @param array  $headers
      *
-     * @return View
+     * @return static
      */
     public static function createRouteRedirect(
         $route,


### PR DESCRIPTION
When creating a new instance using the 'static' keyword but the
docblock uses the class name, autocomplete can't figure out the late
static binding. Changing this to 'static' fixes this.