### PR TITLE
Add fos_rest.exception.show_exceptions config param

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,21 @@ use Symfony\Component\HttpFoundation\Response;
 final class Configuration implements ConfigurationInterface
 {
     /**
+     * Default debug mode value.
+     *
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @param bool $debug
+     */
+    public function __construct($debug)
+    {
+        $this->debug = (bool) $debug;
+    }
+
+    /**
      * Generates the configuration tree.
      *
      * @return TreeBuilder
@@ -387,6 +402,9 @@ return $v; })
                         ->arrayNode('messages')
                             ->useAttributeAsKey('name')
                             ->prototype('boolean')->end()
+                        ->end()
+                        ->booleanNode('debug')
+                            ->defaultValue($this->debug)
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -33,7 +33,8 @@ class FOSRestExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $configs);
+        $configuration = new Configuration($container->getParameter('kernel.debug'));
+        $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('view.xml');
@@ -326,6 +327,13 @@ class FOSRestExtension extends Extension
                 ->replaceArgument(0, $config['exception']['codes']);
             $container->getDefinition('fos_rest.exception.messages_map')
                 ->replaceArgument(0, $config['exception']['messages']);
+
+            $container->getDefinition('fos_rest.exception.controller')
+                ->replaceArgument(2, $config['exception']['debug']);
+            $container->getDefinition('fos_rest.serializer.exception_normalizer.jms')
+                ->replaceArgument(1, $config['exception']['debug']);
+            $container->getDefinition('fos_rest.serializer.exception_normalizer.symfony')
+                ->replaceArgument(1, $config['exception']['debug']);
         }
 
         foreach ($config['exception']['codes'] as $exception => $code) {

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -15,7 +15,7 @@
         <service id="fos_rest.exception.controller" class="FOS\RestBundle\Controller\ExceptionController">
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="fos_rest.exception.codes_map" />  <!-- exception codes -->
-            <argument>%kernel.debug%</argument>
+            <argument /><!-- show exception -->
         </service>
 
         <service id="fos_rest.exception.twig_controller" class="FOS\RestBundle\Controller\TwigExceptionController" parent="fos_rest.exception.controller">
@@ -32,13 +32,13 @@
 
         <service id="fos_rest.serializer.exception_normalizer.jms" class="FOS\RestBundle\Serializer\Normalizer\ExceptionHandler">
             <argument type="service" id="fos_rest.exception.messages_map" /> <!-- exception messages -->
-            <argument>%kernel.debug%</argument>
+            <argument /><!-- show exception message -->
             <tag name="jms_serializer.subscribing_handler" />
         </service>
 
         <service id="fos_rest.serializer.exception_normalizer.symfony" class="FOS\RestBundle\Serializer\Normalizer\ExceptionNormalizer" public="false">
             <argument type="service" id="fos_rest.exception.messages_map" /> <!-- exception messages -->
-            <argument>%kernel.debug%</argument>
+            <argument /><!-- show exception message -->
             <tag name="serializer.normalizer" />
         </service>
     </services>

--- a/Tests/Functional/Bundle/TestBundle/Controller/SerializerErrorController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/SerializerErrorController.php
@@ -33,6 +33,14 @@ class SerializerErrorController extends Controller
     /**
      * @View
      */
+    public function unknownExceptionAction()
+    {
+        throw new \OutOfBoundsException('Unknown exception message.');
+    }
+
+    /**
+     * @View
+     */
     public function invalidFormAction()
     {
         // BC hack for Symfony 2.7 where FormType's didn't yet get configured via the FQN

--- a/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -6,6 +6,10 @@ test_serializer_error_exception:
     path:     /serializer-error/exception.{_format}
     defaults: { _controller: TestBundle:SerializerError:logicException }
 
+test_serializer_unknown_exception:
+    path:     /serializer-error/unknown_exception.{_format}
+    defaults: { _controller: TestBundle:SerializerError:unknownException }
+
 test_serializer_error_invalid_form:
     path:     /serializer-error/invalid-form.{_format}
     defaults: { _controller: TestBundle:SerializerError:invalidForm }

--- a/Tests/Functional/SerializerErrorTest.php
+++ b/Tests/Functional/SerializerErrorTest.php
@@ -31,6 +31,26 @@ class SerializerErrorTest extends WebTestCase
         $this->assertEquals('{"code":500,"message":"Something bad happened."}', $client->getResponse()->getContent());
     }
 
+    public function testSerializeExceptionJsonWithDebug()
+    {
+        $this->iniSet('error_log', file_exists('/dev/null') ? '/dev/null' : 'nul');
+
+        $client = $this->createClient(['test_case' => 'Debug', 'debug' => false]);
+        $client->request('GET', '/serializer-error/unknown_exception.json');
+
+        $this->assertEquals('{"code":500,"message":"Unknown exception message."}', $client->getResponse()->getContent());
+    }
+
+    public function testSerializeExceptionJsonWithoutDebug()
+    {
+        $this->iniSet('error_log', file_exists('/dev/null') ? '/dev/null' : 'nul');
+
+        $client = $this->createClient(['test_case' => 'Serializer', 'debug' => false]);
+        $client->request('GET', '/serializer-error/unknown_exception.json');
+
+        $this->assertEquals('{"code":500,"message":"Internal Server Error"}', $client->getResponse()->getContent());
+    }
+
     /**
      * @dataProvider serializeExceptionXmlProvider
      */

--- a/Tests/Functional/app/Debug/bundles.php
+++ b/Tests/Functional/app/Debug/bundles.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \JMS\SerializerBundle\JMSSerializerBundle(),
+    new \FOS\RestBundle\FOSRestBundle(),
+    new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
+];

--- a/Tests/Functional/app/Debug/config.yml
+++ b/Tests/Functional/app/Debug/config.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: ../config/exception_listener.yml }
+
+fos_rest:
+    exception:
+        debug: true


### PR DESCRIPTION
In order to be able manually enable/disable exception in error response.
Now kernel.debug value is used and it is not useful in some cases.
For example in functional test, thou it is run in debug mode, be able to check error response as it would be in prod environment (without exception).