### PR TITLE
[#1463] add empty implementation for required method

### DIFF
--- a/Controller/Annotations/Param.php
+++ b/Controller/Annotations/Param.php
@@ -11,6 +11,8 @@
 
 namespace FOS\RestBundle\Controller\Annotations;
 
+use Symfony\Component\HttpFoundation\Request;
+
 /**
  * Represents a parameter that can be present in GET or POST data.
  *
@@ -50,5 +52,10 @@ abstract class Param extends AbstractScalarParam
     public function getKey()
     {
         return $this->key ?: $this->name;
+    }
+
+    public function getValue(Request $request, $default)
+    {
+        return;
     }
 }


### PR DESCRIPTION
The new `ParamInterface` requires implementing classes to provide the
body of the `getValue()` method. This adds an empty implementation to
the `Param` class to prevent BC breaks for existing classes that extend
the `Param` class.