### PR TITLE
remove \Exception type hint

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -54,14 +54,14 @@ class ExceptionController
      * Converts an Exception to a Response.
      *
      * @param Request                   $request
-     * @param \Exception                $exception
+     * @param \Exception|\Throwable     $exception
      * @param DebugLoggerInterface|null $logger
      *
      * @throws \InvalidArgumentException
      *
      * @return Response
      */
-    public function showAction(Request $request, \Exception $exception, DebugLoggerInterface $logger = null)
+    public function showAction(Request $request, $exception, DebugLoggerInterface $logger = null)
     {
         $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
         $code = $this->getStatusCode($exception);


### PR DESCRIPTION
Without the type hint we can also support objects implementing the
\Throwable interface when using PHP 7.