### PR TITLE
Avoid use of __DIR__ in RestXmlCollectionLoader by using the FileLocator

### DIFF
--- a/Routing/Loader/RestXmlCollectionLoader.php
+++ b/Routing/Loader/RestXmlCollectionLoader.php
@@ -207,9 +207,10 @@ class RestXmlCollectionLoader extends XmlFileLoader
      */
     protected function validate(\DOMDocument $dom)
     {
-        $restRoutinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing/rest_routing-1.0.xsd');
+        $configBasePath = realpath($this->locator->locate('../../../Resources/config'));
+        $restRoutinglocation = $configBasePath.'/schema/routing/rest_routing-1.0.xsd';
         $restRoutinglocation = rawurlencode(str_replace('\\', '/', $restRoutinglocation));
-        $routinglocation = realpath(__DIR__.'/../../Resources/config/schema/routing-1.0.xsd');
+        $routinglocation = $configBasePath.'/schema/routing-1.0.xsd';
         $routinglocation = rawurlencode(str_replace('\\', '/', $routinglocation));
         $source = <<<EOF
 <?xml version="1.0" encoding="utf-8" ?>


### PR DESCRIPTION
This fixes the corresponding [major violation](https://insight.sensiolabs.com/projects/0be23389-2e85-49cf-b333-caaa36d11c62/analyses/271) on SL Insight.
(i.e. "Absolute path constants `__DIR__` and `__FILE__` should not be used")

Maybe someone with a better fix ?