### PR TITLE
Allow to customize deeper the AccessDeniedListener

### DIFF
--- a/Resources/config/access_denied_listener.xml
+++ b/Resources/config/access_denied_listener.xml
@@ -11,8 +11,6 @@
             <tag name="monolog.logger" channel="request" />
             <argument type="collection" /> <!-- formats -->
             <argument /> <!-- unauthorized challenge -->
-            <argument>%twig.exception_listener.controller%</argument>
-            <argument type="service" id="logger" on-invalid="null" />
         </service>
 
     </services>

--- a/Resources/doc/3-listener-support.rst
+++ b/Resources/doc/3-listener-support.rst
@@ -193,7 +193,7 @@ You need to enable this listener as follows, as it is disabled by default:
             # all requests using the 'json' format will return a 403 on an access denied violation
             json: true
 
-It is also recommended to enable the exception controller described in the next chapter.
+Note: The access_denied_listener doesn't return a response itself and must be coupled with an exception listener returning a response (see the :doc:`FOSRestBundle exception controller <4-exception-controller-support>`. or the `twig exception controller`_).
 
 Zone Listener
 =============
@@ -238,3 +238,4 @@ That was it!
 .. _`ParamConverters`: http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/annotations/converters.html
 .. _`mime type listener`: http://symfony.com/doc/current/cookbook/request/mime_type.html
 .. _`Test Cases for HTTP Test Cases for the HTTP WWW-Authenticate header field`: http://greenbytes.de/tech/tc/httpauth/
+.. _`twig exception controller`: https://symfony.com/doc/current/cookbook/controller/error_pages.html

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,6 +27,7 @@ This document will be updated to list important BC breaks and behavioral changes
    * ``UNLOCK``
  * the ``RequestBodyParamConverter`` now has a priority of ``-50``
  * the ``RequestBodyParamConverter`` doesn't throw an exception anymore when a parameter is optional
+ * removed the ability of the ``AccessDeniedListener`` to render a response. Use the FOSRestBundle or the twig exception controller in complement.
 
 ### upgrading from 1.5.*
 


### PR DESCRIPTION
See https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1356#issuecomment-190932403

This PR makes the AccessDeniedListener simpler and let the others listeners render the response.