### PR TITLE
Use ExceptionValueMap to store exception values (codes or message) instead of trait

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -11,7 +11,7 @@
 
 namespace FOS\RestBundle\Controller;
 
-use FOS\RestBundle\Util\ClassMapHandlerTrait;
+use FOS\RestBundle\Util\ExceptionValueMap;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,15 +25,24 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
  */
 class ExceptionController
 {
-    use ClassMapHandlerTrait;
-
+    /**
+     * @var ViewHandlerInterface
+     */
     private $viewHandler;
+
+    /**
+     * @var ExceptionValueMap
+     */
     private $exceptionCodes;
+
+    /**
+     * @var bool
+     */
     private $showException;
 
     public function __construct(
         ViewHandlerInterface $viewHandler,
-        array $exceptionCodes,
+        ExceptionValueMap $exceptionCodes,
         $showException
     ) {
         $this->viewHandler = $viewHandler;
@@ -92,7 +101,7 @@ class ExceptionController
     protected function getStatusCode(\Exception $exception)
     {
         // If matched
-        if ($statusCode = $this->resolveValue(get_class($exception), $this->exceptionCodes)) {
+        if ($statusCode = $this->exceptionCodes->resolveException($exception)) {
             return $statusCode;
         }
 

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -322,11 +322,9 @@ class FOSRestExtension extends Extension
                 $container->getDefinition('fos_rest.exception_listener')->replaceArgument(0, 'fos_rest.exception.twig_controller:showAction');
             }
 
-            $container->getDefinition('fos_rest.exception.controller')
-                ->replaceArgument(2, $config['exception']['codes']);
-            $container->getDefinition('fos_rest.serializer.exception_normalizer.jms')
-                ->replaceArgument(0, $config['exception']['messages']);
-            $container->getDefinition('fos_rest.serializer.exception_normalizer.symfony')
+            $container->getDefinition('fos_rest.exception.codes_map')
+                ->replaceArgument(0, $config['exception']['codes']);
+            $container->getDefinition('fos_rest.exception.messages_map')
                 ->replaceArgument(0, $config['exception']['messages']);
         }
 

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -14,7 +14,7 @@
 
         <service id="fos_rest.exception.controller" class="FOS\RestBundle\Controller\ExceptionController">
             <argument type="service" id="fos_rest.view_handler" />
-            <argument type="collection" /> <!-- exception codes -->
+            <argument type="service" id="fos_rest.exception.codes_map" />  <!-- exception codes -->
             <argument>%kernel.debug%</argument>
         </service>
 
@@ -22,14 +22,22 @@
             <argument type="service" id="templating.engine.twig" />
         </service>
 
+        <service id="fos_rest.exception.codes_map" class="FOS\RestBundle\Util\ExceptionValueMap">
+            <argument type="collection"/> <!-- exception codes -->
+        </service>
+
+        <service id="fos_rest.exception.messages_map" class="FOS\RestBundle\Util\ExceptionValueMap">
+            <argument type="collection"/> <!-- exception messages -->
+        </service>
+
         <service id="fos_rest.serializer.exception_normalizer.jms" class="FOS\RestBundle\Serializer\Normalizer\ExceptionHandler">
-            <argument type="collection" /> <!-- exception messages -->
+            <argument type="service" id="fos_rest.exception.messages_map" /> <!-- exception messages -->
             <argument>%kernel.debug%</argument>
             <tag name="jms_serializer.subscribing_handler" />
         </service>
 
         <service id="fos_rest.serializer.exception_normalizer.symfony" class="FOS\RestBundle\Serializer\Normalizer\ExceptionNormalizer" public="false">
-            <argument type="collection" /> <!-- exception messages -->
+            <argument type="service" id="fos_rest.exception.messages_map" /> <!-- exception messages -->
             <argument>%kernel.debug%</argument>
             <tag name="serializer.normalizer" />
         </service>

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -22,11 +22,11 @@
             <argument type="service" id="templating.engine.twig" />
         </service>
 
-        <service id="fos_rest.exception.codes_map" class="FOS\RestBundle\Util\ExceptionValueMap">
+        <service id="fos_rest.exception.codes_map" class="FOS\RestBundle\Util\ExceptionValueMap" public="false">
             <argument type="collection"/> <!-- exception codes -->
         </service>
 
-        <service id="fos_rest.exception.messages_map" class="FOS\RestBundle\Util\ExceptionValueMap">
+        <service id="fos_rest.exception.messages_map" class="FOS\RestBundle\Util\ExceptionValueMap" public="false">
             <argument type="collection"/> <!-- exception messages -->
         </service>
 

--- a/Serializer/Normalizer/AbstractExceptionNormalizer.php
+++ b/Serializer/Normalizer/AbstractExceptionNormalizer.php
@@ -11,7 +11,7 @@
 
 namespace FOS\RestBundle\Serializer\Normalizer;
 
-use FOS\RestBundle\Util\ClassMapHandlerTrait;
+use FOS\RestBundle\Util\ExceptionValueMap;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -21,16 +21,21 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AbstractExceptionNormalizer
 {
-    use ClassMapHandlerTrait;
-
+    /**
+     * @var ExceptionValueMap
+     */
     private $messagesMap;
+
+    /**
+     * @var bool
+     */
     private $debug;
 
     /**
      * @param array $messagesMap
      * @param bool  $debug
      */
-    public function __construct(array $messagesMap, $debug)
+    public function __construct(ExceptionValueMap $messagesMap, $debug)
     {
         $this->messagesMap = $messagesMap;
         $this->debug = $debug;
@@ -46,7 +51,7 @@ class AbstractExceptionNormalizer
      */
     protected function getExceptionMessage(\Exception $exception, $statusCode = null)
     {
-        $showMessage = $this->resolveValue(get_class($exception), $this->messagesMap);
+        $showMessage = $this->messagesMap->resolveException($exception);
 
         if ($showMessage || $this->debug) {
             return $exception->getMessage();

--- a/Tests/Util/ExceptionValueMapTest.php
+++ b/Tests/Util/ExceptionValueMapTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests;
+
+use FOS\RestBundle\Util\ExceptionValueMap;
+
+/**
+ * ExceptionValueMap test.
+ *
+ * @author Mikhail Shamin <munk13@gmail.com>
+ */
+class ExceptionValueMapTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ExceptionValueMap
+     */
+    private $valueMap;
+
+    protected function setUp()
+    {
+        $map = [
+            \LogicException::class => 'logic',
+            \DomainException::class => 'domain',
+            \OutOfBoundsException::class => null,
+        ];
+
+        $this->valueMap = new ExceptionValueMap($map);
+    }
+
+    public function testResolveExceptionValueIsFound()
+    {
+        $this->assertSame('logic', $this->valueMap->resolveException(new \LogicException()));
+    }
+
+    public function testResolveExceptionValueIsFoundBySubclass()
+    {
+        $this->assertSame('logic', $this->valueMap->resolveException(new \BadFunctionCallException()));
+    }
+
+    public function testResolveExceptionValueNotFound()
+    {
+        $this->assertFalse($this->valueMap->resolveException(new \RuntimeException()));
+    }
+
+    public function testResolveExceptionNullValueIsSkipped()
+    {
+        $this->assertFalse($this->valueMap->resolveClass(new \OutOfBoundsException()));
+    }
+
+    public function testResolveClassValueIsFound()
+    {
+        $this->assertSame('logic', $this->valueMap->resolveClass(\LogicException::class));
+    }
+
+    public function testResolveClassValueIsFoundBySubclass()
+    {
+        $this->assertSame('logic', $this->valueMap->resolveClass(\BadFunctionCallException::class));
+    }
+
+    public function testResolveClassValueNotFound()
+    {
+        $this->assertFalse($this->valueMap->resolveClass(\RuntimeException::class));
+    }
+
+    public function testResolveClassNullValueIsSkipped()
+    {
+        $this->assertFalse($this->valueMap->resolveClass(\OutOfBoundsException::class));
+    }
+}

--- a/Tests/Util/ExceptionValueMapTest.php
+++ b/Tests/Util/ExceptionValueMapTest.php
@@ -50,29 +50,4 @@ class ExceptionValueMapTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->valueMap->resolveException(new \RuntimeException()));
     }
-
-    public function testResolveExceptionNullValueIsSkipped()
-    {
-        $this->assertFalse($this->valueMap->resolveClass(new \OutOfBoundsException()));
-    }
-
-    public function testResolveClassValueIsFound()
-    {
-        $this->assertSame('logic', $this->valueMap->resolveClass(\LogicException::class));
-    }
-
-    public function testResolveClassValueIsFoundBySubclass()
-    {
-        $this->assertSame('logic', $this->valueMap->resolveClass(\BadFunctionCallException::class));
-    }
-
-    public function testResolveClassValueNotFound()
-    {
-        $this->assertFalse($this->valueMap->resolveClass(\RuntimeException::class));
-    }
-
-    public function testResolveClassNullValueIsSkipped()
-    {
-        $this->assertFalse($this->valueMap->resolveClass(\OutOfBoundsException::class));
-    }
 }

--- a/Util/ExceptionValueMap.php
+++ b/Util/ExceptionValueMap.php
@@ -11,24 +11,35 @@
 
 namespace FOS\RestBundle\Util;
 
-/**
- * @author Ener-Getick <egetick@gmail.com>
- *
- * @internal do not use this trait or its functions in your code.
- */
-trait ClassMapHandlerTrait
+class ExceptionValueMap
 {
+    /**
+     * Map of values mapped to exception class
+     * key => exception class
+     * value => value associated with exception.
+     *
+     * @var array
+     */
+    private $map;
+
+    /**
+     * @param array $map
+     */
+    public function __construct(array $map)
+    {
+        $this->map = $map;
+    }
+
     /**
      * Resolves the value corresponding to a class from an array.
      *
      * @param string $class
-     * @param array  $map
      *
      * @return mixed|false if not found
      */
-    public function resolveValue($class, array $map)
+    public function resolveClass($class)
     {
-        foreach ($map as $mapClass => $value) {
+        foreach ($this->map as $mapClass => $value) {
             if (!$value) {
                 continue;
             }
@@ -39,5 +50,17 @@ trait ClassMapHandlerTrait
         }
 
         return false;
+    }
+
+    /**
+     * Get value by exception.
+     *
+     * @param \Exception $exception
+     *
+     * @return false|mixed
+     */
+    public function resolveException(\Exception $exception)
+    {
+        return $this->resolveClass(get_class($exception));
     }
 }

--- a/Util/ExceptionValueMap.php
+++ b/Util/ExceptionValueMap.php
@@ -11,6 +11,12 @@
 
 namespace FOS\RestBundle\Util;
 
+/**
+ * Stores map of values mapped to exception class
+ * Resolves value by exception.
+ *
+ * @author Mikhail Shamin <munk13@gmail.com>
+ */
 class ExceptionValueMap
 {
     /**
@@ -31,13 +37,25 @@ class ExceptionValueMap
     }
 
     /**
-     * Resolves the value corresponding to a class from an array.
+     * Resolves the value corresponding to an exception object.
+     *
+     * @param \Exception $exception
+     *
+     * @return mixed|false Value found or false is not found
+     */
+    public function resolveException(\Exception $exception)
+    {
+        return $this->doResolveClass(get_class($exception));
+    }
+
+    /**
+     * Resolves the value corresponding to an exception class.
      *
      * @param string $class
      *
      * @return mixed|false if not found
      */
-    public function resolveClass($class)
+    private function doResolveClass($class)
     {
         foreach ($this->map as $mapClass => $value) {
             if (!$value) {
@@ -50,17 +68,5 @@ class ExceptionValueMap
         }
 
         return false;
-    }
-
-    /**
-     * Get value by exception.
-     *
-     * @param \Exception $exception
-     *
-     * @return false|mixed
-     */
-    public function resolveException(\Exception $exception)
-    {
-        return $this->resolveClass(get_class($exception));
     }
 }


### PR DESCRIPTION
Use ExceptionValueMap to store map of exception values (codes or messages)
And use it instead of ClassMapHandlerTrait to get code or message associated with exception
In this case resolve logic is incapsulated in ExceptionValueMap and is not exposed into controller or serialize normalizer.
