### PR TITLE
Invalid parameter name change.

### DIFF
--- a/Context/Context.php
+++ b/Context/Context.php
@@ -173,7 +173,7 @@ final class Context
     /**
      * Sets the normalization max depth.
      *
-     * @param int|null $depth
+     * @param int|null $maxDepth
      *
      * @return self
      */


### PR DESCRIPTION
Just made the doc parameter name consistent with actual parameter name.