### PR TITLE
fix loading route directory resources

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -17,17 +17,18 @@
 
     <services>
 
+        <service id="fos_rest.routing.loader.directory" class="FOS\RestBundle\Routing\Loader\DirectoryRouteLoader" public="false">
+            <argument type="service" id="file_locator" />
+            <argument type="service" id="fos_rest.routing.loader.processor" />
+            <tag name="routing.loader" />
+        </service>
+
         <service id="fos_rest.routing.loader.controller" class="%fos_rest.routing.loader.controller.class%">
             <argument type="service" id="service_container" />
             <argument type="service" id="file_locator" />
             <argument type="service" id="controller_name_converter" />
             <argument type="service" id="fos_rest.routing.loader.reader.controller" />
             <argument>%fos_rest.routing.loader.default_format%</argument>
-            <tag name="routing.loader" />
-        </service>
-
-        <service id="fos_rest.routing.loader.directory" class="FOS\RestBundle\Routing\Loader\DirectoryRouteLoader">
-            <argument type="service" id="fos_rest.routing.loader.processor" />
             <tag name="routing.loader" />
         </service>
 

--- a/Tests/Functional/Bundle/TestBundle/Controller/Api/CommentController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/Api/CommentController.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller\Api;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class CommentController
+{
+    public function getCommentAction($id)
+    {
+        return new JsonResponse(array('id' => $id));
+    }
+}

--- a/Tests/Functional/Bundle/TestBundle/Controller/Api/PostController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/Api/PostController.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller\Api;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class PostController
+{
+    public function getPostAction($id)
+    {
+        return new JsonResponse(array('id' => $id));
+    }
+}

--- a/Tests/Functional/RoutingTest.php
+++ b/Tests/Functional/RoutingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Functional;
+
+class RoutingTest extends WebTestCase
+{
+    private $client;
+
+    public function setUp()
+    {
+        $this->client = $this->createClient(array('test_case' => 'Routing'));
+    }
+
+    public function testPostControllerRoutesAreRegistered()
+    {
+        $this->client->request('GET', '/posts/1');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertJsonStringEqualsJsonString('{ "id": 1 }', $this->client->getResponse()->getContent());
+    }
+
+    public function testCommentControllerRoutesAreRegistered()
+    {
+        $this->client->request('GET', '/comments/3');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertJsonStringEqualsJsonString('{ "id": 3 }', $this->client->getResponse()->getContent());
+    }
+}

--- a/Tests/Functional/app/Routing/bundles.php
+++ b/Tests/Functional/app/Routing/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \FOS\RestBundle\FOSRestBundle(),
+    new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
+);

--- a/Tests/Functional/app/Routing/config.yml
+++ b/Tests/Functional/app/Routing/config.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    serializer:
+        enabled: true
+    router: { resource: "%kernel.root_dir%/Routing/routing.yml" }
+
+fos_rest: ~

--- a/Tests/Functional/app/Routing/routing.yml
+++ b/Tests/Functional/app/Routing/routing.yml
@@ -1,0 +1,3 @@
+api_dir:
+    resource: '@TestBundle/Controller/Api'
+    type: rest

--- a/Tests/Routing/Loader/DirectoryRouteLoaderTest.php
+++ b/Tests/Routing/Loader/DirectoryRouteLoaderTest.php
@@ -33,7 +33,7 @@ class DirectoryRouteLoaderTest extends LoaderTest
      */
     public function testSupports($resource, $type, $expected)
     {
-        $loader = new DirectoryRouteLoader(new RestRouteProcessor());
+        $loader = new DirectoryRouteLoader($this->getMock('Symfony\Component\Config\FileLocatorInterface'), new RestRouteProcessor());
 
         if ($expected) {
             $this->assertTrue($loader->supports($resource, $type));
@@ -54,7 +54,7 @@ class DirectoryRouteLoaderTest extends LoaderTest
 
     private function loadFromDirectory($resource)
     {
-        $directoryLoader = new DirectoryRouteLoader(new RestRouteProcessor());
+        $directoryLoader = new DirectoryRouteLoader($this->getMock('Symfony\Component\Config\FileLocatorInterface'), new RestRouteProcessor());
         $controllerLoader = $this->getControllerLoader();
 
         // LoaderResolver sets the resolvers on the loaders passed to it


### PR DESCRIPTION
This fixes support for the bundle shortcut notation when loading routes from a directory (fixes #1377).