### PR TITLE
make status code configurable even if content is empty

### DIFF
--- a/Resources/doc/empty-content-status-code.rst
+++ b/Resources/doc/empty-content-status-code.rst
@@ -1,0 +1,27 @@
+Status code when responding with no content
+===========================================
+
+In some use cases the api should not send any content, especially when deleting (*DELETE*) or updating (*PUT* or *PATCH*) a resource.
+
+In order to provide a status code that should be sent when having no content, the configuration must be customized:
+
+.. code-block:: yaml
+
+    fost_rest:
+        view:
+            empty_content: 204
+
+If a controller returns no respone, this will be the status code.
+
+.. versionadded:: 2.0
+  Until FOSRestBundle 2.0 this code will be used even if another code is configured inside the view object!
+
+Changes in 2.0
+--------------
+
+In the ticket .. _#1278: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1278 has been decided to make it possible for
+users to adjust a custom status code. So if the configured code is *204*, but you want to send a 200 with empty content, you simply
+have to adjust a status code to the *View* annotation or the view api of the *ControllerTrait*.
+
+Another reason for this change was that for the *OPTIONS* http verb a *200* in favour of a *204* should be sent with empty
+content as reported in .. _#1126: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1126

--- a/Resources/doc/empty-content-status-code.rst
+++ b/Resources/doc/empty-content-status-code.rst
@@ -15,12 +15,5 @@ If you want to use another status code for empty responses, you can update your 
 .. versionadded:: 2.0
   Until FOSRestBundle 2.0 this code will be used even if another code is configured manually inside the view object!
 
-Changes in 2.0
---------------
-
-In the ticket .. _#1278: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1278 has been decided to make it possible for
-users to adjust a custom status code. So if the configured code is *204*, but you want to send a 200 with empty content, you simply
-have to adjust a status code to the *View* annotation or the view api of the *ControllerTrait*.
-
-Another reason for this change was that for the *OPTIONS* http verb a *200* in favour of a *204* should be sent with empty
-content as reported in .. _#1126: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1126
+If you don't want to use the default empty content status for a specific empty ``Response``, you just
+have to set a status code manually thanks to the ``@View()`` annotation or the ``View`` class.

--- a/Resources/doc/empty-content-status-code.rst
+++ b/Resources/doc/empty-content-status-code.rst
@@ -3,7 +3,7 @@ Status code when responding with no content
 
 In some use cases the api should not send any content, especially when deleting (*DELETE*) or updating (*PUT* or *PATCH*) a resource.
 
-In order to provide a status code that should be sent when having no content, the configuration must be customized:
+In order to provide a status code that should be sent when having no content, the configuration must can customized (the default value for the shown parameter would be "204"):
 
 .. code-block:: yaml
 
@@ -11,10 +11,10 @@ In order to provide a status code that should be sent when having no content, th
         view:
             empty_content: 204
 
-If a controller returns no respone, this will be the status code.
+If a controller returns an empty response, this status will be used.
 
 .. versionadded:: 2.0
-  Until FOSRestBundle 2.0 this code will be used even if another code is configured inside the view object!
+  Until FOSRestBundle 2.0 this code will be used even if another code is configured manually inside the view object!
 
 Changes in 2.0
 --------------

--- a/Resources/doc/empty-content-status-code.rst
+++ b/Resources/doc/empty-content-status-code.rst
@@ -3,15 +3,14 @@ Status code when responding with no content
 
 In some use cases the api should not send any content, especially when deleting (*DELETE*) or updating (*PUT* or *PATCH*) a resource.
 
-In order to provide a status code that should be sent when having no content, the configuration must can customized (the default value for the shown parameter would be "204"):
+By default, ``FOSRestBundle`` will send a *204* status if the response is empty.
+If you want to use another status code for empty responses, you can update your configuration file:
 
 .. code-block:: yaml
 
     fost_rest:
         view:
             empty_content: 204
-
-If a controller returns an empty response, this status will be used.
 
 .. versionadded:: 2.0
   Until FOSRestBundle 2.0 this code will be used even if another code is configured manually inside the view object!

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,11 +1,12 @@
 Getting Started With FOSRestBundle
-=====================================
+==================================
 
 .. toctree::
     :hidden:
 
     1-setting_up_the_bundle
     2-the-view-layer
+    empty-content-status-code
     3-listener-support
     view_response_listener
     body_listener

--- a/Tests/View/ViewHandlerTest.php
+++ b/Tests/View/ViewHandlerTest.php
@@ -85,8 +85,16 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getStatusCodeDataProvider
      */
