### PR TITLE
Fix a bug in FOSRestExtension

### DIFF
--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -310,6 +310,18 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->container->has('fos_rest.validator'));
     }
 
+    public function testBodyConvertorDisabledAndSerializerVersionGiven()
+    {
+        $config = ['fos_rest' => ['body_converter' => ['enabled' => false], 'serializer' => ['version' => '1.0']]];
+        $this->extension->load($config, $this->container);
+    }
+
+    public function testBodyConvertorDisabledAndSerializerGroupsGiven()
+    {
+        $config = ['fos_rest' => ['body_converter' => ['enabled' => false], 'serializer' => ['groups' => ['Default']]]];
+        $this->extension->load($config, $this->container);
+    }
+
     /**
      * Test that extension loads properly.
      */


### PR DESCRIPTION
``fos_rest.converter.request_body`` is always touched even if it doesn't exist in ``loadSerializer``.

Fix #1268 