### PR TITLE
Fix QueryParam map with no constraints breaking

### DIFF
--- a/Controller/Annotations/AbstractScalarParam.php
+++ b/Controller/Annotations/AbstractScalarParam.php
@@ -57,8 +57,9 @@ abstract class AbstractScalarParam extends AbstractParam
             $constraints[] = new NotBlank();
         }
 
-        // If the user wants to map the value
-        if ($this->map) {
+        // If the user wants to map the value, apply all constraints to every
+        // value of the map
+        if ($this->map && !empty($constraints)) {
             $constraints = array(
                 new All($constraints),
             );

--- a/Controller/Annotations/AbstractScalarParam.php
+++ b/Controller/Annotations/AbstractScalarParam.php
@@ -59,9 +59,9 @@ abstract class AbstractScalarParam extends AbstractParam
 
         // If the user wants to map the value, apply all constraints to every
         // value of the map
-        if ($this->map && !empty($constraints)) {
+        if ($this->map) {
             $constraints = array(
-                new All($constraints),
+                new All(array('constraints' => $constraints)),
             );
         }
 

--- a/Tests/Controller/Annotations/AbstractScalarParamTest.php
+++ b/Tests/Controller/Annotations/AbstractScalarParamTest.php
@@ -103,6 +103,8 @@ class AbstractScalarParamTest extends \PHPUnit_Framework_TestCase
     {
         $this->param->nullable = true;
         $this->param->map = true;
-        $this->assertEmpty($this->param->getConstraints());
+        $this->assertEquals(array(new Constraints\All(array(
+            'constraints' => [],
+        ))), $this->param->getConstraints());
     }
 }

--- a/Tests/Controller/Annotations/AbstractScalarParamTest.php
+++ b/Tests/Controller/Annotations/AbstractScalarParamTest.php
@@ -98,4 +98,11 @@ class AbstractScalarParamTest extends \PHPUnit_Framework_TestCase
             new Constraints\NotNull(),
         ))), $this->param->getConstraints());
     }
+
+    public function testArrayWithNoConstraintsDoesNotCreateInvalidConstraint()
+    {
+        $this->param->nullable = true;
+        $this->param->map = true;
+        $this->assertEmpty($this->param->getConstraints());
+    }
 }


### PR DESCRIPTION
When upgrading to [2.0.0-BETA2](https://github.com/FriendsOfSymfony/FOSRestBundle/releases/tag/), we ran into cases where we had this kind of annotation:

```php
/*
 * @QueryParam(name="filter", map=true, nullable=true)
 */
```

This broke as of #1191 (I believe) because using `Constraints\All` requires at least one constraint. Simple fix is to check to see if any actual constraints were specified.

### How to test

```bash
phpunit --filter ParamFetcherTest
```

### Notes/thoughts
This may be considered user error, but we also rely on the `map` property (previously `array`) to indicate that we expect to treat this parameter as an array. This is a case where `be liberal in what you accept, conservative in what you emit` informs my opinion that we should let consumers of this code use the `map=true` option liberally.

Tangential note is that I agree with the removal of type-checking in #1191; we actually are very flexible with these parameters, and expect either a comma-separated string or an actual array param.