-    public function testGetStatusCode($expected, $data, $isSubmitted, $isValid, $isSubmittedCalled, $isValidCalled, $noContentCode)
-    {
+    public function testGetStatusCode(
+        $expected,
+        $data,
+        $isSubmitted,
+        $isValid,
+        $isSubmittedCalled,
+        $isValidCalled,
+        $noContentCode,
+        $actualStatusCode
+    ) {
         $reflectionMethod = new \ReflectionMethod(ViewHandler::class, 'getStatusCode');
         $reflectionMethod->setAccessible(true);
 
@@ -103,7 +111,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         if ($data) {
             $data = ['form' => $form];
         }
-        $view = new View($data ? $data : null);
+        $view = new View($data ?: null, $actualStatusCode ?: null);
 
         $viewHandler = $this->createViewHandler([], $expected, $noContentCode);
         $this->assertEquals($expected, $reflectionMethod->invoke($viewHandler, $view, $view->getData()));
@@ -112,12 +120,13 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
     public static function getStatusCodeDataProvider()
     {
         return [
-            'no data' => [Response::HTTP_OK, false, false, false, 0, 0, Response::HTTP_OK],
-            'no data with 204' => [Response::HTTP_NO_CONTENT, false, false, false, 0, 0, Response::HTTP_NO_CONTENT],
-            'form key form not bound' => [Response::HTTP_OK, true, false, true, 1, 0, Response::HTTP_OK],
-            'form key form is bound and invalid' => [403, true, true, false, 1, 1, Response::HTTP_OK],
-            'form key form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK],
-            'form key null form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK],
+            'no data' => [Response::HTTP_OK, false, false, false, 0, 0, Response::HTTP_OK, null],
+            'no data with 204' => [Response::HTTP_NO_CONTENT, false, false, false, 0, 0, Response::HTTP_NO_CONTENT, null],
+            'no data, but custom response code' => [Response::HTTP_OK, false, false, false, 0, 0, Response::HTTP_NO_CONTENT, Response::HTTP_OK],
+            'form key form not bound' => [Response::HTTP_OK, true, false, true, 1, 0, Response::HTTP_OK, null],
+            'form key form is bound and invalid' => [Response::HTTP_FORBIDDEN, true, true, false, 1, 1, Response::HTTP_OK, null],
+            'form key form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK, null],
+            'form key null form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK, null],
         ];
     }
 

--- a/Tests/View/ViewHandlerTest.php
+++ b/Tests/View/ViewHandlerTest.php
@@ -93,7 +93,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         $isSubmittedCalled,
         $isValidCalled,
         $noContentCode,
-        $actualStatusCode
+        $actualStatusCode = null
     ) {
         $reflectionMethod = new \ReflectionMethod(ViewHandler::class, 'getStatusCode');
         $reflectionMethod->setAccessible(true);
@@ -120,13 +120,13 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
     public static function getStatusCodeDataProvider()
     {
         return [
-            'no data' => [Response::HTTP_OK, false, false, false, 0, 0, Response::HTTP_OK, null],
-            'no data with 204' => [Response::HTTP_NO_CONTENT, false, false, false, 0, 0, Response::HTTP_NO_CONTENT, null],
+            'no data' => [Response::HTTP_OK, false, false, false, 0, 0, Response::HTTP_OK],
+            'no data with 204' => [Response::HTTP_NO_CONTENT, false, false, false, 0, 0, Response::HTTP_NO_CONTENT],
             'no data, but custom response code' => [Response::HTTP_OK, false, false, false, 0, 0, Response::HTTP_NO_CONTENT, Response::HTTP_OK],
-            'form key form not bound' => [Response::HTTP_OK, true, false, true, 1, 0, Response::HTTP_OK, null],
-            'form key form is bound and invalid' => [Response::HTTP_FORBIDDEN, true, true, false, 1, 1, Response::HTTP_OK, null],
-            'form key form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK, null],
-            'form key null form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK, null],
+            'form key form not bound' => [Response::HTTP_OK, true, false, true, 1, 0, Response::HTTP_OK],
+            'form key form is bound and invalid' => [Response::HTTP_FORBIDDEN, true, true, false, 1, 1, Response::HTTP_OK],
+            'form key form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK],
+            'form key null form bound and valid' => [Response::HTTP_OK, true, true, true, 1, 1, Response::HTTP_OK],
         ];
     }
 

--- a/Tests/View/ViewTest.php
+++ b/Tests/View/ViewTest.php
@@ -149,5 +149,13 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         $code = 404;
         $view->setStatusCode($code);
         $this->assertEquals($code, $view->getStatusCode());
+        $this->assertEquals($code, $view->getResponse()->getStatusCode());
+    }
+
+    public function testGetStatusCodeFromResponse()
+    {
+        $view = new View();
+        $this->assertNull($view->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $view->getResponse()->getStatusCode()); // default code of the response.
     }
 }

