### PR TITLE
Fix #1412

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -319,6 +319,7 @@ class RestActionReader
                 $condition = $this->getCondition($method, $annotation);
 
                 $this->includeFormatIfNeeded($path, $requirements);
+                $this->includeMethodsIfNeeded($annoMethods, $requirements);
 
                 // add route to collection
                 $route = new Route(
@@ -328,7 +329,8 @@ class RestActionReader
             }
         } else {
             $this->includeFormatIfNeeded($path, $requirements);
-
+            $this->includeMethodsIfNeeded($methods, $requirements);
+            
             $methods = explode('|', strtoupper($httpMethod));
 
             // add route to collection
@@ -382,6 +384,18 @@ class RestActionReader
             if (!isset($requirements['_format']) && !empty($this->formats)) {
                 $requirements['_format'] = implode('|', array_keys($this->formats));
             }
+        }
+    }
+    
+    /**
+     * Include the method in the requirements 
+     * @param array $methods
+     * @param array $requirements
+     */
+    private function includeMethodsIfNeeded(array $methods, &$requirements)
+    {
+        if(!isset($requirements['_method']) && !empty($methods)) {
+            $requirements['_method'] = implode('|', $methods);
         }
     }
 


### PR DESCRIPTION
Symfony 3 Route class does not automatically adds the required methods to the route requirements anymore. This fix the issue, correctly creating the $requirements array.