### PR TITLE
Serializer adapters no longer final

### DIFF
--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -22,7 +22,7 @@ use JMS\Serializer\SerializerInterface;
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-final class JMSSerializerAdapter implements Serializer
+class JMSSerializerAdapter implements Serializer
 {
     /**
      * @internal

--- a/Serializer/SymfonySerializerAdapter.php
+++ b/Serializer/SymfonySerializerAdapter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-final class SymfonySerializerAdapter implements Serializer
+class SymfonySerializerAdapter implements Serializer
 {
     private $serializer;
 


### PR DESCRIPTION
The serializers are marked lazy, but defined as final. This causes an
exception being thrown when de container is initialized since it tries
to create a proxy, but fails because the classes are final.
Fixes#1325