### PR TITLE
fix compatibility with jms serializer 1.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 
     "conflict": {
         "symfony/validator": ">=2.5.0,<2.5.5",
-        "jms/serializer": "<0.13",
+        "jms/serializer": "<0.13 | 1.3.0",
         "jms/serializer-bundle": "<0.11",
         "sensio/framework-extra-bundle": ">=3.0.13"
     },


### PR DESCRIPTION
jms serializser 1.3 changed the default value of `Context::serializeNull`

ref: https://github.com/schmittjoh/serializer/pull/317