### PR TITLE
Throw an exception an exception when the SensioFrameworkExtraBundle is wrongly configured

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationCheckPass.php
+++ b/DependencyInjection/Compiler/ConfigurationCheckPass.php
@@ -28,5 +28,11 @@ final class ConfigurationCheckPass implements CompilerPassInterface
         if ($container->has('fos_rest.converter.request_body') && !$container->has('sensio_framework_extra.converter.listener')) {
             throw new \RuntimeException('You need to enable the parameter converter listeners in SensioFrameworkExtraBundle when using the FOSRestBundle RequestBodyParamConverter');
         }
+
+        if ($container->has('fos_rest.view_response_listener') && isset($container->getParameter('kernel.bundles')['SensioFrameworkExtraBundle'])) {
+            if (!$container->has('sensio_framework_extra.view.listener')) {
+                throw new \RuntimeException('You must enable the SensioFrameworkExtraBundle view annotations to use the ViewResponseListener.');
+            }
+        }
     }
 }

--- a/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
@@ -21,25 +21,30 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class ConfigurationCheckPassTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage You need to enable the parameter converter listeners in SensioFrameworkExtraBundle when using the FOSRestBundle RequestBodyParamConverter
+     */
     public function testShouldThrowRuntimeExceptionWhenBodyConverterIsEnabledButParamConvertersAreNotEnabled()
     {
-        $this->setExpectedException(
-            'RuntimeException',
-            'You need to enable the parameter converter listeners in SensioFrameworkExtraBundle when using the FOSRestBundle RequestBodyParamConverter'
-        );
-        $container = $this->getMockBuilder(ContainerBuilder::class)
-            ->setMethods(['has'])
-            ->getMock();
+        $container = new ContainerBuilder();
 
-        $container->expects($this->at(0))
-            ->method('has')
-            ->with($this->equalTo('fos_rest.converter.request_body'))
-            ->will($this->returnValue(true));
+        $container->register('fos_rest.converter.request_body');
 
-        $container->expects($this->at(1))
-            ->method('has')
-            ->with($this->equalTo('sensio_framework_extra.converter.listener'))
-            ->will($this->returnValue(false));
+        $compiler = new ConfigurationCheckPass();
+        $compiler->process($container);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage SensioFrameworkExtraBundle view annotations
+     */
+    public function testExceptionWhenViewAnnotationsAreNotEnabled()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('fos_rest.view_response_listener');
+        $container->setParameter('kernel.bundles', ['SensioFrameworkExtraBundle' => '']);
 
         $compiler = new ConfigurationCheckPass();
         $compiler->process($container);

--- a/Tests/Functional/app/Configuration/config.yml
+++ b/Tests/Functional/app/Configuration/config.yml
@@ -10,6 +10,7 @@ framework:
 fos_rest:
     view:
         mime_types: true
+        view_response_listener: true
     param_fetcher_listener: true
     disable_csrf_role: foo
     allowed_methods_listener: true


### PR DESCRIPTION
People doesn't seem to read the upgrading file so it's probably better to throw an exception when their configuration won't work.
see https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1381