### PR TITLE
update Composer cache directory on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 branches:
   only:


### PR DESCRIPTION
We only need to cache downloaded packages but not metadata from Packagist.