### PR TITLE
Add Context::create() for easier usage with groups

### DIFF
--- a/Context/Context.php
+++ b/Context/Context.php
@@ -40,6 +40,14 @@ final class Context
     private $serializeNull;
 
     /**
+     * Create a net instance.
+     */
+    public static function create()
+    {
+        return new self();
+    }
+
+    /**
      * Sets an attribute.
      *
      * @param string $key

--- a/Context/Context.php
+++ b/Context/Context.php
@@ -40,7 +40,7 @@ final class Context
     private $serializeNull;
 
     /**
-     * Create a net instance.
+     * Create a new instance.
      */
     public static function create()
     {


### PR DESCRIPTION
Instead of having to do:
```php
$context = new Context();
$context->addGroup('some-group');
$view->setContext($context);
```
You can do 
```php
$view->setContext(Context::create()->addGroup('some-group'));
```