### PR TITLE
backport #1427

### DIFF
--- a/Context/Context.php
+++ b/Context/Context.php
@@ -157,6 +157,20 @@ final class Context
     }
 
     /**
+     * Set the normalization groups.
+     *
+     * @param array $groups
+     *
+     * @return self
+     */
+    public function setGroups(array $groups)
+    {
+        $this->groups = $groups;
+
+        return $this;
+    }
+
+    /**
      * Sets the normalization max depth.
      *
      * @param int|null $depth

--- a/Tests/Context/ContextTest.php
+++ b/Tests/Context/ContextTest.php
@@ -56,6 +56,16 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('quz', 'foo', 'bar'), $this->context->getGroups());
     }
 
+    public function testSetGroups()
+    {
+        $this->context->setGroups(array('quz', 'foo'));
+
+        $this->assertEquals(['quz', 'foo'], $this->context->getGroups());
+
+        $this->context->setGroups(['foo']);
+        $this->assertEquals(['foo'], $this->context->getGroups());
+    }
+
     public function testAlreadyExistentGroupAddition()
     {
         $this->context->addGroup('foo');

--- a/Tests/Context/ContextTest.php
+++ b/Tests/Context/ContextTest.php
@@ -60,10 +60,10 @@ class ContextTest extends \PHPUnit_Framework_TestCase
     {
         $this->context->setGroups(array('quz', 'foo'));
 
-        $this->assertEquals(['quz', 'foo'], $this->context->getGroups());
+        $this->assertEquals(array('quz', 'foo'), $this->context->getGroups());
 
-        $this->context->setGroups(['foo']);
-        $this->assertEquals(['foo'], $this->context->getGroups());
+        $this->context->setGroups(array('foo'));
+        $this->assertEquals(array('foo'), $this->context->getGroups());
     }
 
     public function testAlreadyExistentGroupAddition()


### PR DESCRIPTION
This puts the `Context` class in `1.8` and `2.0` in sync again.