### PR TITLE
Add namespace in documentation examples that show a Controller class

### DIFF
--- a/Resources/doc/2-the-view-layer.rst
+++ b/Resources/doc/2-the-view-layer.rst
@@ -27,6 +27,8 @@ which adds several convenience methods:
 
     <?php
 
+    namespace AppBundle\Controller;
+
     use FOS\RestBundle\Controller\FOSRestController;
 
     class UsersController extends FOSRestController
@@ -68,6 +70,8 @@ If you need to pass more data in template, not for serialization, you can use ``
 
     <?php
 
+    namespace AppBundle\Controller;
+
     use FOS\RestBundle\Controller\FOSRestController;
 
     class UsersController extends FOSRestController
@@ -94,6 +98,8 @@ or it is possible to use lazy-loading:
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
 
     use FOS\RestBundle\Controller\FOSRestController;
 
@@ -352,6 +358,8 @@ Here is an example using a closure registered inside a Controller action:
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\Controller;
     use FOS\RestBundle\View\View;

--- a/Resources/doc/4-exception-controller-support.rst
+++ b/Resources/doc/4-exception-controller-support.rst
@@ -65,6 +65,11 @@ mapping, you can do this in your controller:
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
+
+    use Symfony\Component\HttpKernel\Exception\HttpException;
+
     class UsersController extends Controller
     {
         public function postUserCommentsAction($slug)

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
@@ -43,6 +43,9 @@ Define resource actions
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
+
     class UsersController
     {
         public function copyUserAction($id) // RFC-2518
@@ -156,6 +159,8 @@ following would work as well:
 
     <?php
 
+    namespace AppBundle\Controller;
+
     use FOS\RestBundle\Routing\ClassResourceInterface;
 
     class UserController implements ClassResourceInterface
@@ -185,6 +190,8 @@ name via the ``@RouteResource`` annotation:
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
 
     use FOS\RestBundle\Controller\Annotations\RouteResource;
 
@@ -217,6 +224,8 @@ Finally, it's possible to have a singular resource name thanks to the ``@RouteRe
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
 
     use FOS\RestBundle\Controller\Annotations\RouteResource;
 
@@ -355,6 +364,8 @@ to limit or add a custom format, you can do so by overriding it with the
 
     <?php
 
+    namespace AppBundle\Controller;
+
     use FOS\RestBundle\Controller\Annotations\Route;
 
         // ...
@@ -382,6 +393,7 @@ Example class implementing ``InflectorInterface``:
 .. code-block:: php
 
     <?php
+
     namespace Acme\HelloBundle\Util\Inflector;
 
     use FOS\RestBundle\Inflector\InflectorInterface;

--- a/Resources/doc/6-automatic-route-generation_multiple-restful-controllers.rst
+++ b/Resources/doc/6-automatic-route-generation_multiple-restful-controllers.rst
@@ -53,6 +53,9 @@ In this case, your ``UsersController`` MUST always have a single resource
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
+
     class UsersController extends Controller
     {
         public function getUserAction($slug)
@@ -72,6 +75,9 @@ Define child resource controller
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
+
     class CommentsController extends Controller
     {
         public function postCommentVoteAction($slug, $id)

--- a/Resources/doc/param_fetcher_listener.rst
+++ b/Resources/doc/param_fetcher_listener.rst
@@ -14,6 +14,8 @@ configured for the matched controller so that the user does not need to do this 
 
     <?php
 
+    namespace AppBundle\Controller;
+
     use FOS\RestBundle\Request\ParamFetcher;
     use FOS\RestBundle\Controller\Annotations\RequestParam;
     use FOS\RestBundle\Controller\Annotations\QueryParam;
@@ -138,6 +140,8 @@ request attributes
 
     <?php
 
+    namespace AppBundle\Controller;
+
     class FooController extends Controller
     {
         /**
@@ -163,6 +167,8 @@ Container parameters can be used in requirements and default field.
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
 
     class FooController extends Controller
     {

--- a/Resources/doc/view_response_listener.rst
+++ b/Resources/doc/view_response_listener.rst
@@ -13,6 +13,8 @@ Now inside a controller it's possible to simply return a ``View`` instance.
 
     <?php
 
+    namespace AppBundle\Controller;
+
     use FOS\RestBundle\View\View;
 
     class UsersController
@@ -44,6 +46,8 @@ of ``force`` and ``@View()`` is not used, then rendering will be delegated to
 .. code-block:: php
 
     <?php
+
+    namespace AppBundle\Controller;
 
     use FOS\RestBundle\Controller\Annotations\View;
 


### PR DESCRIPTION
Added namespace `AppBundle\Controller` to all documentation examples that show a Controller class, according to symfony standards for documentation.

Closes #1266.