### PR TITLE
fixed groups to default to an empty collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 1.7.9
 -----
 
+* fixed that the default exclusion strategy groups for the serializer are not the empty string
+
 * fixed a BC break that prevented the `CamelKeysNormalizer` from removing leading underscores
 
 * fixed the `AllowedMethodsRouteLoader` to work with Symfony 3.0

--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="fos_rest.serializer.exclusion_strategy.version" />
-        <parameter key="fos_rest.serializer.exclusion_strategy.groups"/>
+        <parameter key="fos_rest.serializer.exclusion_strategy.groups" type="collection" />
         <parameter key="fos_rest.view_handler.jsonp.callback_param"/>
         <parameter key="fos_rest.view.exception_wrapper_handler">FOS\RestBundle\View\ExceptionWrapperHandler</parameter>
         <parameter key="fos_rest.view_handler.default.class">FOS\RestBundle\View\ViewHandler</parameter>

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -334,6 +334,14 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->container->has('fos_rest.validator'));
     }
 
+    public function testDefaultSerializerGroupsIsArray()
+    {
+        $config = array();
+        $this->extension->load($config, $this->container);
+
+        $this->assertInternaltype('array', $this->container->getParameter('fos_rest.serializer.exclusion_strategy.groups'));
+    }
+
     /**
      * Test that extension loads properly.
      */


### PR DESCRIPTION
This basically backports #1365 to FOSRestBundle 1.7.