### PR TITLE
Fixed typo in ExceptionController.php

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -190,7 +190,7 @@ class ExceptionController
                 }
             }
         } catch (\ReflectionException $re) {
-            return 'FOSUserBundle: Invalid class in fos_res.exception.messages: '
+            return 'FOSRestBundle: Invalid class in fos_rest.exception.messages: '
                     .$re->getMessage();
         }
 


### PR DESCRIPTION
In`ExceptionController::isSubclassOf`, when an invalid class was found in the array of exceptions that are allowed to display their message, it returned an exception message where `FOSUserBundle` was written, instead of `FOSRestBundle`. In the same message, the configuration parameter `fos_rest.exception.messages` was mispelled.