### PR TITLE
Fix fallback format with priorities

### DIFF
--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -83,12 +83,16 @@ class FormatNegotiator extends BaseNegotiator
                 }
             }
 
-            $mimeTypes = $this->normalizePriorities($request,
-                empty($priorities) ? $options['priorities'] : $priorities
-            );
-            $mimeType = parent::getBest($header, $mimeTypes);
-            if ($mimeType !== null) {
-                return $mimeType;
+            if ($header) {
+                $mimeTypes = $this->normalizePriorities($request,
+                    empty($priorities) ? $options['priorities'] : $priorities
+                );
+
+                $mimeType = parent::getBest($header, $mimeTypes);
+
+                if ($mimeType !== null) {
+                    return $mimeType;
+                }
             }
 
             if (isset($options['fallback_format'])) {

--- a/Tests/Negotiation/FormatNegotiatorTest.php
+++ b/Tests/Negotiation/FormatNegotiatorTest.php
@@ -61,6 +61,15 @@ class FormatNegotiatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Accept('text/html'), $this->negotiator->getBest(''));
     }
 
+    public function testFallbackFormatWithPriorities()
+    {
+        $this->addRequestMatcher(true, ['priorities' => ['json', 'xml'], 'fallback_format' => null]);
+        $this->assertNull($this->negotiator->getBest(''));
+
+        $this->addRequestMatcher(true, ['priorities' => ['json', 'xml'], 'fallback_format' => 'json']);
+        $this->assertEquals(new Accept('application/json'), $this->negotiator->getBest(''));
+    }
+
     public function testGetBest()
     {
         $this->request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8');


### PR DESCRIPTION
Hey!

When trying to perform request on an API without providing the `Accept` header, the fallback format is not used (if the matched rule defines priotities) and instead a `Negotiation\Exception\InvalidArgument` is thrown because the Negotiation library seems not supporting empty header in its 2.x version.