--- a/View/View.php
+++ b/View/View.php
@@ -24,14 +24,54 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class View
 {
+    /**
+     * @var mixed
+     */
     private $data;
+
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * @var mixed[]
+     */
     private $templateData = [];
+
+    /**
+     * @var string
+     */
     private $template;
+
+    /**
+     * @var string
+     */
     private $templateVar;
+
+    /**
+     * @var string
+     */
     private $engine;
+
+    /**
+     * @var string
+     */
     private $format;
+
+    /**
+     * @var string
+     */
     private $location;
+
+    /**
+     * @var string
+     */
     private $route;
+
+    /**
+     * @var mixed[]
+     */
     private $routeParameters;
 
     /**
@@ -110,7 +150,7 @@ class View
     public function __construct($data = null, $statusCode = null, array $headers = [])
     {
         $this->setData($data);
-        $this->setStatusCode($statusCode ?: 200);
+        $this->setStatusCode($statusCode);
         $this->setTemplateVar('data');
 
         if (!empty($headers)) {
@@ -184,7 +224,7 @@ class View
      */
     public function setStatusCode($code)
     {
-        $this->getResponse()->setStatusCode($code);
+        $this->statusCode = (int) $code;
 
         return $this;
     }
@@ -349,7 +389,7 @@ class View
      */
     public function getStatusCode()
     {
-        return $this->getResponse()->getStatusCode();
+        return $this->statusCode;
     }
 
     /**
@@ -441,6 +481,10 @@ class View
     {
         if (null === $this->response) {
             $this->response = new Response();
+
+            if ($code = $this->getStatusCode()) {
+                $this->response->setStatusCode($this->getStatusCode());
+            }
         }
 
         return $this->response;

--- a/View/View.php
+++ b/View/View.php
@@ -25,52 +25,52 @@ use Symfony\Component\HttpFoundation\Response;
 class View
 {
     /**
-     * @var mixed
+     * @var mixed|null
      */
     private $data;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $statusCode;
 
     /**
-     * @var mixed[]
+     * @var mixed|null
      */
     private $templateData = [];
 
     /**
-     * @var string
+     * @var TemplateReference|string|null
      */
     private $template;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $templateVar;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $engine;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $format;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $location;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $route;
 
     /**
-     * @var mixed[]
+     * @var array|null
      */
     private $routeParameters;
 
@@ -485,7 +485,7 @@ class View
             $this->response = new Response();
 
             if ($code = $this->getStatusCode()) {
-                $this->response->setStatusCode($this->getStatusCode());
+                $this->response->setStatusCode($code);
             }
         }
 

--- a/View/View.php
+++ b/View/View.php
@@ -224,8 +224,8 @@ class View
      */
     public function setStatusCode($code)
     {
-        if (!empty($code)) {
-            $this->statusCode = (int) $code;
+        if (null !== $code) {
+            $this->statusCode = $code;
         }
 
         return $this;
@@ -484,7 +484,7 @@ class View
         if (null === $this->response) {
             $this->response = new Response();
 
-            if ($code = $this->getStatusCode()) {
+            if (null !== ($code = $this->getStatusCode())) {
                 $this->response->setStatusCode($code);
             }
         }

--- a/View/View.php
+++ b/View/View.php
@@ -224,7 +224,9 @@ class View
      */
     public function setStatusCode($code)
     {
-        $this->statusCode = (int) $code;
+        if (!empty($code)) {
+            $this->statusCode = (int) $code;
+        }
 
         return $this;
     }

--- a/View/View.php
+++ b/View/View.php
@@ -218,7 +218,7 @@ class View
     /**
      * Sets the HTTP status code.
      *
-     * @param int $code
+     * @param int|null $code
      *
      * @return View
      */

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -247,7 +247,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface
         }
 
         $statusCode = $view->getStatusCode();
-        if (!empty($statusCode)) {
+        if (null !== $statusCode) {
             return $statusCode;
         }
 

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -246,8 +246,9 @@ class ViewHandler implements ConfigurableViewHandlerInterface
             return $this->failedValidationCode;
         }
 
-        if (200 !== ($code = $view->getStatusCode())) {
-            return $code;
+        $statusCode = $view->getStatusCode();
+        if (!empty($statusCode)) {
+            return $statusCode;
         }
 
         return null !== $content ? Response::HTTP_OK : $this->emptyContentCode;


### PR DESCRIPTION
resolves #1278 and #1126 

the status code in *FOS\RestBundle\View\View* is null by default (on getResponse() null will be 200 in the response object).
If the code is null and the content is null, the emptyContentErrorCode will be used.
But if the status code is not null, the given status code will be used.