### PR TITLE
fall back to core Symfony exception listener outside configured REST zones

### DIFF
--- a/DependencyInjection/Compiler/TwigExceptionPass.php
+++ b/DependencyInjection/Compiler/TwigExceptionPass.php
@@ -23,10 +23,6 @@ final class TwigExceptionPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if ($container->has('fos_rest.exception_listener') && $container->has('twig.exception_listener')) {
-            $container->removeDefinition('twig.exception_listener');
-        }
-
         if (!$container->has('templating.engine.twig')) {
             $container->removeDefinition('fos_rest.exception.twig_controller');
         }

--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -12,9 +12,10 @@
 namespace FOS\RestBundle\EventListener;
 
 use FOS\RestBundle\FOSRestBundle;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener as HttpKernelExceptionListener;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 
 /**
@@ -38,6 +39,16 @@ class ExceptionListener extends HttpKernelExceptionListener
         }
 
         parent::onKernelException($event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::EXCEPTION => array('onKernelException', -100),
+        );
     }
 
     /**

--- a/Tests/Functional/ExceptionListenerTest.php
+++ b/Tests/Functional/ExceptionListenerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Functional;
+
+class ExceptionListenerTest extends WebTestCase
+{
+    private $client;
+
+    public function setUp()
+    {
+        $this->client = $this->createClient(['test_case' => 'ExceptionListener']);
+    }
+
+    public function testBundleListenerHandlesExceptionsInRestZones()
+    {
+        $this->client->request('GET', '/api/test');
+
+        $this->assertEquals('application/json', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+
+    public function testSymfonyListenerHandlesExceptionsOutsideRestZones()
+    {
+        $this->client->request('GET', '/test');
+
+        $this->assertEquals('text/html; charset=UTF-8', $this->client->getResponse()->headers->get('Content-Type'));
+    }
+}

--- a/Tests/Functional/app/ExceptionListener/bundles.php
+++ b/Tests/Functional/app/ExceptionListener/bundles.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \Symfony\Bundle\TwigBundle\TwigBundle(),
+    new \FOS\RestBundle\FOSRestBundle(),
+    new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
+];

--- a/Tests/Functional/app/ExceptionListener/config.yml
+++ b/Tests/Functional/app/ExceptionListener/config.yml
@@ -1,0 +1,16 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    serializer:
+        enabled: true
+    templating:
+        engines: ['twig']
+
+fos_rest:
+    exception: ~
+    format_listener:
+        rules:
+            - { path: '^/', fallback_format: json }
+    zone:
+        - { path: ^/api/* }


### PR DESCRIPTION
@jovobe discovered that core Symfony exception listener was removed when the one from the FOSRestBundle was registered. This leads to errors when an exception is thrown for a request that does not match a configured REST zone meaning that the exception is entirely ignored by the exception handling process.