### PR TITLE
disable Xdebug on Travis CI when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
 
 before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "5.6" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
 


### PR DESCRIPTION
Disabling Xdebug on Travis CI jobs that do not generate code coverage
reports speeds up builds significantly.