### PR TITLE
Update the annotation doc to change array to map.

### DIFF
--- a/Resources/doc/annotations-reference.rst
+++ b/Resources/doc/annotations-reference.rst
@@ -20,7 +20,7 @@ QueryParam
      *   default=null,
      *   description="",
      *   strict=false,
-     *   array=false,
+     *   map=false,
      *   nullable=false
      * )
      */
@@ -40,7 +40,7 @@ RequestParam
      *   default=null,
      *   description="",
      *   strict=true,
-     *   array=false,
+     *   map=false,
      *   nullable=false
      * )
      */


### PR DESCRIPTION
I noticed this while doing annotations based off the docs. It looks like the `array` property for the annotation `QueryParam` and `RequestParam` was changed to `map` a while ago.