### PR TITLE
Compatibility for RFC-2518

### DIFF
--- a/Controller/Annotations/Copy.php
+++ b/Controller/Annotations/Copy.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * COPY Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Copy extends Route
+{
+    public function getMethod()
+    {
+        return 'COPY';
+    }
+}

--- a/Controller/Annotations/Lock.php
+++ b/Controller/Annotations/Lock.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * LOCK Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Lock extends Route
+{
+    public function getMethod()
+    {
+        return 'LOCK';
+    }
+}

--- a/Controller/Annotations/Mkcol.php
+++ b/Controller/Annotations/Mkcol.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * MKCOL Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Mkcol extends Route
+{
+    public function getMethod()
+    {
+        return 'MKCOL';
+    }
+}

--- a/Controller/Annotations/Move.php
+++ b/Controller/Annotations/Move.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * MOVE Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Move extends Route
+{
+    public function getMethod()
+    {
+        return 'MOVE';
+    }
+}

--- a/Controller/Annotations/PropFind.php
+++ b/Controller/Annotations/PropFind.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * PROPFIND Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class PropFind extends Route
+{
+    public function getMethod()
+    {
+        return 'PROPFIND';
+    }
+}

--- a/Controller/Annotations/PropPatch.php
+++ b/Controller/Annotations/PropPatch.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * PROPPATCH Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class PropPatch extends Route
+{
+    public function getMethod()
+    {
+        return 'PROPPATCH';
+    }
+}

