### PR TITLE
Fixed arguments passed to custom handlers

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -297,7 +297,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface
         }
 
         if (isset($this->customHandlers[$format])) {
-            return call_user_func($this->customHandlers[$format], $this, $view, $request, $format);
+            return call_user_func($this->customHandlers[$format], $view, $request, $format);
         }
 
         return $this->createResponse($view, $request, $format);


### PR DESCRIPTION
When trying to use custom view handlers, an error would be thrown saying a view is expected for the first parameter to the createResponse method. It looks like $this was being added as a parameter in the call which was causing the error. This changed fixed it for me.