### PR TITLE
Added ability to upload an array of e.g. images

### DIFF
--- a/Controller/Annotations/FileParam.php
+++ b/Controller/Annotations/FileParam.php
@@ -31,6 +31,8 @@ class FileParam extends AbstractParam
     public $requirements = null;
     /** @var bool */
     public $image = false;
+    /** @var bool */
+    public $multiple = false;
 
     /**
      * {@inheritdoc}
@@ -43,7 +45,9 @@ class FileParam extends AbstractParam
         }
 
         $options = is_array($this->requirements) ? $this->requirements : array();
-        if ($this->image) {
+        if($this->multiple) {
+            $constraints = new Constraints\Collection($options);
+        } elseif ($this->image) {
             $constraints[] = new Constraints\Image($options);
         } else {
             $constraints[] = new Constraints\File($options);

--- a/Controller/Annotations/FileParam.php
+++ b/Controller/Annotations/FileParam.php
@@ -46,7 +46,7 @@ class FileParam extends AbstractParam
 
         $options = is_array($this->requirements) ? $this->requirements : array();
         if($this->multiple) {
-            $constraints = new Constraints\Collection($options);
+            $constraints = new Constraints\All($options);
         } elseif ($this->image) {
             $constraints[] = new Constraints\Image($options);
         } else {


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1535

It is possible for the array to have NULL values if the REST function gets POSTed with e.g. empty file uploads in an HTML form.

I'm not really sure if it is reasonable/necessary to filter the array in that case.