--- a/Controller/Annotations/Unlock.php
+++ b/Controller/Annotations/Unlock.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * UNLOCK Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Unlock extends Route
+{
+    public function getMethod()
+    {
+        return 'UNLOCK';
+    }
+}

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
@@ -45,44 +45,62 @@ Define resource actions
     <?php
     class UsersController
     {
+        public function copyUserAction($id) // RFC-2518
+        {} // "copy_user"            [COPY] /users/{id}
+
+        public function propfindUserPropsAction($id, $property) // RFC-2518
+        {} // "propfind_user_props"  [PROPFIND] /users/{id}/props/{property}
+
+        public function proppatchUserPropsAction($id, $property) // RFC-2518
+        {} // "proppatch_user_props" [PROPPATCH] /users/{id}/props/{property}
+
+        public function moveUserAction($id) // RFC-2518
+        {} // "move_user"            [MOVE] /users/{id}
+
+        public function mkcolUsersAction() // RFC-2518
+        {} // "mkcol_users"          [MKCOL] /users
+
         public function optionsUsersAction()
-        {} // "options_users" [OPTIONS] /users
+        {} // "options_users"        [OPTIONS] /users
 
         public function getUsersAction()
-        {} // "get_users"     [GET] /users
+        {} // "get_users"            [GET] /users
 
         public function newUsersAction()
-        {} // "new_users"     [GET] /users/new
+        {} // "new_users"            [GET] /users/new
 
         public function postUsersAction()
-        {} // "post_users"    [POST] /users
+        {} // "post_users"           [POST] /users
 
         public function patchUsersAction()
-        {} // "patch_users"   [PATCH] /users
+        {} // "patch_users"          [PATCH] /users
 
         public function getUserAction($slug)
-        {} // "get_user"      [GET] /users/{slug}
+        {} // "get_user"             [GET] /users/{slug}
 
         public function editUserAction($slug)
-        {} // "edit_user"     [GET] /users/{slug}/edit
+        {} // "edit_user"            [GET] /users/{slug}/edit
 
         public function putUserAction($slug)
-        {} // "put_user"      [PUT] /users/{slug}
+        {} // "put_user"             [PUT] /users/{slug}
 
         public function patchUserAction($slug)
-        {} // "patch_user"    [PATCH] /users/{slug}
+        {} // "patch_user"           [PATCH] /users/{slug}
 
         public function lockUserAction($slug)
-        {} // "lock_user"     [PATCH] /users/{slug}/lock
+        {} // "lock_user"            [LOCK] /users/{slug}
+
+        public function unlockUserAction($slug)
+        {} // "unlock_user"          [UNLOCK] /users/{slug}
 
         public function banUserAction($slug)
-        {} // "ban_user"      [PATCH] /users/{slug}/ban
+        {} // "ban_user"             [PATCH] /users/{slug}/ban
 
         public function removeUserAction($slug)
-        {} // "remove_user"   [GET] /users/{slug}/remove
+        {} // "remove_user"          [GET] /users/{slug}/remove
 
         public function deleteUserAction($slug)
-        {} // "delete_user"   [DELETE] /users/{slug}
+        {} // "delete_user"          [DELETE] /users/{slug}
 
         public function getUserCommentsAction($slug)
         {} // "get_user_comments"    [GET] /users/{slug}/comments

--- a/Resources/doc/annotations-reference.rst
+++ b/Resources/doc/annotations-reference.rst
@@ -46,7 +46,7 @@ RequestParam
      */
 
 FileParam
-~~~~~~~~~~~~
+~~~~~~~~~
 
 .. code-block:: php
 
@@ -112,7 +112,7 @@ Route
 
 RestBundle extends the `@Route Symfony annotation`_ from Symfony.
 
-@Delete @Get @Head @Link @Patch @Post @Put @Unlink have the same options as @Route.
+@Delete @Get @Head @Link @Patch @Post @Put @Unlink @Lock @Unlock @PropFind @PropPatch @Move @Mkcol @Copy have the same options as @Route.
 
 When using ``symfony/routing:>=2.4`` (or the full framework) you have access to
 the expression language component and can add conditions to your routing

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -14,10 +14,9 @@ namespace FOS\RestBundle\Routing\Loader\Reader;
 use Doctrine\Common\Annotations\Reader;
 use FOS\RestBundle\Controller\Annotations\Route as RouteAnnotation;
 use FOS\RestBundle\Inflector\InflectorInterface;
-use FOS\RestBundle\Request\ParamReader;
+use FOS\RestBundle\Request\ParamReaderInterface;
 use FOS\RestBundle\Routing\RestRouteCollection;
 use Symfony\Component\Routing\Route;
-use FOS\RestBundle\Request\ParamReaderInterface;
 
 /**
  * REST controller actions reader.
@@ -28,17 +27,81 @@ class RestActionReader
 {
     const COLLECTION_ROUTE_PREFIX = 'c';
 
+    /**
+     * @var Reader
+     */
     private $annotationReader;
+
+    /**
+     * @var ParamReaderInterface
+     */
     private $paramReader;
+
+    /**
+     * @var InflectorInterface
+     */
     private $inflector;
+
+    /**
+     * @var array
+     */
     private $formats;
+
+    /**
+     * @var bool
+     */
     private $includeFormat;
+
+    /**
+     * @var string|null
+     */
     private $routePrefix;
+
+    /**
+     * @var string|null
+     */
     private $namePrefix;
+
+    /**
+     * @var array|string|null
+     */
     private $versions;
+
+    /**
+     * @var bool|null
+     */
     private $pluralize;
+
+    /**
+     * @var array
+     */
     private $parents = [];
-    private $availableHTTPMethods = ['get', 'post', 'put', 'patch', 'delete', 'link', 'unlink', 'head', 'options'];
+
+    /**
+     * @var array
+     */
+    private $availableHTTPMethods = [
+        'get',
+        'post',
+        'put',
+        'patch',
+        'delete',
+        'link',
+        'unlink',
+        'head',
+        'options',
+        'mkcol',
+        'propfind',
+        'proppatch',
+        'move',
+        'copy',
+        'lock',
+        'unlock',
+    ];
+
+    /**
+     * @var array
+     */
     private $availableConventionalActions = ['new', 'edit', 'remove'];
 
     /**
@@ -536,7 +599,7 @@ class RestActionReader
             return 'get';
         }
 
-        //custom object
+        // custom object
         return 'patch';
     }
 
@@ -551,7 +614,7 @@ class RestActionReader
     {
         $annotations = [];
 
-        foreach (['Route', 'Get', 'Post', 'Put', 'Patch', 'Delete', 'Link', 'Unlink', 'Head', 'Options'] as $annotationName) {
+        foreach ($this->convertAvailableHttpMethodsToAnnotationNames() as $annotationName) {
             if ($annotations_new = $this->readMethodAnnotations($reflectionMethod, $annotationName)) {
                 $annotations = array_merge($annotations, $annotations_new);
             }
@@ -648,5 +711,20 @@ class RestActionReader
         } else {
             $collection->add($fullRouteName, $route);
         }
+    }
+
+    /**
+     * Converts all given http methods to their annotation names.
+     *
+     * @return string[]
+     */
+    private function convertAvailableHttpMethodsToAnnotationNames()
+    {
+        return array_map(
+            function ($httpMethod) {
+                return ucfirst($httpMethod);
+            },
+            $this->availableHTTPMethods
+        );
     }
 }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -614,10 +614,8 @@ class RestActionReader
     {
         $annotations = [];
 
-        foreach ($this->convertAvailableHttpMethodsToAnnotationNames() as $annotationName) {
-            if ($newAnnotations = $this->readMethodAnnotations($reflectionMethod, $annotationName)) {
-                $annotations = array_merge($annotations, $newAnnotations);
-            }
+        if ($newAnnotations = $this->readMethodAnnotations($reflectionMethod, 'Route')) {
+            $annotations = array_merge($annotations, $newAnnotations);
         }
 
         return $annotations;
@@ -711,23 +709,5 @@ class RestActionReader
         } else {
             $collection->add($fullRouteName, $route);
         }
-    }
-
-    /**
-     * Converts all given http methods to their annotation names.
-     *
-     * @return string[]
-     */
-    private function convertAvailableHttpMethodsToAnnotationNames()
-    {
-        return array_merge(
-            ['Route'],
-            array_map(
-                function ($httpMethod) {
-                    return ucfirst($httpMethod);
-                },
-                $this->availableHTTPMethods
-            )
-        );
     }
 }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -720,11 +720,14 @@ class RestActionReader
      */
     private function convertAvailableHttpMethodsToAnnotationNames()
     {
-        return array_map(
-            function ($httpMethod) {
-                return ucfirst($httpMethod);
-            },
-            $this->availableHTTPMethods
+        return array_merge(
+            ['Route'],
+            array_map(
+                function ($httpMethod) {
+                    return ucfirst($httpMethod);
+                },
+                $this->availableHTTPMethods
+            )
         );
     }
 }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -615,8 +615,8 @@ class RestActionReader
         $annotations = [];
 
         foreach ($this->convertAvailableHttpMethodsToAnnotationNames() as $annotationName) {
-            if ($annotations_new = $this->readMethodAnnotations($reflectionMethod, $annotationName)) {
-                $annotations = array_merge($annotations, $annotations_new);
+            if ($newAnnotations = $this->readMethodAnnotations($reflectionMethod, $annotationName)) {
+                $annotations = array_merge($annotations, $newAnnotations);
             }
         }
 

--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -76,12 +76,10 @@ class RestRouteCollection extends RouteCollection
      */
     public function all()
     {
-        $regex = <<<REGEX
-/
+        $regex = '/
     (_|^)
     (get|post|put|delete|patch|head|options|mkcol|propfind|proppatch|lock|unlock|move|copy|link|unlink)_ # allowed http methods
-/i
-REGEX;
+        /i';
 
         $routes = parent::all();
         $customMethodRoutes = [];

--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -76,10 +76,17 @@ class RestRouteCollection extends RouteCollection
      */
     public function all()
     {
+        $regex = <<<REGEX
+/
+    (_|^)
+    (get|post|put|delete|patch|head|options|mkcol|propfind|proppatch|lock|unlock|move|copy|link|unlink)_ # allowed http methods
+/i
+REGEX;
+
         $routes = parent::all();
         $customMethodRoutes = [];
         foreach ($routes as $routeName => $route) {
-            if (!preg_match('/(_|^)(get|post|put|delete|patch|head|options)_/', $routeName)) {
+            if (!preg_match($regex, $routeName)) {
                 $customMethodRoutes[$routeName] = $route;
                 unset($routes[$routeName]);
             }

--- a/Tests/Fixtures/Controller/AnnotatedUsersController.php
+++ b/Tests/Fixtures/Controller/AnnotatedUsersController.php
@@ -11,17 +11,24 @@
 
 namespace FOS\RestBundle\Tests\Fixtures\Controller;
 
+use FOS\RestBundle\Controller\Annotations\Copy;
 use FOS\RestBundle\Controller\Annotations\Delete;
 use FOS\RestBundle\Controller\Annotations\Get;
 use FOS\RestBundle\Controller\Annotations\Head;
 use FOS\RestBundle\Controller\Annotations\Link;
+use FOS\RestBundle\Controller\Annotations\Lock;
+use FOS\RestBundle\Controller\Annotations\Mkcol;
+use FOS\RestBundle\Controller\Annotations\Move;
 use FOS\RestBundle\Controller\Annotations\NoRoute;
 use FOS\RestBundle\Controller\Annotations\Options;
 use FOS\RestBundle\Controller\Annotations\Patch;
 use FOS\RestBundle\Controller\Annotations\Post;
+use FOS\RestBundle\Controller\Annotations\PropFind;
+use FOS\RestBundle\Controller\Annotations\PropPatch;
 use FOS\RestBundle\Controller\Annotations\Put;
 use FOS\RestBundle\Controller\Annotations\Route;
 use FOS\RestBundle\Controller\Annotations\Unlink;
+use FOS\RestBundle\Controller\Annotations\Unlock;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class AnnotatedUsersController extends Controller
@@ -30,6 +37,83 @@ class AnnotatedUsersController extends Controller
      * [OPTIONS]     /users.
      */
     public function optionsUsersAction()
+    {
+    }
+
+    /**
+     * [COPY] /users/{id}.
+     *
+     * @param $id
+     *
+     * @Copy()
+     */
+    public function copyUserAction($id)
+    {
+    }
+
+    /**
+     * [PROPFIND] /users/{id}/props/{property}.
+     *
+     * @param $id
+     * @param $property
+     *
+     * @PropFind()
+     */
+    public function propfindUserPropsAction($id, $property)
+    {
+    }
+
+    /**
+     * [PROPPATCH] /users/{id}/props/{property}.
+     *
+     * @param $id
+     * @param $property
+     *
+     * @PropPatch()
+     */
+    public function proppatchUserPropsAction($id, $property)
+    {
+    }
+
+    /**
+     * [MOVE] /users/{id}.
+     *
+     * @param $id
+     *
+     * @Move()
+     */
+    public function moveUserAction($id)
+    {
+    }
+
+    /**
+     * [MKCOL] /users.
+     *
+     * @Mkcol()
+     */
+    public function mkcolUsersAction()
+    {
+    }
+
+    /**
+     * [LOCK] /users/{slug}.
+     *
+     * @param $slug
+     *
+     * @Lock()
+     */
+    public function lockUserAction($slug)
+    {
+    }
+
+    /**
+     * [UNLOCK] /users/{slug}.
+     *
+     * @param $slug
+     *
+     * @Unlock()
+     */
+    public function unlockUserAction($slug)
     {
     }
 

--- a/Tests/Fixtures/Controller/ArticleController.php
+++ b/Tests/Fixtures/Controller/ArticleController.php
@@ -77,7 +77,7 @@ class ArticleController extends Controller implements ClassResourceInterface
     }
 
     /**
-     * [PATCH] /articles/{slug}/lock.
+     * [LOCK] /articles/{slug}/lock.
      *
      * @param $slug
      */

--- a/Tests/Fixtures/Controller/ArticleController.php
+++ b/Tests/Fixtures/Controller/ArticleController.php
@@ -77,7 +77,7 @@ class ArticleController extends Controller implements ClassResourceInterface
     }
 
     /**
-     * [LOCK] /articles/{slug}/lock.
+     * [LOCK] /articles/{slug}.
      *
      * @param $slug
      */

--- a/Tests/Fixtures/Controller/OrdersController.php
+++ b/Tests/Fixtures/Controller/OrdersController.php
@@ -18,16 +18,16 @@ class OrdersController extends Controller
     // conventional HATEOAS action after REST action
 
     /**
-     * [GET] /foos.
+     * [GET] /foos/new.
      */
-    public function getFoosAction()
+    public function newFoosAction()
     {
     }
 
     /**
-     * [GET] /foos/new.
+     * [GET] /foos.
      */
-    public function newFoosAction()
+    public function getFoosAction()
     {
     }
 

--- a/Tests/Fixtures/Controller/UsersController.php
+++ b/Tests/Fixtures/Controller/UsersController.php
@@ -72,7 +72,7 @@ class UsersController extends Controller
     }
 
     /**
-     * [PATCH] /users/{slug}/lock.
+     * [LOCK] /users/{slug}/lock.
      *
      * @param $slug
      */

--- a/Tests/Fixtures/Controller/UsersController.php
+++ b/Tests/Fixtures/Controller/UsersController.php
@@ -17,7 +17,52 @@ use Symfony\Component\HttpFoundation\Request;
 class UsersController extends Controller
 {
     /**
-     * [OPTION] /users.
+     * [COPY] /users/{id}.
+     *
+     * @param $id
+     */
+    public function copyUserAction($id)
+    {
+    }
+
+    /**
+     * [PROPFIND] /users/{id}/props/{property}.
+     *
+     * @param $id
+     * @param $property
+     */
+    public function propfindUserPropsAction($id, $property)
+    {
+    }
+
+    /**
+     * [PROPPATCH] /users/{id}/props/{property}.
+     *
+     * @param $id
+     * @param $property
+     */
+    public function proppatchUserPropsAction($id, $property)
+    {
+    }
+
+    /**
+     * [MOVE] /users/{id}.
+     *
+     * @param $id
+     */
+    public function moveUserAction($id)
+    {
+    }
+
+    /**
+     * [MKCOL] /users.
+     */
+    public function mkcolUsersAction()
+    {
+    }
+
+    /**
+     * [OPTIONS] /users.
      */
     public function optionsUsersAction()
     {
@@ -72,11 +117,20 @@ class UsersController extends Controller
     }
 
     /**
-     * [LOCK] /users/{slug}/lock.
+     * [LOCK] /users/{slug}.
      *
      * @param $slug
      */
     public function lockUserAction($slug)
+    {
+    }
+
+    /**
+     * [UNLOCK] /users/{slug}.
+     *
+     * @param $slug
+     */
+    public function unlockUserAction($slug)
     {
     }
 

--- a/Tests/Fixtures/Etalon/annotated_users_controller.yml
+++ b/Tests/Fixtures/Etalon/annotated_users_controller.yml
@@ -1,3 +1,38 @@
+copy_user:
+  methods: [COPY]
+  path:    /users/{id}.{_format}
+  controller: ::copyUserAction
+
+propfind_user_props:
+  methods:    [PROPFIND]
+  path:       /users/{id}/props/{property}.{_format}
+  controller: ::propfindUserPropsAction
+
+proppatch_user_props:
+  methods:    [PROPPATCH]
+  path:       /users/{id}/props/{property}.{_format}
+  controller: ::proppatchUserPropsAction
+
+move_user:
+  methods:    [MOVE]
+  path:       /users/{id}.{_format}
+  controller: ::moveUserAction
+
+mkcol_users:
+  methods:    [MKCOL]
+  path:       /users.{_format}
+  controller: ::mkcolUsersAction
+
+lock_user:
+  methods: [LOCK]
+  path:    /users/{slug}.{_format}
+  controller: ::lockUserAction
+
+unlock_user:
+  methods: [UNLOCK]
+  path:    /users/{slug}.{_format}
+  controller: ::unlockUserAction
+
 get_users:
   path:      /users.{_format}
   controller:   ::getUsersAction

--- a/Tests/Fixtures/Etalon/prefixed_users_collection.yml
+++ b/Tests/Fixtures/Etalon/prefixed_users_collection.yml
@@ -29,8 +29,8 @@ patch_user:
   controller: ::patchUserAction
 
 lock_user:
-  methods: [PATCH]
-  path:    /resources/all/users/{slug}/lock.{_format}
+  methods: [LOCK]
+  path:    /resources/all/users/{slug}.{_format}
   controller: ::lockUserAction
 
 get_user_comments:

--- a/Tests/Fixtures/Etalon/resource_controller.yml
+++ b/Tests/Fixtures/Etalon/resource_controller.yml
@@ -34,8 +34,8 @@ patch_article:
   controller: ::patchAction
 
 lock_article:
-  methods: [PATCH]
-  path:    /articles/{slug}/lock.{_format}
+  methods: [LOCK]
+  path:    /articles/{slug}.{_format}
   controller: ::lockAction
 
 get_article_comments:

--- a/Tests/Fixtures/Etalon/users_collection.yml
+++ b/Tests/Fixtures/Etalon/users_collection.yml
@@ -29,8 +29,8 @@ patch_user:
   controller: ::patchUserAction
 
 lock_user:
-  methods: [PATCH]
-  path:    /users/{slug}/lock.{_format}
+  methods: [LOCK]
+  path:    /users/{slug}.{_format}
   controller: ::lockUserAction
 
 get_user_comments:

--- a/Tests/Fixtures/Etalon/users_controller.yml
+++ b/Tests/Fixtures/Etalon/users_controller.yml
@@ -1,3 +1,28 @@
+copy_user:
+  methods: [COPY]
+  path:    /users/{id}.{_format}
+  controller: ::copyUserAction
+
+propfind_user_props:
+  methods:    [PROPFIND]
+  path:       /users/{id}/props/{property}.{_format}
+  controller: ::propfindUserPropsAction
+
+proppatch_user_props:
+  methods:    [PROPPATCH]
+  path:       /users/{id}/props/{property}.{_format}
+  controller: ::proppatchUserPropsAction
+
+move_user:
+  methods:    [MOVE]
+  path:       /users/{id}.{_format}
+  controller: ::moveUserAction
+
+mkcol_users:
+  methods:    [MKCOL]
+  path:       /users.{_format}
+  controller: ::mkcolUsersAction
+
 get_users:
   methods: [GET]
   path:    /users.{_format}
@@ -32,6 +57,11 @@ lock_user:
   methods: [LOCK]
   path:    /users/{slug}.{_format}
   controller: ::lockUserAction
+
+unlock_user:
+  methods: [UNLOCK]
+  path:    /users/{slug}.{_format}
+  controller: ::unlockUserAction
 
 get_user_comments:
   methods: [GET]

--- a/Tests/Fixtures/Etalon/users_controller.yml
+++ b/Tests/Fixtures/Etalon/users_controller.yml
@@ -29,8 +29,8 @@ patch_user:
   controller: ::patchUserAction
 
 lock_user:
-  methods: [PATCH]
-  path:    /users/{slug}/lock.{_format}
+  methods: [LOCK]
+  path:    /users/{slug}.{_format}
   controller: ::lockUserAction
 
 get_user_comments:

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -30,7 +30,7 @@ class RestRouteLoaderTest extends LoaderTest
         $etalonRoutes = $this->loadEtalonRoutesInfo('users_controller.yml');
 
         $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(26, count($collection->all()));
+        $this->assertEquals(32, count($collection->all()));
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -96,7 +96,7 @@ class RestRouteLoaderTest extends LoaderTest
         $etalonRoutes = $this->loadEtalonRoutesInfo('annotated_users_controller.yml');
 
         $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(24, count($collection->all()));
+        $this->assertEquals(31, count($collection->all()));
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,7 +18,14 @@ This document will be updated to list important BC breaks and behavioral changes
  * removed all ``.class`` parameters, instead overwriting services via explicit Bundle configuration is preferred
  * renamed ``AbstractScalarParam::$array`` to ``AbstractScalarParam::$map``
  * added `ControllerTrait` for developers that prefer to use DI for their controllers instead of extending ``FOSRestController``
- * when having an action called ``lockUserAction``, then it will have use the http method ``LOCK`` (RFC-2518) instead of ``PATCH``
+ * when having an action called ``lockUserAction``, then it will have to use the http method ``LOCK`` (RFC-2518) instead of ``PATCH``. The following methods are affected by this change
+   * ``COPY``
+   * ``LOCK``
+   * ``MKCOL``
+   * ``MOVE``
+   * ``PROPFIND``
+   * ``PROPPATCH``
+   * ``UNLOCK``
 
 ### upgrading from 1.5.*
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,6 +18,7 @@ This document will be updated to list important BC breaks and behavioral changes
  * removed all ``.class`` parameters, instead overwriting services via explicit Bundle configuration is preferred
  * renamed ``AbstractScalarParam::$array`` to ``AbstractScalarParam::$map``
  * added `ControllerTrait` for developers that prefer to use DI for their controllers instead of extending ``FOSRestController``
+ * when having an action called ``lockUserAction``, then it will have use the http method ``LOCK`` (RFC-2518) instead of ``PATCH``
 
 ### upgrading from 1.5.*
 

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "symfony/routing":                "^2.7|^3.0",
         "doctrine/inflector":             "^1.0",
         "willdurand/negotiation":         "^2.0",
-        "willdurand/jsonp-callback-validator": "^1.0",
-        "phpunit/phpunit": "^5.1"
+        "willdurand/jsonp-callback-validator": "^1.0"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/routing":                "^2.7|^3.0",
         "doctrine/inflector":             "^1.0",
         "willdurand/negotiation":         "^2.0",
-        "willdurand/jsonp-callback-validator": "^1.0"
+        "willdurand/jsonp-callback-validator": "^1.0",
+        "phpunit/phpunit": "^5.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
this pr aims to provide support for the http methods introduced in the RFC-2518 (e.g. LOCK/UNLOCK or MOVE)

**ToDo**

- [x] annotation classes
- [x] support for the rest routing loader
- [x] docs
- [x] tests with annotations