### PR TITLE
Add boolean extension support

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -89,6 +89,8 @@ class FOSRestExtension extends Extension implements PrependExtensionInterface
 
     private function loadForm(array $config, XmlFileLoader $loader, ContainerBuilder $container)
     {
+        $loader->load('form.xml');
+
         if (!empty($config['disable_csrf_role'])) {
             $loader->load('forms.xml');
             $container->setParameter('fos_rest.disable_csrf_role', $config['disable_csrf_role']);

--- a/Form/Extension/BooleanExtension.php
+++ b/Form/Extension/BooleanExtension.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Form\Extension;
+
+use FOS\RestBundle\Form\Transformer\BooleanTypeToBooleanTransformer;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class BooleanExtension extends AbstractTypeExtension
+{
+    const TYPE_API = 'api';
+    const TYPE_CHECKBOX = 'checkbox';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($options['type'] === self::TYPE_API) {
+            $builder
+                ->resetViewTransformers()
+                ->addViewTransformer(new BooleanTypeToBooleanTransformer());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        // Symfony >= 2.6
+        if (method_exists($resolver, 'setDefault')) {
+            $resolver
+                ->setDefault('type', self::TYPE_CHECKBOX)
+                ->setAllowedValues('type', array(self::TYPE_API, self::TYPE_CHECKBOX))
+            ;
+        } else {
+            $resolver
+                ->setDefaults(array('type' => self::TYPE_CHECKBOX))
+                ->setAllowedValues(array('type' => array(self::TYPE_API, self::TYPE_CHECKBOX)))
+            ;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        // Symfony >= 2.8
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            return 'Symfony\Component\Form\Extension\Core\Type\CheckboxType';
+        }
+
+        return 'checkbox';
+    }
+}

--- a/Form/Transformer/BooleanTypeToBooleanTransformer.php
+++ b/Form/Transformer/BooleanTypeToBooleanTransformer.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Form\Transformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class BooleanTypeToBooleanTransformer implements DataTransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!is_bool($value)) {
+            throw new TransformationFailedException(sprintf(
+                'The boolean type expects a boolean or null value, got "%s"',
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (in_array($value, array('1', 'true', 'on', 'yes'), true)) {
+            return true;
+        }
+
+        if (in_array($value, array('0', 'false', 'off', 'no', '', null), true)) {
+            return false;
+        }
+
+        throw new TransformationFailedException('The boolean type could not be reverse transformed.');
+    }
+}

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_rest.form.extension.boolean" class="FOS\RestBundle\Form\Extension\BooleanExtension">
+            <!-- "alias" option for SF <2.8 -->
+            <tag name="form.type_extension" alias="checkbox" extended_type="Symfony\Component\Form\Extension\Core\Type\CheckboxType" />
+        </service>
+    </services>
+</container>

--- a/Tests/Form/Extension/BooleanExtensionTest.php
+++ b/Tests/Form/Extension/BooleanExtensionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Form\Extension;
+
+use FOS\RestBundle\Form\Extension\BooleanExtension;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Forms;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class BooleanExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->formFactory = Forms::createFormFactoryBuilder()
+            ->addTypeExtension(new BooleanExtension())
+            ->getFormFactory();
+    }
+
+    public function testCheckboxType()
+    {
+        $viewTransformers = $this->createCheckboxForm()->getConfig()->getViewTransformers();
+
+        $this->assertCount(1, $viewTransformers);
+        $this->assertInstanceOf(
+            'Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer',
+            $viewTransformers[0]
+        );
+    }
+
+    public function testApiType()
+    {
+        $viewTransformers = $this->createCheckboxForm(array('type' => BooleanExtension::TYPE_API))
+            ->getConfig()
+            ->getViewTransformers();
+
+        $this->assertCount(1, $viewTransformers);
+        $this->assertInstanceOf(
+            'FOS\RestBundle\Form\Transformer\BooleanTypeToBooleanTransformer',
+            $viewTransformers[0]
+        );
+    }
+
+    /**
+     * @param bool  $expected
+     * @param mixed $data
+     *
+     * @dataProvider validProvider
+     */
+    public function testValidSubmittedData($expected, $data)
+    {
+        $form = $this->createCheckboxForm(array('type' => BooleanExtension::TYPE_API));
+        $form->submit($data);
+
+        $this->assertSame($expected, $form->getData());
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @dataProvider invalidProvider
+     */
+    public function testInvalidSubmittedData($data)
+    {
+        $form = $this->createCheckboxForm(array('type' => BooleanExtension::TYPE_API));
+        $form->submit($data);
+
+        $this->assertNull($form->getData());
+    }
+
+    public static function validProvider()
+    {
+        return array(
+            array(true, true),
+            array(true, 1),
+            array(true, '1'),
+            array(true, 'true'),
+            array(true, 'yes'),
+            array(true, 'on'),
+            array(false, false),
+            array(false, 0),
+            array(false, '0'),
+            array(false, 'false'),
+            array(false, 'no'),
+            array(false, 'off'),
+            array(false, ''),
+            array(false, null),
+    );
+    }
+
+    public static function invalidProvider()
+    {
+        return array(
+            array('foo'),
+            array(1.2),
+            array(new \stdClass()),
+            array(array('foo' => 'bar')),
+        );
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return FormInterface
+     */
+    private function createCheckboxForm(array $options = array())
+    {
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $type = 'Symfony\Component\Form\Extension\Core\Type\CheckboxType';
+        } else {
+            $type = 'checkbox';
+        }
+
+        return $this->formFactory->create($type, null, $options);
+    }
+}


### PR DESCRIPTION
Hey!

I was starting wrting this piece of text and realize there is #1295... Anyway, as it is done let's share it and additionally, I'm not really in favor of #1295. Instead, I propose this one which is more strict on the submitted value. IMO, in a API context, if a user sends something like `abcd`, it should not be considered as true or false for a checkbox field but instead it should be considered as invalid.

To enable it, you need to use the `api` type:

``` php
$builder->add('enabled', CheckboxType::class, [
    'type' => 'api',
    'true_values'  => ['1', 'true', 'yes', 'on'],
    'false_values' => ['0', 'false', 'no', 'off', '', null],
]);
```

Enabling it will automatically convert the defined `true_values` to `true` and the `false_values` to `false`. Anything else will trigger a transformation failed exception and mark the form as invalid. The true/false values are optional, I add them in the example in order to more easily explain how does it work. The values used here are the default ones except for the type one.

If you look it closely you will notice the values looks strange. We don't allow the `true`/`false` values or the `1`/`0` values but instead we allow there string representations. This is because the form component automatically converts scalar value to string and false to null (See [here](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Form.php#L525-L529)). So, the values provided must reflect this form behavior.

For the list of supported submitted boolean values, you can take a look to the PHPUnit data provider in the extension tests.

WDYT?
