### PR TITLE
Update JMSSerializerAdapter.php

### DIFF
--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -22,7 +22,7 @@ use JMS\Serializer\SerializerInterface;
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-final class JMSSerializerAdapter implements Serializer
+class JMSSerializerAdapter implements Serializer
 {
     /**
      * @internal

--- a/Serializer/SymfonySerializerAdapter.php
+++ b/Serializer/SymfonySerializerAdapter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-final class SymfonySerializerAdapter implements Serializer
+class SymfonySerializerAdapter implements Serializer
 {
     private $serializer;
 


### PR DESCRIPTION
Fixes `Provided class "FOS\RestBundle\Serializer\JMSSerializerAdapter" is final and cannot be proxied` exception.

issue https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1325