### PR TITLE
make Twig exception controller service public

### DIFF
--- a/DependencyInjection/Compiler/TwigExceptionPass.php
+++ b/DependencyInjection/Compiler/TwigExceptionPass.php
@@ -26,5 +26,9 @@ final class TwigExceptionPass implements CompilerPassInterface
         if ($container->has('fos_rest.exception_listener') && $container->has('twig.exception_listener')) {
             $container->removeDefinition('twig.exception_listener');
         }
+
+        if (!$container->has('templating.engine.twig')) {
+            $container->removeDefinition('fos_rest.exception.twig_controller');
+        }
     }
 }

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -21,7 +21,7 @@
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="fos_rest.exception.twig_controller" class="FOS\RestBundle\Controller\TwigExceptionController" parent="fos_rest.exception.controller" public="false">
+        <service id="fos_rest.exception.twig_controller" class="FOS\RestBundle\Controller\TwigExceptionController" parent="fos_rest.exception.controller">
             <call method="setTemplating">
                 <argument type="service" id="templating.engine.twig" />
             </call>


### PR DESCRIPTION
The controller resolver in the Symfony FrameworkBundle lazy loads
controllers as services. Thus, the Twig exception controller service
must be `public` and we must remove it in a compiler pass in case the
injected `templating.engine.twig` service definition does not exist.