### PR TITLE
Backport for annotation enhancements

### DIFF
--- a/Controller/Annotations/Copy.php
+++ b/Controller/Annotations/Copy.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * COPY Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Copy extends Route
+{
+    public function getMethod()
+    {
+        return 'COPY';
+    }
+}

--- a/Controller/Annotations/Lock.php
+++ b/Controller/Annotations/Lock.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * LOCK Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Lock extends Route
+{
+    public function getMethod()
+    {
+        return 'LOCK';
+    }
+}

--- a/Controller/Annotations/Mkcol.php
+++ b/Controller/Annotations/Mkcol.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * MKCOL Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Mkcol extends Route
+{
+    public function getMethod()
+    {
+        return 'MKCOL';
+    }
+}

--- a/Controller/Annotations/Move.php
+++ b/Controller/Annotations/Move.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * MOVE Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Move extends Route
+{
+    public function getMethod()
+    {
+        return 'MOVE';
+    }
+}

--- a/Controller/Annotations/PropFind.php
+++ b/Controller/Annotations/PropFind.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * PROPFIND Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class PropFind extends Route
+{
+    public function getMethod()
+    {
+        return 'PROPFIND';
+    }
+}

--- a/Controller/Annotations/PropPatch.php
+++ b/Controller/Annotations/PropPatch.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * PROPPATCH Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class PropPatch extends Route
+{
+    public function getMethod()
+    {
+        return 'PROPPATCH';
+    }
+}

--- a/Controller/Annotations/Unlock.php
+++ b/Controller/Annotations/Unlock.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Controller\Annotations;
+
+/**
+ * UNLOCK Route annotation class.
+ *
+ * @Annotation
+ * @Target("METHOD")
+ *
+ * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>
+ */
+class Unlock extends Route
+{
+    public function getMethod()
+    {
+        return 'UNLOCK';
+    }
+}

--- a/Resources/doc/annotations-reference.rst
+++ b/Resources/doc/annotations-reference.rst
@@ -92,7 +92,7 @@ Route
 
 RestBundle extends the `@Route Symfony annotation`_ from Symfony.
 
-@Delete @Get @Head @Link @Patch @Post @Put @Unlink have the same options as @Route.
+@Delete @Get @Head @Link @Patch @Post @Put @Unlink @Lock @Unlock @PropFind @PropPatch @Move @Mkcol @Copy have the same options as @Route.
 
 When using ``symfony/routing:>=2.4`` (or the full framework) you have access to
 the expression language component and can add conditions to your routing


### PR DESCRIPTION
@xabbuh wanted me to backport the feature implemented in #1314 into the 1.8 branch to provide at least parts of the feature in older versions, so the first two commits of that feature containing no BC breaks are cherry-picked into this branch.

for more information please see the discussion in the actual PR for 2.0: https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1314#issuecomment-173967308