### PR TITLE
[FormatNegotiator] Re-add the ability to transform automatically most common mime types when using symfony 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       env: SYMFONY_VERSION='2.8.*'
     - php: 7.0
       env: SYMFONY_VERSION='3.0.*'
+    - php: 7.0
+      env: SYMFONY_VERSION='3.1.*@dev'
 
 before_install:
   - if [[ "$TRAVIS_PHP_VERSION" != "5.6" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -170,12 +170,14 @@ return $v; })
                         ->arrayNode('mime_types')
                             ->canBeEnabled()
                             ->beforeNormalization()
-                                ->ifArray()->then(function ($v) { if (!empty($v) && empty($v['formats'])) {
-     unset($v['enabled']);
-     $v = ['enabled' => true, 'formats' => $v];
- }
+                                ->ifArray()->then(function ($v) {
+                                    if (!empty($v) && empty($v['formats'])) {
+                                        unset($v['enabled']);
+                                        $v = ['enabled' => true, 'formats' => $v];
+                                    }
 
-return $v; })
+                                    return $v;
+                                })
                             ->end()
                             ->fixXmlConfig('format', 'formats')
                             ->children()

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class FOSRestExtension extends Extension
@@ -160,8 +161,8 @@ class FOSRestExtension extends Extension
                 $config['format_listener']['rules']
             );
 
-            if ($config['view']['mime_types']['enabled']) {
-                $container->getDefinition('fos_rest.format_negotiator')->replaceArgument(1, $config['view']['mime_types']['formats']);
+            if ($config['view']['mime_types']['enabled'] && !method_exists(Request::class, 'getMimeTypes')) {
+                $container->getDefinition('fos_rest.format_negotiator')->addArgument($config['view']['mime_types']['formats']);
             }
         }
     }
@@ -261,7 +262,7 @@ class FOSRestExtension extends Extension
                 $service->clearTag('kernel.event_listener');
             }
 
-            $container->getDefinition('fos_rest.mime_type_listener')->replaceArgument(0, $config['view']['mime_types']);
+            $container->getDefinition('fos_rest.mime_type_listener')->replaceArgument(0, $config['view']['mime_types']['formats']);
         }
 
         if ($config['view']['view_response_listener']['enabled']) {
@@ -331,8 +332,8 @@ class FOSRestExtension extends Extension
                 $container->getDefinition('fos_rest.exception_listener')->replaceArgument(0, 'fos_rest.exception.twig_controller:showAction');
             }
 
-            if ($config['view']['mime_types']['enabled']) {
-                $container->getDefinition('fos_rest.exception_format_negotiator')->replaceArgument(1, $config['view']['mime_types']['formats']);
+            if ($config['view']['mime_types']['enabled'] && !method_exists(Request::class, 'getMimeTypes')) {
+                $container->getDefinition('fos_rest.exception_format_negotiator')->addArgument($config['view']['mime_types']['formats']);
             }
 
             $exceptionController = $container->getDefinition('fos_rest.exception.controller');

--- a/EventListener/MimeTypeListener.php
+++ b/EventListener/MimeTypeListener.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\EventListener;
 
 use FOS\RestBundle\FOSRestBundle;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -51,8 +52,16 @@ class MimeTypeListener
         }
 
         if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
-            foreach ($this->mimeTypes as $format => $mimeType) {
-                $request->setFormat($format, $mimeType);
+            foreach ($this->mimeTypes as $format => $mimeTypes) {
+                if (method_exists(Request::class, 'getMimeTypes')) {
+                    $mimeTypes = array_merge($mimeTypes, Request::getMimeTypes($format));
+                } elseif (null !== $request->getMimeType($format)) {
+                    $class = new \ReflectionClass(Request::class);
+                    $properties = $class->getStaticProperties();
+                    $mimeTypes = array_merge($mimeTypes, $properties['formats'][$format]);
+                }
+
+                $request->setFormat($format, $mimeTypes);
             }
         }
     }

--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -138,12 +138,18 @@ class FormatNegotiator extends BaseNegotiator
                 continue;
             }
 
