### PR TITLE
Deprecate the maxDepth context attribute in favor of enableMaxDepth

### DIFF
--- a/Context/Context.php
+++ b/Context/Context.php
@@ -37,6 +37,10 @@ final class Context
     /**
      * @var bool
      */
+    private $isMaxDepthEnabled;
+    /**
+     * @var bool
+     */
     private $serializeNull;
 
     /**
@@ -176,9 +180,14 @@ final class Context
      * @param int|null $maxDepth
      *
      * @return self
+     *
+     * @deprecated since 2.1, to be removed in 3.0. Use {@link self::enableMaxDepth()} instead.
      */
-    public function setMaxDepth($maxDepth)
+    public function setMaxDepth($maxDepth, $triggerDeprecation = true)
     {
+        if ($triggerDeprecation) {
+            @trigger_error(sprintf('%s is deprecated since version 2.1 and will be removed in 3.0. Use %s::enabledMaxDepth() instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
+        }
         $this->maxDepth = $maxDepth;
 
         return $this;
@@ -188,10 +197,34 @@ final class Context
      * Gets the normalization max depth.
      *
      * @return int|null
+     *
+     * @deprecated since version 2.1, to be removed in 3.0. Use {@link self::isMaxDepthEnabled()} instead.
      */
-    public function getMaxDepth()
+    public function getMaxDepth($triggerDeprecation = true)
     {
+        if ($triggerDeprecation) {
+            @trigger_error(sprintf('%s is deprecated since version 2.1 and will be removed in 3.0. Use %s::isMaxDepthEnabled() instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
+        }
+
         return $this->maxDepth;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function enableMaxDepth($enabled = true)
+    {
+        $this->isMaxDepthEnabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isMaxDepthEnabled()
+    {
+        return $this->isMaxDepthEnabled;
     }
 
     /**

--- a/EventListener/ViewResponseListener.php
+++ b/EventListener/ViewResponseListener.php
@@ -84,7 +84,10 @@ class ViewResponseListener implements EventSubscriberInterface
                 $context->addGroups($configuration->getSerializerGroups());
             }
             if ($configuration->getSerializerEnableMaxDepthChecks()) {
-                $context->setMaxDepth(0);
+                $context->setMaxDepth(0, false);
+            }
+            if (null !== $configuration->getSerializerEnableMaxDepthChecks()) {
+                $context->enableMaxDepth($configuration->getSerializerEnableMaxDepthChecks());
             }
 
             list($controller, $action) = $configuration->getOwner();

--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -139,7 +139,10 @@ class RequestBodyParamConverter implements ParamConverterInterface
             } elseif ($key === 'version') {
                 $context->setVersion($options['version']);
             } elseif ($key === 'maxDepth') {
+                @trigger_error('Context attribute "maxDepth" is deprecated since version 2.1 and will be removed in 3.0. Use "enable_max_depth" instead.', E_USER_DEPRECATED);
                 $context->setMaxDepth($options['maxDepth']);
+            } elseif ($key === 'enableMaxDepth') {
+                $context->enableMaxDepth($options['enableMaxDepth']);
             } elseif ($key === 'serializeNull') {
                 $context->setSerializeNull($options['serializeNull']);
             } else {

--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -91,7 +91,7 @@ class JMSSerializerAdapter implements Serializer
         if (!empty($groups)) {
             $jmsContext->setGroups($context->getGroups());
         }
-        if (null !== $context->getMaxDepth()) {
+        if (null !== $context->getMaxDepth(false) || null !== $context->isMaxDepthEnabled()) {
             $jmsContext->enableMaxDepthChecks();
         }
         if (null !== $context->getSerializeNull()) {

--- a/Serializer/SymfonySerializerAdapter.php
+++ b/Serializer/SymfonySerializerAdapter.php
@@ -61,7 +61,8 @@ class SymfonySerializerAdapter implements Serializer
 
         $newContext['groups'] = $context->getGroups();
         $newContext['version'] = $context->getVersion();
-        $newContext['maxDepth'] = $context->getMaxDepth();
+        $newContext['maxDepth'] = $context->getMaxDepth(false);
+        $newContext['enable_max_depth'] = $context->isMaxDepthEnabled();
 
         return $newContext;
     }

--- a/Tests/Context/ContextTest.php
+++ b/Tests/Context/ContextTest.php
@@ -82,6 +82,9 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('1.3.2', $this->context->getVersion());
     }
 
+    /**
+     * @group legacy
+     */
     public function testMaxDepth()
     {
         $this->context->setMaxDepth(10);

--- a/Tests/EventListener/ViewResponseListenerTest.php
+++ b/Tests/EventListener/ViewResponseListenerTest.php
@@ -207,11 +207,12 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
         $this->createViewResponseListener(['json' => true]);
 
         $viewAnnotation = new ViewAnnotation([]);
+        $viewAnnotation->setOwner([$this, 'testSerializerEnableMaxDepthChecks']);
         $viewAnnotation->setSerializerEnableMaxDepthChecks($enableMaxDepthChecks);
 
         $request = new Request();
         $request->setRequestFormat('json');
-        $request->attributes->set('_view', $viewAnnotation);
+        $request->attributes->set('_template', $viewAnnotation);
 
         $this->templating->expects($this->any())
             ->method('render')
@@ -224,9 +225,9 @@ class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->onKernelView($event);
 
         $context = $view->getContext();
-        $maxDepth = $context->getMaxDepth();
 
-        $this->assertEquals($expectedMaxDepth, $maxDepth);
+        $this->assertEquals($expectedMaxDepth, $context->getMaxDepth(false));
+        $this->assertEquals($enableMaxDepthChecks, $context->isMaxDepthEnabled());
     }
 
     public function getDataForDefaultVarsCopy()

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -156,7 +156,7 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
         $options = [
             'groups' => ['foo', 'bar'],
             'version' => 'v1.2',
-            'maxDepth' => 5,
+            'enableMaxDepth' => true,
             'serializeNull' => false,
             'foo' => 'bar',
         ];
@@ -169,9 +169,30 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
         $expectedContext
             ->addGroups($options['groups'])
             ->setVersion($options['version'])
-            ->setMaxDepth($options['maxDepth'])
+            ->enableMaxDepth($options['enableMaxDepth'])
             ->setSerializeNull($options['serializeNull'])
             ->setAttribute('foo', 'bar');
+
+        $this->assertEquals($expectedContext, $context);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testMaxDepthContextConfiguration()
+    {
+        $converter = new RequestBodyParamConverter($this->serializer);
+        $options = [
+            'maxDepth' => 5,
+        ];
+
+        $contextConfigurationMethod = new \ReflectionMethod($converter, 'configureContext');
+        $contextConfigurationMethod->setAccessible(true);
+        $contextConfigurationMethod->invoke($converter, $context = new Context(), $options);
+
+        $expectedContext = new Context();
+        $expectedContext
+            ->setMaxDepth($options['maxDepth']);
 
         $this->assertEquals($expectedContext, $context);
     }


### PR DESCRIPTION
Both serializers don't allow to define maxDepth at runtime so it shouldn't have been called this way...
I'm targeting master as this may break apps using 2.0.