### PR TITLE
ignore leading underscores in base normalizer

### DIFF
--- a/Normalizer/CamelKeysNormalizer.php
+++ b/Normalizer/CamelKeysNormalizer.php
@@ -39,27 +39,30 @@ class CamelKeysNormalizer implements ArrayNormalizerInterface
      */
     private function normalizeArray(array &$data)
     {
+        $normalizedData = array();
+
         foreach ($data as $key => $val) {
             $normalizedKey = $this->normalizeString($key);
 
             if ($normalizedKey !== $key) {
-                if (array_key_exists($normalizedKey, $data)) {
+                if (array_key_exists($normalizedKey, $normalizedData)) {
                     throw new NormalizationException(sprintf(
                         'The key "%s" is invalid as it will override the existing key "%s"',
                         $key,
                         $normalizedKey
                     ));
                 }
-
-                unset($data[$key]);
-                $data[$normalizedKey] = $val;
-                $key = $normalizedKey;
             }
+
+            $normalizedData[$normalizedKey] = $val;
+            $key = $normalizedKey;
 
             if (is_array($val)) {
-                $this->normalizeArray($data[$key]);
+                $this->normalizeArray($normalizedData[$key]);
             }
         }
+
+        $data = $normalizedData;
     }
 
     /**
@@ -75,17 +78,8 @@ class CamelKeysNormalizer implements ArrayNormalizerInterface
             return $string;
         }
 
-        if (preg_match('/^(_+)(.*)/', $string, $matches)) {
-            $underscorePrefix = $matches[1];
-            $string = $matches[2];
-        } else {
-            $underscorePrefix = '';
-        }
-
-        $string = preg_replace_callback('/_([a-zA-Z0-9])/', function ($matches) {
+        return preg_replace_callback('/_([a-zA-Z0-9])/', function ($matches) {
             return strtoupper($matches[1]);
         }, $string);
-
-        return $underscorePrefix.$string;
     }
 }

--- a/Tests/Normalizer/CamelKeysNormalizerTest.php
+++ b/Tests/Normalizer/CamelKeysNormalizerTest.php
@@ -41,6 +41,31 @@ class CamelKeysNormalizerTest extends \PHPUnit_Framework_TestCase
 
     public function normalizeProvider()
     {
+        $array = $this->normalizeProviderCommon();
+        $array[] = array(array('__username' => 'foo', '_password' => 'bar', '_foo_bar' => 'foobar'), array('_Username' => 'foo', 'Password' => 'bar', 'FooBar' => 'foobar'));
+
+        return $array;
+    }
+
+    /**
+     * @dataProvider normalizeProviderLeadingUnderscore
+     */
+    public function testNormalizeLeadingUnderscore(array $array, array $expected)
+    {
+        $normalizer = new CamelKeysNormalizerWithLeadingUnderscore();
+        $this->assertEquals($expected, $normalizer->normalize($array));
+    }
+
+    public function normalizeProviderLeadingUnderscore()
+    {
+        $array = $this->normalizeProviderCommon();
+        $array[] = array(array('__username' => 'foo', '_password' => 'bar', '_foo_bar' => 'foobar'), array('__username' => 'foo', '_password' => 'bar', '_fooBar' => 'foobar'));
+
+        return $array;
+    }
+
+    private function normalizeProviderCommon()
+    {
         return array(
             array(array(), array()),
             array(
@@ -52,22 +77,5 @@ class CamelKeysNormalizerTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
         );
-    }
-
-    /**
-     * @dataProvider normalizeProvider
-     */
-    public function testNormalizeLeadingUnderscore(array $array, array $expected)
-    {
-        $normalizer = new CamelKeysNormalizerWithLeadingUnderscore();
-        $this->assertEquals($expected, $normalizer->normalize($array));
-    }
-
-    public function normalizeProviderLeadingUnderscore()
-    {
-        $array = $this->normalizeProvider();
-        $array[] = array(array('__username' => 'foo', '_password' => 'bar', '_foo_bar' => 'foobar'), array('__username' => 'foo', '_password' => 'bar', '_fooBar' => 'foobar'));
-
-        return $array;
     }
 }


### PR DESCRIPTION
In #1267, a new normalizer class was introduced that ignores underscores
when converting snake case to camel case. However, the same change was
made to the base class. This means that both classes act in exactly the
same way. Furthermore, this change was a BC break as the behavior of the
base normalizer class was changed without fixing an actual bug.