-            if (isset($this->mimeTypes[$priority])) {
-                foreach ($this->mimeTypes[$priority] as $mimeType) {
+            if (method_exists(Request::class, 'getMimeTypes')) {
+                foreach (Request::getMimeTypes($priority) as $mimeType) {
                     $mimeTypes[] = $mimeType;
                 }
             } elseif (($mimeType = $request->getMimeType($priority)) !== null) {
                 $mimeTypes[] = $mimeType;
+            }
+
+            if (isset($this->mimeTypes[$priority])) {
+                foreach ($this->mimeTypes[$priority] as $mimeType) {
+                    $mimeTypes[] = $mimeType;
+                }
             }
         }
 

--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -139,11 +139,11 @@ class FormatNegotiator extends BaseNegotiator
             }
 
             if (method_exists(Request::class, 'getMimeTypes')) {
-                foreach (Request::getMimeTypes($priority) as $mimeType) {
-                    $mimeTypes[] = $mimeType;
-                }
-            } elseif (($mimeType = $request->getMimeType($priority)) !== null) {
-                $mimeTypes[] = $mimeType;
+                $mimeTypes = array_merge($mimeTypes, Request::getMimeTypes($priority));
+            } elseif (null !== $request->getMimeType($priority)) {
+                $class = new \ReflectionClass(Request::class);
+                $properties = $class->getStaticProperties();
+                $mimeTypes = array_merge($mimeTypes, $properties['formats'][$priority]);
             }
 
             if (isset($this->mimeTypes[$priority])) {

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -27,7 +27,6 @@
 
         <service id="fos_rest.exception_format_negotiator" class="FOS\RestBundle\Negotiation\FormatNegotiator" >
             <argument type="service" id="request_stack" />
-            <argument type="collection" /> <!-- mime types -->
         </service>
     </services>
 </container>

--- a/Resources/config/format_listener.xml
+++ b/Resources/config/format_listener.xml
@@ -13,7 +13,6 @@
 
         <service id="fos_rest.format_negotiator" class="FOS\RestBundle\Negotiation\FormatNegotiator">
             <argument type="service" id="request_stack" />
-            <argument type="collection" /> <!-- mime types -->
         </service>
 
         <service id="fos_rest.format_request_matcher" class="Symfony\Component\HttpFoundation\RequestMatcher" public="false" />

--- a/Resources/doc/format_listener.rst
+++ b/Resources/doc/format_listener.rst
@@ -84,7 +84,7 @@ in the controller action.
         // ...
     }
 
-Note that the format needs to be added using the :doc:`Mime Type Listener <3-listener-support>`.
+Note that the mime types corresponding to your format need to be added using the :doc:`Mime Type Listener <3-listener-support>` (only the uncommon if you're using symfony 3.1 or higher).
 
 Disabling the Format Listener via Rules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Resources/doc/format_listener.rst
+++ b/Resources/doc/format_listener.rst
@@ -84,7 +84,7 @@ in the controller action.
         // ...
     }
 
-Note that the mime types corresponding to your format need to be added using the :doc:`Mime Type Listener <3-listener-support>` (only the uncommon if you're using symfony 3.1 or higher).
+Note that if you use custom mime types, they need to be added using the :doc:`Mime Type Listener <3-listener-support>`.
 
 Disabling the Format Listener via Rules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/Functional/app/Version/config.yml
+++ b/Tests/Functional/app/Version/config.yml
@@ -15,7 +15,6 @@ fos_rest:
     view:
         view_response_listener: true
         mime_types:
-            html: ['text/html']
             json: ['application/json', 'application/json;myversion=2.3']
     versioning:
         enabled: true

--- a/Tests/Negotiation/FormatNegotiatorTest.php
+++ b/Tests/Negotiation/FormatNegotiatorTest.php
@@ -32,12 +32,7 @@ class FormatNegotiatorTest extends \PHPUnit_Framework_TestCase
         $this->requestStack = new RequestStack();
         $this->request = new Request();
         $this->requestStack->push($this->request);
-        if (method_exists(Request::class, 'getMimeTypes')) {
-            $mimeTypes = ['json' => ['application/json;version=1.0']];
-        } else {
-            $mimeTypes = ['json' => ['application/json', 'application/json;version=1.0'], 'html' => ['text/html', 'application/xhtml+xml'], 'xml' => ['application/xml']];
-        }
-        $this->negotiator = new FormatNegotiator($this->requestStack, $mimeTypes);
+        $this->negotiator = new FormatNegotiator($this->requestStack, ['json' => ['application/json;version=1.0']]);
     }
 
     public function testEmptyRequestMatcherMap()

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,7 +5,7 @@ This document will be updated to list important BC breaks and behavioral changes
 
 ### upgrading to 2.0.0
 
- * it is now recommended to explicitly configure the format to mime type mapping via ``fos_rest.view.mime_types``
+ * it is now recommended to explicitly configure the format to mime type mapping via ``fos_rest.view.mime_types`` except if you're using symfony 3.1 or higher
  * dropped support for the legacy ``Symfony\Component\Validator\ValidatorInterface``
  * removed ``FOS\RestBundle\Util\Codes`` in favor of ``Symfony\Component\HttpFoundation\Response``
  * compatibility with Symfony <2.7, JMS Serializer/SerializerBundle <1.0 and SensioFrameworkExtraBundle <3.0 was dropped

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,7 +5,6 @@ This document will be updated to list important BC breaks and behavioral changes
 
 ### upgrading to 2.0.0
 
- * it is now recommended to explicitly configure the format to mime type mapping via ``fos_rest.view.mime_types`` except if you're using symfony 3.1 or higher
  * dropped support for the legacy ``Symfony\Component\Validator\ValidatorInterface``
  * removed ``FOS\RestBundle\Util\Codes`` in favor of ``Symfony\Component\HttpFoundation\Response``
  * compatibility with Symfony <2.7, JMS Serializer/SerializerBundle <1.0 and SensioFrameworkExtraBundle <3.0 was dropped


### PR DESCRIPTION
Re-add the ability to transform automatically most common mime types.

See https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1149#discussion-diff-41261255