### PR TITLE
stop injecting the container when possible

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -11,14 +11,14 @@
 
 namespace FOS\RestBundle\Controller;
 
+use FOS\RestBundle\Negotiation\FormatNegotiator;
 use FOS\RestBundle\Util\ExceptionWrapper;
 use FOS\RestBundle\Util\StopFormatListenerException;
 use FOS\RestBundle\View\ExceptionWrapperHandlerInterface;
 use FOS\RestBundle\View\View;
-use FOS\RestBundle\View\ViewHandler;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Debug\Exception\FlattenException;
@@ -27,9 +27,33 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 /**
  * Custom ExceptionController that uses the view layer and supports HTTP response status code mapping.
  */
-class ExceptionController implements ContainerAwareInterface
+class ExceptionController
 {
-    use ContainerAwareTrait;
+    private $exceptionWrapperHandler;
+    private $formatNegotiator;
+    private $viewHandler;
+    private $templating;
+    private $exceptionCodes;
+    private $exceptionMessages;
+    private $showException;
+
+    public function __construct(
+        ExceptionWrapperHandlerInterface $exceptionWrapperHandler,
+        FormatNegotiator $formatNegotiator,
+        ViewHandlerInterface $viewHandler,
+        EngineInterface $templating,
+        array $exceptionCodes,
+        array $exceptionMessages,
+        $showException
+    ) {
+        $this->exceptionWrapperHandler = $exceptionWrapperHandler;
+        $this->formatNegotiator = $formatNegotiator;
+        $this->viewHandler = $viewHandler;
+        $this->templating = $templating;
+        $this->exceptionCodes = $exceptionCodes;
+        $this->exceptionMessages = $exceptionMessages;
+        $this->showException = $showException;
+    }
 
     /**
      * Creates a new ExceptionWrapper instance that can be overwritten by a custom
@@ -41,10 +65,7 @@ class ExceptionController implements ContainerAwareInterface
      */
     protected function createExceptionWrapper(array $parameters)
     {
-        /** @var ExceptionWrapperHandlerInterface $exceptionWrapperHandler */
-        $exceptionWrapperHandler = $this->container->get('fos_rest.exception_handler');
-
-        return $exceptionWrapperHandler->wrap($parameters);
+        return $this->exceptionWrapperHandler->wrap($parameters);
     }
 
     /**
@@ -76,23 +97,22 @@ class ExceptionController implements ContainerAwareInterface
             $request->headers->get('X-Php-Ob-Level', -1)
         );
         $code = $this->getStatusCode($exception);
-        /** @var ViewHandler $viewHandler */
-        $viewHandler = $this->container->get('fos_rest.view_handler');
-        $parameters = $this->getParameters($viewHandler, $currentContent, $code, $exception, $logger, $format);
-        $showException = $request->attributes->get('showException', $this->container->get('kernel')->isDebug());
+        $parameters = $this->getParameters($this->viewHandler, $currentContent, $code, $exception, $logger, $format);
+        $showException = $request->attributes->get('showException', $this->showException);
+
         try {
-            if (!$viewHandler->isFormatTemplating($format)) {
+            if (!$this->viewHandler->isFormatTemplating($format)) {
                 $parameters = $this->createExceptionWrapper($parameters);
             }
 
             $view = View::create($parameters, $code, $exception->getHeaders());
             $view->setFormat($format);
 
-            if ($viewHandler->isFormatTemplating($format)) {
+            if ($this->viewHandler->isFormatTemplating($format)) {
                 $view->setTemplate($this->findTemplate($request, $format, $code, $showException));
             }
 
-            $response = $viewHandler->handle($view);
+            $response = $this->viewHandler->handle($view);
         } catch (\Exception $e) {
             $message = 'An Exception was thrown while handling: ';
             $message .= $this->getExceptionMessage($exception);
@@ -173,10 +193,9 @@ class ExceptionController implements ContainerAwareInterface
      */
     protected function getExceptionMessage($exception)
     {
-        $exceptionMap = $this->container->getParameter('fos_rest.exception.messages');
-        $showExceptionMessage = $this->isSubclassOf($exception, $exceptionMap);
+        $showExceptionMessage = $this->isSubclassOf($exception, $this->exceptionMessages);
 
-        if ($showExceptionMessage || $this->container->get('kernel')->isDebug()) {
+        if ($showExceptionMessage || $this->showException) {
             return $exception->getMessage();
         }
 
@@ -194,8 +213,7 @@ class ExceptionController implements ContainerAwareInterface
      */
     protected function getStatusCode($exception)
     {
-        $exceptionMap = $this->container->getParameter('fos_rest.exception.codes');
-        $isExceptionMappedToStatusCode = $this->isSubclassOf($exception, $exceptionMap);
+        $isExceptionMappedToStatusCode = $this->isSubclassOf($exception, $this->exceptionCodes);
 
         return $isExceptionMappedToStatusCode ?: $exception->getStatusCode();
     }
@@ -211,8 +229,7 @@ class ExceptionController implements ContainerAwareInterface
     protected function getFormat(Request $request, $format)
     {
         try {
-            $formatNegotiator = $this->container->get('fos_rest.exception_format_negotiator');
-            $accept = $formatNegotiator->getBest('', []);
+            $accept = $this->formatNegotiator->getBest('', []);
             if ($accept) {
                 $format = $request->getFormat($accept->getType());
             }
@@ -230,7 +247,7 @@ class ExceptionController implements ContainerAwareInterface
      * Overwrite it in a custom ExceptionController class to add additionally parameters
      * that should be passed to the view layer.
      *
-     * @param ViewHandler          $viewHandler
+     * @param ViewHandlerInterface $viewHandler
      * @param string               $currentContent
      * @param int                  $code
      * @param FlattenException     $exception
@@ -239,7 +256,7 @@ class ExceptionController implements ContainerAwareInterface
      *
      * @return array
      */
-    protected function getParameters(ViewHandler $viewHandler, $currentContent, $code, $exception, DebugLoggerInterface $logger = null, $format = 'html')
+    protected function getParameters(ViewHandlerInterface $viewHandler, $currentContent, $code, $exception, DebugLoggerInterface $logger = null, $format = 'html')
     {
         $parameters = [
             'status' => 'error',
@@ -283,14 +300,14 @@ class ExceptionController implements ContainerAwareInterface
         // when not in debug, try to find a template for the specific HTTP status code and format
         if (!$showException) {
             $template = new TemplateReference('TwigBundle', 'Exception', $name.$statusCode, $format, 'twig');
-            if ($this->container->get('templating')->exists($template)) {
+            if ($this->templating->exists($template)) {
                 return $template;
             }
         }
 
         // try to find a template for the given format
         $template = new TemplateReference('TwigBundle', 'Exception', $name, $format, 'twig');
-        if ($this->container->get('templating')->exists($template)) {
+        if ($this->templating->exists($template)) {
             return $template;
         }
 

--- a/Decoder/ContainerDecoderProvider.php
+++ b/Decoder/ContainerDecoderProvider.php
@@ -11,27 +11,27 @@
 
 namespace FOS\RestBundle\Decoder;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides encoders through the Symfony2 DIC.
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ContainerDecoderProvider implements DecoderProviderInterface, ContainerAwareInterface
+class ContainerDecoderProvider implements DecoderProviderInterface
 {
-    use ContainerAwareTrait;
-
+    private $container;
     private $decoders;
 
     /**
      * Constructor.
      *
-     * @param array $decoders List of key (format) value (service ids) of decoders
+     * @param ContainerInterface $container The container from which the actual decoders are retrieved
+     * @param array              $decoders  List of key (format) value (service ids) of decoders
      */
-    public function __construct(array $decoders)
+    public function __construct(ContainerInterface $container, array $decoders)
     {
+        $this->container = $container;
         $this->decoders = $decoders;
     }
 

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -145,7 +145,7 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
             $service->replaceArgument(1, $config['body_listener']['throw_exception_on_unsupported_content_type']);
             $service->addMethodCall('setDefaultFormat', array($config['body_listener']['default_format']));
 
-            $container->getDefinition('fos_rest.decoder_provider')->replaceArgument(0, $config['body_listener']['decoders']);
+            $container->getDefinition('fos_rest.decoder_provider')->replaceArgument(1, $config['body_listener']['decoders']);
 
             $arrayNormalizer = $config['body_listener']['array_normalizer'];
 
@@ -284,13 +284,13 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
 
         if ($config['view']['view_response_listener']['enabled']) {
             $loader->load('view_response_listener.xml');
+            $service = $container->getDefinition('fos_rest.view_response_listener');
 
             if (!empty($config['view_response_listener']['service'])) {
-                $service = $container->getDefinition('fos_rest.view_response_listener');
                 $service->clearTag('kernel.event_listener');
             }
 
-            $container->setParameter('fos_rest.view_response_listener.force_view', $config['view']['view_response_listener']['force']);
+            $service->replaceArgument(1, $config['view']['view_response_listener']['force']);
         }
 
         $formats = [];
@@ -308,7 +308,6 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
         $container->getDefinition('fos_rest.routing.loader.yaml_collection')->replaceArgument(3, $formats);
         $container->getDefinition('fos_rest.routing.loader.xml_collection')->replaceArgument(3, $formats);
         $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(4, $formats);
-        $container->getDefinition('fos_rest.view_handler.default')->replaceArgument(0, $formats);
 
         foreach ($config['view']['force_redirects'] as $format => $code) {
             if (true === $code) {
@@ -321,16 +320,17 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
         }
 
         $defaultViewHandler = $container->getDefinition('fos_rest.view_handler.default');
-        $defaultViewHandler->replaceArgument(1, $config['view']['failed_validation']);
+        $defaultViewHandler->replaceArgument(5, $formats);
+        $defaultViewHandler->replaceArgument(6, $config['view']['failed_validation']);
 
         if (!is_numeric($config['view']['empty_content'])) {
             $config['view']['empty_content'] = constant('\Symfony\Component\HttpFoundation\Response::'.$config['view']['empty_content']);
         }
 
-        $defaultViewHandler->replaceArgument(2, $config['view']['empty_content']);
-        $defaultViewHandler->replaceArgument(3, $config['view']['serialize_null']);
-        $defaultViewHandler->replaceArgument(4, $config['view']['force_redirects']);
-        $defaultViewHandler->replaceArgument(5, $config['view']['default_engine']);
+        $defaultViewHandler->replaceArgument(7, $config['view']['empty_content']);
+        $defaultViewHandler->replaceArgument(8, $config['view']['serialize_null']);
+        $defaultViewHandler->replaceArgument(9, $config['view']['force_redirects']);
+        $defaultViewHandler->replaceArgument(10, $config['view']['default_engine']);
     }
 
     private function loadException(array $config, XmlFileLoader $loader, ContainerBuilder $container)
@@ -350,6 +350,10 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
             if ($config['view']['mime_types']['enabled']) {
                 $container->getDefinition('fos_rest.exception_format_negotiator')->replaceArgument(1, $config['view']['mime_types']['formats']);
             }
+
+            $exceptionController = $container->getDefinition('fos_rest.controller.exception');
+            $exceptionController->replaceArgument(4, $config['exception']['codes']);
+            $exceptionController->replaceArgument(5, $config['exception']['messages']);
         }
 
         foreach ($config['exception']['codes'] as $exception => $code) {
@@ -363,9 +367,6 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
         foreach ($config['exception']['messages'] as $exception => $message) {
             $this->testExceptionExists($exception);
         }
-
-        $container->setParameter('fos_rest.exception.codes', $config['exception']['codes']);
-        $container->setParameter('fos_rest.exception.messages', $config['exception']['messages']);
     }
 
     private function loadSerializer(array $config, ContainerBuilder $container)

--- a/EventListener/ParamFetcherListener.php
+++ b/EventListener/ParamFetcherListener.php
@@ -13,7 +13,6 @@ namespace FOS\RestBundle\EventListener;
 
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Request\ParamFetcherInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 /**
@@ -28,18 +27,18 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
  */
 class ParamFetcherListener
 {
-    private $container;
+    private $paramFetcher;
     private $setParamsAsAttributes;
 
     /**
      * Constructor.
      *
-     * @param ContainerInterface $container
-     * @param bool               $setParamsAsAttributes
+     * @param ParamFetcherInterface $paramFetcher
+     * @param bool                  $setParamsAsAttributes
      */
-    public function __construct(ContainerInterface $container, $setParamsAsAttributes = false)
+    public function __construct(ParamFetcherInterface $paramFetcher, $setParamsAsAttributes = false)
     {
-        $this->container = $container;
+        $this->paramFetcher = $paramFetcher;
         $this->setParamsAsAttributes = $setParamsAsAttributes;
     }
 
@@ -58,20 +57,18 @@ class ParamFetcherListener
             return;
         }
 
-        $paramFetcher = $this->container->get('fos_rest.request.param_fetcher');
-
         $controller = $event->getController();
 
         if (is_callable($controller) && method_exists($controller, '__invoke')) {
             $controller = [$controller, '__invoke'];
         }
 
-        $paramFetcher->setController($controller);
+        $this->paramFetcher->setController($controller);
         $attributeName = $this->getAttributeName($controller);
-        $request->attributes->set($attributeName, $paramFetcher);
+        $request->attributes->set($attributeName, $this->paramFetcher);
 
         if ($this->setParamsAsAttributes) {
-            $params = $paramFetcher->all();
+            $params = $this->paramFetcher->all();
             foreach ($params as $name => $param) {
                 if ($request->attributes->has($name) && null !== $request->attributes->get($name)) {
                     $msg = sprintf("ParamFetcher parameter conflicts with a path parameter '$name' for route '%s'", $request->attributes->get('_route'));
@@ -90,7 +87,7 @@ class ParamFetcherListener
      *
      * @return string
      */
-    private function getAttributeName(array $controller)
+    private function getAttributeName(callable $controller)
     {
         list($object, $name) = $controller;
         $method = new \ReflectionMethod($object, $name);

--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -15,9 +15,7 @@ use FOS\RestBundle\Controller\Annotations\ParamInterface;
 use FOS\RestBundle\Util\ResolverTrait;
 use FOS\RestBundle\Validator\Constraints\ResolvableConstraintInterface;
 use FOS\RestBundle\Validator\ViolationFormatterInterface;
-use FOS\RestBundle\Controller\Annotations\Param;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -35,10 +33,11 @@ use Symfony\Component\Validator\ConstraintViolation;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Boris Guéry <guery.b@gmail.com>
  */
-class ParamFetcher implements ParamFetcherInterface, ContainerAwareInterface
+class ParamFetcher implements ParamFetcherInterface
 {
-    use ResolverTrait, ContainerAwareTrait;
+    use ResolverTrait;
 
+    private $container;
     private $parameterBag;
     private $requestStack;
     private $validator;
@@ -51,13 +50,15 @@ class ParamFetcher implements ParamFetcherInterface, ContainerAwareInterface
     /**
      * Initializes fetcher.
      *
+     * @param ContainerInterface          $container
      * @param ParamReaderInterface        $paramReader
      * @param RequestStack                $requestStack
      * @param ValidatorInterface          $validator
      * @param ViolationFormatterInterface $violationFormatter
      */
-    public function __construct(ParamReaderInterface $paramReader, RequestStack $requestStack, ViolationFormatterInterface $violationFormatter, ValidatorInterface $validator = null)
+    public function __construct(ContainerInterface $container, ParamReaderInterface $paramReader, RequestStack $requestStack, ViolationFormatterInterface $violationFormatter, ValidatorInterface $validator = null)
     {
+        $this->container = $container;
         $this->requestStack = $requestStack;
         $this->violationFormatter = $violationFormatter;
         $this->validator = $validator;
@@ -128,13 +129,6 @@ class ParamFetcher implements ParamFetcherInterface, ContainerAwareInterface
      */
     protected function cleanParamWithRequirements(ParamInterface $param, $paramValue, $strict)
     {
-        if (empty($this->container)) {
-            throw new \InvalidArgumentException(
-                'The ParamFetcher has been not initialized correctly. '.
-                'The container for parameter resolution is missing.'
-            );
-        }
-
         $default = $param->getDefault();
         $default = $this->resolveValue($this->container, $default);
 

--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -55,7 +55,6 @@ class RequestBodyParamConverter implements ParamConverterInterface
      * @param object             $serializer
      * @param array|null         $groups                   An array of groups to be used in the serialization context
      * @param string|null        $version                  A version string to be used in the serialization context
-     * @param object             $serializer
      * @param ValidatorInterface $validator
      * @param string|null        $validationErrorsArgument
      *

--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -17,10 +17,8 @@
         <service id="fos_rest.decoder.xml" class="FOS\RestBundle\Decoder\XmlDecoder" />
 
         <service id="fos_rest.decoder_provider" class="FOS\RestBundle\Decoder\ContainerDecoderProvider">
+            <argument type="service" id="service_container" />
             <argument type="collection" /> <!-- decoders -->
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
         </service>
 
         <service id="fos_rest.body_listener" class="FOS\RestBundle\EventListener\BodyListener">

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -13,9 +13,13 @@
         </service>
 
         <service id="fos_rest.controller.exception" class="FOS\RestBundle\Controller\ExceptionController">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
+            <argument type="service" id="fos_rest.exception_handler" />
+            <argument type="service" id="fos_rest.exception_format_negotiator" />
+            <argument type="service" id="fos_rest.view_handler" />
+            <argument type="service" id="templating" />
+            <argument type="collection" /> <!-- exception codes -->
+            <argument type="collection" /> <!-- exception messages -->
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="fos_rest.exception_format_negotiator" class="FOS\RestBundle\Negotiation\FormatNegotiator" >

--- a/Resources/config/param_fetcher_listener.xml
+++ b/Resources/config/param_fetcher_listener.xml
@@ -8,7 +8,7 @@
 
         <service id="fos_rest.param_fetcher_listener" class="FOS\RestBundle\EventListener\ParamFetcherListener">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="5"/>
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="fos_rest.request.param_fetcher"/>
             <argument>false</argument>
         </service>
 

--- a/Resources/config/request.xml
+++ b/Resources/config/request.xml
@@ -7,13 +7,11 @@
     <services>
 
         <service id="fos_rest.request.param_fetcher" class="FOS\RestBundle\Request\ParamFetcher">
+            <argument type="service" id="service_container" />
             <argument type="service" id="fos_rest.request.param_fetcher.reader"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="fos_rest.violation_formatter"/>
             <argument type="service" id="validator" on-invalid="null"/>
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
         </service>
 
         <service id="fos_rest.request.param_fetcher.reader" class="FOS\RestBundle\Request\ParamReader" public="false">

--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -7,6 +7,11 @@
     <services>
 
         <service id="fos_rest.view_handler.default" class="FOS\RestBundle\View\ViewHandler" public="false">
+            <argument type="service" id="fos_rest.router" />
+            <argument type="service" id="fos_rest.serializer" />
+            <argument type="service" id="fos_rest.templating" />
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="fos_rest.exception_handler" />
             <argument type="collection" /> <!-- formats -->
             <argument /> <!-- failed validation -->
             <argument /> <!-- empty content -->
@@ -15,9 +20,6 @@
             <argument /> <!-- default engine -->
             <call method="setSerializationContextAdapter">
                 <argument type="service" id="fos_rest.context.adapter.chain_context_adapter" />
-            </call>
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
             </call>
         </service>
 

--- a/Resources/config/view_response_listener.xml
+++ b/Resources/config/view_response_listener.xml
@@ -9,7 +9,8 @@
         <service id="fos_rest.view_response_listener" class="FOS\RestBundle\EventListener\ViewResponseListener">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-10" />
             <tag name="kernel.event_listener" event="kernel.view" method="onKernelView" priority="100" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="fos_rest.view_handler" />
+            <argument /> <!-- force view -->
         </service>
 
     </services>

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -88,7 +88,7 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertTrue($this->container->hasDefinition('fos_rest.body_listener'));
-        $this->assertEquals($decoders, $this->container->getDefinition('fos_rest.decoder_provider')->getArgument(0));
+        $this->assertEquals($decoders, $this->container->getDefinition('fos_rest.decoder_provider')->getArgument(1));
         $this->assertFalse($this->container->getDefinition('fos_rest.body_listener')->getArgument(1));
         $this->assertCount(2, $this->container->getDefinition('fos_rest.body_listener')->getArguments());
     }
@@ -256,7 +256,7 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load($config, $this->container);
 
         $this->assertTrue($this->container->hasDefinition('fos_rest.view_response_listener'));
-        $this->assertFalse($this->container->getParameter('fos_rest.view_response_listener.force_view'));
+        $this->assertFalse($this->container->getDefinition('fos_rest.view_response_listener')->getArgument(1));
     }
 
     public function testLoadViewResponseListenerForce()
@@ -267,33 +267,33 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load($config, $this->container);
 
         $this->assertTrue($this->container->hasDefinition('fos_rest.view_response_listener'));
-        $this->assertTrue($this->container->getParameter('fos_rest.view_response_listener.force_view'));
+        $this->assertTrue($this->container->getDefinition('fos_rest.view_response_listener')->getArgument(1));
     }
 
     public function testForceEmptyContentDefault()
     {
         $this->extension->load([], $this->container);
-        $this->assertEquals(204, $this->container->getDefinition('fos_rest.view_handler.default')->getArgument(2));
+        $this->assertEquals(204, $this->container->getDefinition('fos_rest.view_handler.default')->getArgument(7));
     }
 
     public function testForceEmptyContentIs200()
     {
         $config = ['fos_rest' => ['view' => ['empty_content' => 200]]];
         $this->extension->load($config, $this->container);
-        $this->assertEquals(200, $this->container->getDefinition('fos_rest.view_handler.default')->getArgument(2));
+        $this->assertEquals(200, $this->container->getDefinition('fos_rest.view_handler.default')->getArgument(7));
     }
 
     public function testViewSerializeNullDefault()
     {
         $this->extension->load([], $this->container);
-        $this->assertFalse($this->container->getDefinition('fos_rest.view_handler.default')->getArgument(3));
+        $this->assertFalse($this->container->getDefinition('fos_rest.view_handler.default')->getArgument(8));
     }
 
     public function testViewSerializeNullIsTrue()
     {
         $config = ['fos_rest' => ['view' => ['serialize_null' => true]]];
         $this->extension->load($config, $this->container);
-        $this->assertTrue($this->container->getDefinition('fos_rest.view_handler.default')->getArgument(3));
+        $this->assertTrue($this->container->getDefinition('fos_rest.view_handler.default')->getArgument(8));
     }
 
     public function testValidatorAliasWhenEnabled()

--- a/Tests/EventListener/BodyListenerTest.php
+++ b/Tests/EventListener/BodyListenerTest.php
@@ -42,24 +42,22 @@ class BodyListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelRequest($decode, Request $request, $method, $expectedParameters, $contentType = null, $throwExceptionOnUnsupportedContentType = false)
     {
-        $decoder = $this->getMockBuilder(DecoderInterface::class)->disableOriginalConstructor()->getMock();
+        $decoder = $this->getMock('FOS\RestBundle\Decoder\DecoderInterface');
         $decoder->expects($this->any())
             ->method('decode')
             ->will($this->returnValue($request->getContent()));
 
-        $decoderProvider = new ContainerDecoderProvider(['json' => 'foo']);
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $decoderProvider = new ContainerDecoderProvider($container, ['json' => 'foo']);
 
         $listener = new BodyListener($decoderProvider, $throwExceptionOnUnsupportedContentType);
 
         if ($decode) {
-            $container = $this->getMock('Symfony\Component\DependencyInjection\Container', ['get']);
             $container
                 ->expects($this->once())
                 ->method('get')
                 ->with('foo')
                 ->will($this->returnValue($decoder));
-
-            $decoderProvider->setContainer($container);
         }
 
         $request->setMethod($method);

--- a/Tests/EventListener/ParamFetcherListenerTest.php
+++ b/Tests/EventListener/ParamFetcherListenerTest.php
@@ -24,11 +24,6 @@ class ParamFetcherListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    private $container;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
     private $paramFetcher;
 
     /**
@@ -191,18 +186,9 @@ class ParamFetcherListenerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerInterface')
-            ->getMock();
-
         $this->paramFetcher = $this->getMockBuilder('FOS\\RestBundle\\Request\\ParamFetcher')
             ->disableOriginalConstructor()
             ->getMock();
-
-        $this->container->expects($this->any())
-            ->method('get')
-            ->with('fos_rest.request.param_fetcher')
-            ->will($this->returnValue($this->paramFetcher));
-
-        $this->paramFetcherListener = new ParamFetcherListener($this->container, true);
+        $this->paramFetcherListener = new ParamFetcherListener($this->paramFetcher, true);
     }
 }

--- a/Tests/EventListener/ViewResponseListenerTest.php
+++ b/Tests/EventListener/ViewResponseListenerTest.php
@@ -14,9 +14,11 @@ namespace FOS\RestBundle\Tests\EventListener;
 use FOS\RestBundle\Controller\Annotations\View as ViewAnnotation;
 use FOS\RestBundle\EventListener\ViewResponseListener;
 use FOS\RestBundle\FOSRestBundle;
+use FOS\RestBundle\View\ExceptionWrapperHandler;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -32,11 +34,6 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
     public $listener;
 
     /**
-     * @var \Symfony\Component\DependencyInjection\Container|\PHPUnit_Framework_MockObject_MockObject
-     */
-    public $container;
-
-    /**
      * @var \FOS\RestBundle\View\ViewHandlerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     public $viewHandler;
@@ -45,6 +42,12 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
      * @var \Symfony\Bundle\FrameworkBundle\Templating\EngineInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     public $templating;
+
+    private $container;
+    private $router;
+    private $serializer;
+    private $requestStack;
+    private $exceptionWrapperHandler;
 
     /**
      * @param Request $request
@@ -88,6 +91,8 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnKernelController()
     {
+        $this->createViewResponseListener();
+
         $request = new Request();
         $request->attributes->set('_view', 'foo');
         $event = $this->getFilterEvent($request);
@@ -99,6 +104,8 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnKernelControllerNoZone()
     {
+        $this->createViewResponseListener();
+
         $request = new Request();
         $request->attributes->set(FOSRestBundle::ZONE_ATTRIBUTE, false);
         $request->attributes->set('_view', 'foo');
@@ -111,6 +118,8 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnKernelControllerNoView()
     {
+        $this->createViewResponseListener();
+
         $request = new Request();
         $event = $this->getFilterEvent($request);
 
@@ -142,78 +151,36 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
             ->method('getFormat')
             ->will($this->onConsecutiveCalls(null, 'html'));
 
-        $this->viewHandler->expects($this->once())
+        $viewHandler = $this->getMock('FOS\RestBundle\View\ViewHandlerInterface');
+        $viewHandler->expects($this->once())
             ->method('handle')
             ->with($this->isInstanceOf('FOS\RestBundle\View\View'), $this->equalTo($request))
             ->will($this->returnValue($response));
-        $this->viewHandler->expects($this->once())
+        $viewHandler->expects($this->once())
             ->method('isFormatTemplating')
             ->with('html')
             ->will($this->returnValue(true));
 
+        $this->listener = new ViewResponseListener($viewHandler, false);
+
         $event = $this->getResponseEvent($request, $view);
         $event->expects($this->once())
             ->method('setResponse');
-
-        $this->container->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('fos_rest.view_handler'))
-            ->will($this->returnValue($this->viewHandler));
 
         $this->listener->onKernelView($event);
     }
 
     public function testOnKernelViewWhenControllerResultIsNotViewObject()
     {
+        $this->createViewResponseListener();
+
         $request = new Request();
 
         $event = $this->getResponseEvent($request, []);
         $event->expects($this->never())
             ->method('setResponse');
 
-        $this->assertEquals([], $this->listener->onKernelView($event));
-    }
-
-    /**
-     * onKernelView falls back to FrameworkExtraBundles' onKernelView
-     * when fos_rest.view_response_listener.force_view is false.
-     */
-    public function testOnKernelViewFallsBackToFrameworkExtraBundle()
-    {
-        $template = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\TemplateReference')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $request = new Request();
-        $request->attributes->set('_template', $template);
-
-        $this->templating->expects($this->any())
-            ->method('renderResponse')
-            ->with($template, [])
-            ->will($this->returnValue(new Response('output')));
-        $this->templating->expects($this->any())
-            ->method('render')
-            ->with($template, [])
-            ->will($this->returnValue('output'));
-
-        $event = $this->getResponseEvent($request, []);
-        $response = null;
-
-        $event->expects($this->once())
-            ->method('setResponse')
-            ->will($this->returnCallback(function ($r) use (&$response) {
-                $response = $r;
-            }));
-
-        $this->container->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('templating'))
-            ->will($this->returnValue($this->templating));
-
-        $this->listener->onKernelView($event);
-
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertSame('output', $response->getContent());
+        $this->assertEquals(null, $this->listener->onKernelView($event));
     }
 
     public static function statusCodeProvider()
@@ -230,26 +197,14 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testStatusCode($annotationCode, $viewCode, $expectedCode)
     {
+        $this->createViewResponseListener(['json' => true]);
+
         $viewAnnotation = new ViewAnnotation([]);
         $viewAnnotation->setStatusCode($annotationCode);
 
         $request = new Request();
         $request->setRequestFormat('json');
         $request->attributes->set('_view', $viewAnnotation);
-
-        $this->viewHandler = new ViewHandler(['json' => true]);
-        $this->viewHandler->setContainer($this->container);
-
-        // This is why we avoid container dependencies!
-        $that = $this;
-        $this->container->expects($this->exactly(2))
-            ->method('get')
-            ->with($this->logicalOr('fos_rest.view_handler', 'fos_rest.templating'))
-            ->will($this->returnCallback(function ($service) use ($that) {
-                return $service === 'fos_rest.view_handler' ?
-                    $that->viewHandler :
-                    $that->templating;
-            }));
 
         $this->templating->expects($this->any())
             ->method('render')
@@ -287,26 +242,14 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSerializerEnableMaxDepthChecks($enableMaxDepthChecks, $expectedMaxDepth)
     {
+        $this->createViewResponseListener(['json' => true]);
+
         $viewAnnotation = new ViewAnnotation([]);
         $viewAnnotation->setSerializerEnableMaxDepthChecks($enableMaxDepthChecks);
 
         $request = new Request();
         $request->setRequestFormat('json');
         $request->attributes->set('_view', $viewAnnotation);
-
-        $this->viewHandler = new ViewHandler(['json' => true]);
-        $this->viewHandler->setContainer($this->container);
-
-        // This is why we avoid container dependencies!
-        $that = $this;
-        $this->container->expects($this->exactly(2))
-            ->method('get')
-            ->with($this->logicalOr('fos_rest.view_handler', 'fos_rest.templating'))
-            ->will($this->returnCallback(function ($service) use ($that) {
-                        return $service === 'fos_rest.view_handler' ?
-                            $that->viewHandler :
-                            $that->templating;
-                    }));
 
         $this->templating->expects($this->any())
             ->method('render')
@@ -338,6 +281,8 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testViewWithNoCopyDefaultVars($createAnnotation, $populateDefaultVars, $shouldCopy)
     {
+        $this->createViewResponseListener(['html' => true]);
+
         $request = new Request();
         $request->attributes->set('_template_default_vars', ['customer']);
         $request->attributes->set('customer', 'A person goes here');
@@ -350,20 +295,6 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
         }
 
         $event = $this->getResponseEvent($request, $view);
-
-        $this->viewHandler = new ViewHandler(['html' => true]);
-        $this->viewHandler->setContainer($this->container);
-
-        // This is why we avoid container dependencies!
-        $that = $this;
-        $this->container->expects($this->exactly(2))
-            ->method('get')
-            ->with($this->logicalOr('fos_rest.view_handler', 'fos_rest.templating'))
-            ->will($this->returnCallback(function ($service) use ($that) {
-                return $service === 'fos_rest.view_handler' ?
-                    $that->viewHandler :
-                    $that->templating;
-            }));
 
         $this->listener->onKernelView($event);
 
@@ -378,9 +309,16 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->viewHandler = $this->getMock('FOS\RestBundle\View\ViewHandlerInterface');
+        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $this->serializer = $this->getMock('JMS\Serializer\SerializerInterface');
         $this->templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->listener = new ViewResponseListener($this->container);
+        $this->requestStack = new RequestStack();
+        $this->exceptionWrapperHandler = new ExceptionWrapperHandler();
+    }
+
+    private function createViewResponseListener($formats = null)
+    {
+        $this->viewHandler = new ViewHandler($this->router, $this->serializer, $this->templating, $this->requestStack, $this->exceptionWrapperHandler, $formats);
+        $this->listener = new ViewResponseListener($this->viewHandler, false);
     }
 }

--- a/Tests/EventListener/ViewResponseListenerTest.php
+++ b/Tests/EventListener/ViewResponseListenerTest.php
@@ -43,7 +43,6 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
      */
     public $templating;
 
-    private $container;
     private $router;
     private $serializer;
     private $requestStack;

--- a/Tests/Request/ParamFetcherTest.php
+++ b/Tests/Request/ParamFetcherTest.php
@@ -77,6 +77,7 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $this->paramFetcherBuilder = $this->getMockBuilder(ParamFetcher::class);
         $this->paramFetcherBuilder
             ->setConstructorArgs(array(
+                $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface'),
                 $this->paramReader,
                 $this->requestStack,
                 $this->violationFormatter,
@@ -179,8 +180,17 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         $param = $this->createMockedParam('none', null, array(), false, null, array('constraint'));
         $this->setParams([$param]);
 
-        $fetcher = new ParamFetcher($this->paramReader, $this->requestStack, $this->violationFormatter, null);
-        $fetcher->setContainer($this->container);
+        list($fetcher, $method) = $this->getFetcherToCheckValidation(
+            $param,
+            array(
+                $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface'),
+                $this->paramReader,
+                $this->requestStack,
+                $this->violationFormatter,
+                null,
+            )
+        );
+
         $fetcher->setController($this->controller);
         $fetcher->get('none', '42');
     }
@@ -256,7 +266,6 @@ class ParamFetcherTest extends \PHPUnit_Framework_TestCase
         }
 
         $fetcher = $this->paramFetcherBuilder->getMock();
-        $fetcher->setContainer($this->container);
 
         $fetcher
             ->expects($this->once())

--- a/Tests/View/JsonpHandlerTest.php
+++ b/Tests/View/JsonpHandlerTest.php
@@ -12,11 +12,12 @@
 namespace FOS\RestBundle\Tests\View;
 
 use FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface;
+use FOS\RestBundle\View\ExceptionWrapperHandler;
 use FOS\RestBundle\View\JsonpHandler;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Jsonp handler test.
@@ -26,6 +27,21 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class JsonpHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    private $router;
+    private $serializer;
+    private $templating;
+    private $requestStack;
+    private $exceptionWrapperHandler;
+
+    protected function setUp()
+    {
+        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $this->serializer = $this->getMock('JMS\Serializer\SerializerInterface');
+        $this->templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $this->requestStack = new RequestStack();
+        $this->exceptionWrapperHandler = new ExceptionWrapperHandler();
+    }
+
     /**
      * @dataProvider handleDataProvider
      */
@@ -33,30 +49,15 @@ class JsonpHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $data = ['foo' => 'bar'];
 
-        $viewHandler = new ViewHandler(['jsonp' => false]);
+        $viewHandler = new ViewHandler($this->router, $this->serializer, $this->templating, $this->requestStack, $this->exceptionWrapperHandler, ['jsonp' => false]);
         $jsonpHandler = new JsonpHandler(key($query));
         $viewHandler->registerHandler('jsonp', [$jsonpHandler, 'createResponse']);
         $viewHandler->setSerializationContextAdapter($this->getMock(SerializationContextAdapterInterface::class));
 
-        $container = $this->getMock(ContainerInterface::class);
-        $serializer = $this->getMock('stdClass', ['serialize', 'setVersion']);
-        $serializer
+        $this->serializer
             ->expects($this->once())
             ->method('serialize')
             ->will($this->returnValue(var_export($data, true)));
-
-        $container
-            ->expects($this->any())
-            ->method('get')
-            ->with($this->equalTo('fos_rest.serializer'))
-            ->will($this->returnValue($serializer));
-
-        $container
-            ->expects($this->any())
-            ->method('getParameter')
-            ->will($this->onConsecutiveCalls('version', '1.0'));
-
-        $viewHandler->setContainer($container);
 
         $view = new View($data);
         $view->setFormat('jsonp');
@@ -85,30 +86,15 @@ class JsonpHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $data = ['foo' => 'bar'];
 
-        $viewHandler = new ViewHandler(['jsonp' => false]);
+        $viewHandler = new ViewHandler($this->router, $this->serializer, $this->templating, $this->requestStack, $this->exceptionWrapperHandler, ['jsonp' => false]);
         $jsonpHandler = new JsonpHandler('callback');
         $viewHandler->registerHandler('jsonp', [$jsonpHandler, 'createResponse']);
         $viewHandler->setSerializationContextAdapter($this->getMock(SerializationContextAdapterInterface::class));
 
-        $container = $this->getMock(ContainerInterface::class);
-        $serializer = $this->getMock('stdClass', ['serialize', 'setVersion']);
-        $serializer
+        $this->serializer
             ->expects($this->once())
             ->method('serialize')
             ->will($this->returnValue(var_export($data, true)));
-
-        $container
-            ->expects($this->any())
-            ->method('get')
-            ->with($this->equalTo('fos_rest.serializer'))
-            ->will($this->returnValue($serializer));
-
-        $container
-            ->expects($this->any())
-            ->method('getParameter')
-            ->will($this->onConsecutiveCalls('version', '1.0'));
-
-        $viewHandler->setContainer($container);
 
         $data = ['foo' => 'bar'];
 

--- a/Tests/View/ViewHandlerTest.php
+++ b/Tests/View/ViewHandlerTest.php
@@ -11,15 +11,10 @@
 
 namespace FOS\RestBundle\Tests\View;
 
-use FOS\RestBundle\Serializer\ExceptionWrapperSerializeHandler;
 use FOS\RestBundle\Util\ExceptionWrapper;
 use FOS\RestBundle\View\ExceptionWrapperHandler;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
-use JMS\Serializer\Handler\FormErrorHandler;
-use JMS\Serializer\Handler\HandlerRegistry;
-use JMS\Serializer\SerializerBuilder;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\FormView;
@@ -34,12 +29,27 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    private $router;
+    private $serializer;
+    private $templating;
+    private $requestStack;
+    private $exceptionWrapperHandler;
+
+    protected function setUp()
+    {
+        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $this->serializer = $this->getMock('JMS\Serializer\SerializerInterface');
+        $this->templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $this->requestStack = new RequestStack();
+        $this->exceptionWrapperHandler = new ExceptionWrapperHandler();
+    }
+
     /**
      * @dataProvider supportsFormatDataProvider
      */
     public function testSupportsFormat($expected, $formats, $customFormatName)
     {
-        $viewHandler = new ViewHandler($formats);
+        $viewHandler = $this->createViewHandler($formats);
         $viewHandler->registerHandler($customFormatName, function () {});
 
         $this->assertEquals($expected, $viewHandler->supports('html'));
@@ -57,7 +67,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testRegisterHandle()
     {
-        $viewHandler = new ViewHandler();
+        $viewHandler = $this->createViewHandler();
         $viewHandler->registerHandler('html', ($callback = function () {}));
         $this->assertAttributeEquals(['html' => $callback], 'customHandlers', $viewHandler);
     }
@@ -67,7 +77,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testRegisterHandleExpectsException()
     {
-        $viewHandler = new ViewHandler();
+        $viewHandler = $this->createViewHandler();
 
         $viewHandler->registerHandler('json', new \stdClass());
     }
@@ -95,7 +105,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         }
         $view = new View($data ? $data : null);
 
-        $viewHandler = new ViewHandler([], $expected, $noContentCode);
+        $viewHandler = $this->createViewHandler([], $expected, $noContentCode);
         $this->assertEquals($expected, $reflectionMethod->invoke($viewHandler, $view, $view->getData()));
     }
 
@@ -116,7 +126,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateResponseWithLocation($expected, $format, $forceRedirects, $noContentCode)
     {
-        $viewHandler = new ViewHandler(['html' => true, 'json' => false, 'xml' => false], Response::HTTP_BAD_REQUEST, $noContentCode, false, $forceRedirects);
+        $viewHandler = $this->createViewHandler(['html' => true, 'json' => false, 'xml' => false], Response::HTTP_BAD_REQUEST, $noContentCode, false, $forceRedirects);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
         $view = new View();
         $view->setLocation('foo');
@@ -140,12 +150,10 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
     public function testCreateResponseWithLocationAndData()
     {
         $testValue = ['naviter' => 'oudie'];
-        $container = $this->getMock(Container::class, ['get']);
-        $this->setupMockedSerializer($container, $testValue);
+        $this->setupMockedSerializer($testValue);
 
-        $viewHandler = new ViewHandler(['json' => false]);
+        $viewHandler = $this->createViewHandler(['json' => false]);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
-        $viewHandler->setContainer($container);
 
         $view = new View();
         $view->setStatusCode(Response::HTTP_CREATED);
@@ -159,8 +167,6 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateResponseWithRoute()
     {
-        $container = $this->getMock(Container::class, ['get']);
-
         $doRoute = function ($name, $parameters) {
             $route = '/';
             foreach ($parameters as $name => $value) {
@@ -170,22 +176,12 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
             return $route;
         };
 
-        $router = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')
-            ->getMock();
-
-        $router
+        $this->router
             ->expects($this->any())
             ->method('generate')
             ->will($this->returnCallback($doRoute));
 
-        $container
-            ->expects($this->any())
-            ->method('get')
-            ->with('fos_rest.router')
-            ->will($this->returnValue($router));
-
-        $viewHandler = new ViewHandler(['json' => false]);
-        $viewHandler->setContainer($container);
+        $viewHandler = $this->createViewHandler(['json' => false]);
 
         $view = new View();
         $view->setStatusCode(Response::HTTP_CREATED);
@@ -198,23 +194,16 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldReturnErrorResponseWhenDataContainsFormAndFormIsNotValid()
     {
-        $container = new Container();
-
-        $serializer = $this->getMock('JMS\Serializer\Serializer', [], [], '', false);
-        $serializer
+        $this->serializer
             ->expects($this->once())
             ->method('serialize')
             ->will($this->returnCallback(function ($data) {
                 return serialize($data);
             }));
 
-        $container->set('fos_rest.serializer', $serializer);
-        $container->set('fos_rest.exception_handler', new ExceptionWrapperHandler());
-
         //test
-        $viewHandler = new ViewHandler(null, $expectedFailedValidationCode = Response::HTTP_I_AM_A_TEAPOT);
+        $viewHandler = $this->createViewHandler(null, $expectedFailedValidationCode = Response::HTTP_I_AM_A_TEAPOT);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
-        $viewHandler->setContainer($container);
 
         $form = $this->getMock('Symfony\\Component\\Form\\Form', ['createView', 'getData', 'isValid', 'isSubmitted'], [], '', false);
         $form
@@ -241,31 +230,17 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateResponseWithoutLocation($format, $expected, $createViewCalls = 0, $formIsValid = false, $form = false)
     {
-        $viewHandler = new ViewHandler(['html' => true, 'json' => false]);
+        $viewHandler = $this->createViewHandler(['html' => true, 'json' => false]);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
 
-        $container = $this->getMock(Container::class, ['get']);
         if ('html' === $format) {
-            $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\PhpEngine')
-                ->setMethods(['render'])
-                ->disableOriginalConstructor()
-                ->getMock();
-
-            $templating
+            $this->templating
                 ->expects($this->once())
                 ->method('render')
                 ->will($this->returnValue(var_export($expected, true)));
-
-            $container
-                ->expects($this->once())
-                ->method('get')
-                ->with('fos_rest.templating')
-                ->will($this->returnValue($templating));
         } else {
-            $this->setupMockedSerializer($container, $expected);
+            $this->setupMockedSerializer($expected);
         }
-
-        $viewHandler->setContainer($container);
 
         if ($form) {
             $data = $this->getMock('Symfony\Component\Form\Form', ['createView', 'getData', 'isValid', 'isSubmitted'], [], '', false);
@@ -294,37 +269,12 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(var_export($expected, true), $response->getContent());
     }
 
-    private function setupMockedSerializer($container, $expected)
+    private function setupMockedSerializer($expected)
     {
-        $serializer = $this->getMockBuilder('JMS\Serializer\Serializer')
-            ->setMethods(['serialize'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $serializer
+        $this->serializer
             ->expects($this->once())
             ->method('serialize')
             ->will($this->returnValue(var_export($expected, true)));
-
-        $container
-            ->expects($this->any())
-            ->method('get')
-            ->with($this->logicalOr(
-                  $this->equalTo('fos_rest.serializer'),
-                  $this->equalTo('fos_rest.exception_handler')
-              ))
-            ->will(
-                  $this->returnCallback(
-                      function ($method) use ($serializer) {
-                            switch ($method) {
-                                case 'fos_rest.serializer':
-                                    return $serializer;
-                                case 'fos_rest.exception_handler':
-                                    return new ExceptionWrapperHandler();
-                            }
-                      }
-                  )
-              );
     }
 
     public static function createResponseWithoutLocationDataProvider()
@@ -342,36 +292,19 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSerializeNull($expected, $serializeNull)
     {
-        $viewHandler = new ViewHandler(['json' => false], 404, 200, $serializeNull);
-        $container = $this->getMock(Container::class, ['get']);
+        $viewHandler = $this->createViewHandler(['json' => false], 404, 200, $serializeNull);
 
-        $viewHandler->setContainer($container);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
 
-        $serializer = $this->getMockBuilder('JMS\Serializer\Serializer')
-            ->setMethods(['serialize', 'setExclusionStrategy'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
         if ($serializeNull) {
-            $serializer
+            $this->serializer
                 ->expects($this->once())
                 ->method('serialize')
                 ->will($this->returnValue(json_encode(null)));
-
-            $container
-                ->expects($this->any())
-                ->method('get')
-                ->with($this->equalTo('fos_rest.serializer'))
-                ->will($this->returnValue($serializer));
         } else {
-            $serializer
+            $this->serializer
                 ->expects($this->never())
                 ->method('serialize');
-
-            $container
-                ->expects($this->never())
-                ->method('get');
         }
 
         $response = $viewHandler->createResponse(new View(), new Request(), 'json');
@@ -391,12 +324,9 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testSerializeNullDataValues($expected, $serializeNull)
     {
-        $viewHandler = new ViewHandler(['json' => false], 404, 200);
+        $viewHandler = $this->createViewHandler(['json' => false], 404, 200);
         $viewHandler->setSerializeNullStrategy($serializeNull);
 
-        $container = $this->getMock(Container::class, ['get']);
-
-        $viewHandler->setContainer($container);
         $contextMethod = new \ReflectionMethod($viewHandler, 'getSerializationContext');
         $contextMethod->setAccessible(true);
 
@@ -418,7 +348,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateResponse($expected, $formats)
     {
-        $viewHandler = new ViewHandler($formats);
+        $viewHandler = $this->createViewHandler($formats);
         $viewHandler->registerHandler('html', function ($handler, $view) { return $view; });
 
         $response = $viewHandler->handle(new View(null, $expected), new Request());
@@ -436,25 +366,14 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandle()
     {
-        $viewHandler = new ViewHandler(['html' => true]);
+        $viewHandler = $this->createViewHandler(['html' => true]);
 
-        $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\PhpEngine')
-            ->setMethods(['render'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $templating
+        $this->templating
             ->expects($this->once())
             ->method('render')
             ->will($this->returnValue(''));
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
-        $container = $this->getMock(Container::class, ['get']);
-        $container
-            ->expects($this->exactly(2))
-            ->method('get')
-            ->will($this->onConsecutiveCalls($requestStack, $templating));
-        $viewHandler->setContainer($container);
+        $this->requestStack->push(new Request());
 
         $data = ['foo' => 'bar'];
 
@@ -464,19 +383,11 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleCustom()
     {
-        $viewHandler = new ViewHandler([]);
+        $viewHandler = $this->createViewHandler([]);
         $viewHandler->registerHandler('html', ($callback = function () { return 'foo'; }));
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
-        $container = $this->getMock(Container::class, ['get']);
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with('request_stack')
-            ->will($this->returnValue($requestStack));
-        $viewHandler->setContainer($container);
+        $this->requestStack->push(new Request());
 
         $data = ['foo' => 'bar'];
 
@@ -489,18 +400,10 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testHandleNotSupported()
     {
-        $viewHandler = new ViewHandler([]);
+        $viewHandler = $this->createViewHandler([]);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
 
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
-        $container = $this->getMock(Container::class, ['get']);
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with('request_stack')
-            ->will($this->returnValue($requestStack));
-        $viewHandler->setContainer($container);
+        $this->requestStack->push(new Request());
 
         $data = ['foo' => 'bar'];
 
@@ -513,7 +416,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testPrepareTemplateParametersWithProvider($viewData, $templateData, $expected)
     {
-        $handler = new ViewHandler(['html' => true]);
+        $handler = $this->createViewHandler(['html' => true]);
         $handler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
 
         $view = new View();
@@ -575,7 +478,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
     public function testConfigurableViewHandlerInterface()
     {
         //test
-        $viewHandler = new ViewHandler();
+        $viewHandler = $this->createViewHandler();
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
         $viewHandler->setExclusionStrategyGroups('bar');
         $viewHandler->setExclusionStrategyVersion('1.1');
@@ -622,7 +525,6 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         $view = new View($exceptionWrapper);
         $view->getSerializationContext()->addGroups(['Custom']);
 
-        $wrapperHandler = new ExceptionWrapperSerializeHandler();
         $translatorMock = $this->getMock(
             'Symfony\\Component\\Translation\\TranslatorInterface',
             ['trans', 'transChoice', 'setLocale', 'getLocale']
@@ -632,73 +534,13 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
             ->method('trans')
             ->will($this->returnArgument(0));
 
-        $formErrorHandler = new FormErrorHandler($translatorMock);
-
-        $serializer = SerializerBuilder::create()
-            ->configureHandlers(function (HandlerRegistry $handlerRegistry) use ($wrapperHandler, $formErrorHandler) {
-                $handlerRegistry->registerSubscribingHandler($wrapperHandler);
-                $handlerRegistry->registerSubscribingHandler($formErrorHandler);
-            })
-            ->build();
-        $adapter = $this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface');
-
-        $container = $this->getMock(Container::class, ['get']);
-        $container
-            ->expects($this->any())
-            ->method('get')
-            ->with($this->logicalOr(
-                  $this->equalTo('fos_rest.serializer'),
-                  $this->equalTo('fos_rest.context.adapter.chain_context_adapter')
-              ))
-            ->will(
-                $this->returnCallback(
-                    function ($method) use ($serializer, $adapter) {
-                          switch ($method) {
-                              case 'fos_rest.serializer':
-                                  return $serializer;
-                              case 'fos_rest.context.adapter.chain_context_adapter':
-                                  return $adapter;
-                          }
-                    }
-                )
-            );
-
-        $viewHandler = new ViewHandler([]);
+        $viewHandler = $this->createViewHandler([]);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
-        $viewHandler->setContainer($container);
 
         $response = $viewHandler->createResponse($view, new Request(), $format);
 
-        $serializer2 = SerializerBuilder::create()
-            ->configureHandlers(function (HandlerRegistry $handlerRegistry) use ($wrapperHandler, $formErrorHandler) {
-                $handlerRegistry->registerSubscribingHandler($formErrorHandler);
-            })
-            ->build();
-
-        $container2 = $this->getMock(Container::class, ['get']);
-        $container2
-            ->expects($this->any())
-            ->method('get')
-            ->with($this->logicalOr(
-                  $this->equalTo('fos_rest.serializer'),
-                  $this->equalTo('fos_rest.context.adapter.chain_context_adapter')
-              ))
-            ->will(
-                $this->returnCallback(
-                    function ($method) use ($serializer2, $adapter) {
-                          switch ($method) {
-                              case 'fos_rest.serializer':
-                                  return $serializer2;
-                              case 'fos_rest.context.adapter.chain_context_adapter':
-                                  return $adapter;
-                          }
-                    }
-                )
-            );
-
-        $viewHandler = new ViewHandler([]);
+        $viewHandler = $this->createViewHandler([]);
         $viewHandler->setSerializationContextAdapter($this->getMock('FOS\RestBundle\Context\Adapter\SerializationContextAdapterInterface'));
-        $viewHandler->setContainer($container2);
 
         $view2 = new View($exceptionWrapper);
         $response2 = $viewHandler->createResponse($view2, new Request(), $format);
@@ -715,5 +557,22 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
             'json' => ['json'],
             'xml' => ['xml'],
         ];
+    }
+
+    private function createViewHandler($formats = null, $failedValidationCode = Response::HTTP_BAD_REQUEST, $emptyContentCode = Response::HTTP_NO_CONTENT, $serializeNull = false, $forceRedirects = null, $defaultEngine = 'twig')
+    {
+        return new ViewHandler(
+            $this->router,
+            $this->serializer,
+            $this->templating,
+            $this->requestStack,
+            $this->exceptionWrapperHandler,
+            $formats,
+            $failedValidationCode,
+            $emptyContentCode,
+            $serializeNull,
+            $forceRedirects,
+            $defaultEngine
+        );
     }
 }

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -17,15 +17,15 @@ use FOS\RestBundle\Context\ContextInterface;
 use FOS\RestBundle\Context\GroupableContextInterface;
 use FOS\RestBundle\Context\SerializeNullContextInterface;
 use FOS\RestBundle\Context\VersionableContextInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * View may be used in controllers to build up a response in a format agnostic way
@@ -35,10 +35,8 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Lukas K. Smith <smith@pooteeweet.org>
  */
-class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInterface
+class ViewHandler implements ConfigurableViewHandlerInterface
 {
-    use ContainerAwareTrait;
-
     /**
      * Key format, value a callable that returns a Response instance.
      *
@@ -108,17 +106,33 @@ class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInt
      */
     protected $contextAdapter;
 
+    private $urlGenerator;
+    private $serializer;
+    private $templating;
+    private $requestStack;
+    private $exceptionWrapperHandler;
+
     /**
      * Constructor.
      *
-     * @param array  $formats              the supported formats as keys and if the given formats uses templating is denoted by a true value
-     * @param int    $failedValidationCode The HTTP response status code for a failed validation
-     * @param int    $emptyContentCode     HTTP response status code when the view data is null
-     * @param bool   $serializeNull        Whether or not to serialize null view data
-     * @param array  $forceRedirects       If to force a redirect for the given key format, with value being the status code to use
-     * @param string $defaultEngine        default engine (twig, php ..)
+     * @param UrlGeneratorInterface            $urlGenerator            The URL generator
+     * @param object                           $serializer              An object implementing a serialize() method
+     * @param EngineInterface                  $templating              The configured templating engine
+     * @param RequestStack                     $requestStack            The request stack
+     * @param ExceptionWrapperHandlerInterface $exceptionWrapperHandler An exception wrapper handler
+     * @param array                            $formats                 the supported formats as keys and if the given formats uses templating is denoted by a true value
+     * @param int                              $failedValidationCode    The HTTP response status code for a failed validation
+     * @param int                              $emptyContentCode        HTTP response status code when the view data is null
+     * @param bool                             $serializeNull           Whether or not to serialize null view data
+     * @param array                            $forceRedirects          If to force a redirect for the given key format, with value being the status code to use
+     * @param string                           $defaultEngine           default engine (twig, php ..)
      */
     public function __construct(
+        UrlGeneratorInterface $urlGenerator,
+        $serializer,
+        EngineInterface $templating,
+        RequestStack $requestStack,
+        ExceptionWrapperHandlerInterface $exceptionWrapperHandler,
         array $formats = null,
         $failedValidationCode = Response::HTTP_BAD_REQUEST,
         $emptyContentCode = Response::HTTP_NO_CONTENT,
@@ -126,6 +140,15 @@ class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInt
         array $forceRedirects = null,
         $defaultEngine = 'twig'
     ) {
+        if (!method_exists($serializer, 'serialize')) {
+            throw new \InvalidArgumentException('The $serializer argument must implement a serialize() method.');
+        }
+
+        $this->urlGenerator = $urlGenerator;
+        $this->serializer = $serializer;
+        $this->templating = $templating;
+        $this->requestStack = $requestStack;
+        $this->exceptionWrapperHandler = $exceptionWrapperHandler;
         $this->formats = (array) $formats;
         $this->failedValidationCode = $failedValidationCode;
         $this->emptyContentCode = $emptyContentCode;
@@ -243,25 +266,13 @@ class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInt
     }
 
     /**
-     * Gets the router service.
-     *
-     * @return RouterInterface
-     */
-    protected function getRouter()
-    {
-        return $this->container->get('fos_rest.router');
-    }
-
-    /**
      * Gets the serializer service.
-     *
-     * @param View $view view instance from which the serializer should be configured
      *
      * @return object that must provide a "serialize()" method
      */
-    protected function getSerializer(View $view = null)
+    protected function getSerializer()
     {
-        return $this->container->get('fos_rest.serializer');
+        return $this->serializer;
     }
 
     /**
@@ -297,11 +308,11 @@ class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInt
     /**
      * Gets the templating service.
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Templating\EngineInterface
+     * @return EngineInterface
      */
     protected function getTemplating()
     {
-        return $this->container->get('fos_rest.templating');
+        return $this->templating;
     }
 
     /**
@@ -319,7 +330,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInt
     public function handle(View $view, Request $request = null)
     {
         if (null === $request) {
-            $request = $this->container->get('request_stack')->getCurrentRequest();
+            $request = $this->requestStack->getCurrentRequest();
         }
 
         $format = $view->getFormat() ?: $request->getRequestFormat();
@@ -437,7 +448,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInt
     {
         $route = $view->getRoute();
         $location = $route
-            ? $this->getRouter()->generate($route, (array) $view->getRouteParameters(), RouterInterface::ABSOLUTE_URL)
+            ? $this->urlGenerator->generate($route, (array) $view->getRouteParameters(), UrlGeneratorInterface::ABSOLUTE_URL)
             : $view->getLocation();
 
         if ($location) {
@@ -529,10 +540,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface, ContainerAwareInt
             return $form;
         }
 
-        /** @var ExceptionWrapperHandlerInterface $exceptionWrapperHandler */
-        $exceptionWrapperHandler = $this->container->get('fos_rest.exception_handler');
-
-        return $exceptionWrapperHandler->wrap(
+        return $this->exceptionWrapperHandler->wrap(
             [
                  'status_code' => $this->failedValidationCode,
                  'message' => 'Validation Failed',


### PR DESCRIPTION
Fork of #1171 on ``FOSRestBundle`` repository to make it easier to contribute to this PR.

> Injecting the container in your services is not a good practice. After this, there are only three classes left that rely on the container being injected: The ``RestRouteLoader`` class needs it to resolve controllers registered as services, the ``ParamFetcher`` class injects the container into container aware ``ParamInterface`` implementations, and the parent class of the ``ViewResponseListener`` uses the container.