### PR TITLE
Option to skip RequestBody validation

### DIFF
--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -105,7 +105,7 @@ class RequestBodyParamConverter implements ParamConverterInterface
 
         $request->attributes->set($configuration->getName(), $object);
 
-        if (null !== $this->validator) {
+        if (null !== $this->validator && (!isset($options['skipValidation']) || !$options['skipValidation'])) {
             $validatorOptions = $this->getValidatorOptions($options);
 
             $errors = $this->validator->validate($object, null, $validatorOptions['groups']);

--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -105,7 +105,7 @@ class RequestBodyParamConverter implements ParamConverterInterface
 
         $request->attributes->set($configuration->getName(), $object);
 
-        if (null !== $this->validator && (!isset($options['skipValidation']) || !$options['skipValidation'])) {
+        if (null !== $this->validator && (!isset($options['validate']) || $options['validate'])) {
             $validatorOptions = $this->getValidatorOptions($options);
 
             $errors = $this->validator->validate($object, null, $validatorOptions['groups']);

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -159,7 +159,7 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
         $converter = new RequestBodyParamConverter($this->serializer, null, null, $validator, 'errors');
 
         $request = $this->createRequest();
-        $configuration = $this->createConfiguration(null, null, ['skipValidation' => true]);
+        $configuration = $this->createConfiguration(null, null, ['validate' => false]);
         $this->launchExecution($converter, $request, $configuration);
         $this->assertEquals(null, $request->attributes->get('errors'));
     }

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -144,6 +144,26 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fooError', $request->attributes->get('errors'));
     }
 
+    public function testValidatorSkipping()
+    {
+        $this->serializer
+            ->expects($this->once())
+            ->method('deserialize')
+            ->willReturn('Object');
+
+        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')->getMock();
+        $validator
+            ->expects($this->never())
+            ->method('validate');
+
+        $converter = new RequestBodyParamConverter($this->serializer, null, null, $validator, 'errors');
+
+        $request = $this->createRequest();
+        $configuration = $this->createConfiguration(null, null, ['skipValidation' => true]);
+        $this->launchExecution($converter, $request, $configuration);
+        $this->assertEquals(null, $request->attributes->get('errors'));
+    }
+
     public function testReturn()
     {
         $converter = new RequestBodyParamConverter($this->serializer);


### PR DESCRIPTION
I have a requirement that the RequestBodyParamConverter doesnt perform the validation, so my controller action can calculate which validation groups are required and do it itself.

Seems to me like its logical that this is configurable on ParamConverter.
