### PR TITLE
Replace references to "Symfony2" with "Symfony"

### DIFF
--- a/Decoder/ContainerDecoderProvider.php
+++ b/Decoder/ContainerDecoderProvider.php
@@ -14,7 +14,7 @@ namespace FOS\RestBundle\Decoder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Provides encoders through the Symfony2 DIC.
+ * Provides encoders through the Symfony DIC.
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ FOSRestBundle
 =============
 
 This bundle provides various tools to rapidly develop RESTful API's &
-applications with Symfony2. Features include:
+applications with Symfony. Features include:
 
 - A View layer to enable output and format agnostic Controllers
 - A custom route loader to generate url's following REST conventions

--- a/Resources/doc/2-the-view-layer.rst
+++ b/Resources/doc/2-the-view-layer.rst
@@ -238,7 +238,7 @@ an example. The serialized Task object will looks as follows:
 
     {"task_form":{"name":"Task1", "person":{"id":1, "name":"Fabien"}}}
 
-In a traditional Symfony2 application we simply define the property of the
+In a traditional Symfony application we simply define the property of the
 related class and it would perfectly assign the person to our task - in this
 case based on the id:
 

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
@@ -33,7 +33,7 @@ are explained in the next section.
         type:     rest
         resource: Acme\HelloBundle\Controller\UsersController
 
-This will tell Symfony2 to automatically generate proper REST routes from your
+This will tell Symfony to automatically generate proper REST routes from your
 ``UsersController`` action names. Notice ``type: rest`` option. It's required so
 that the RestBundle can find which routes are supported.
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -34,7 +34,7 @@ Bundle usage
 Before you start using the bundle it is advised you run a quick look over the
 six sections listed below. This bundle contains many features that are loosely
 coupled so you may or may not need to use all of them. This bundle is just a
-tool to help you in the job of creating a REST API with Symfony2.
+tool to help you in the job of creating a REST API with Symfony.
 
 FOSRestBundle provides several tools to assist in building REST applications:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 2.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Replace references to "Symfony2" with "Symfony" since this bundle is compatible
with Symfony 3.