### PR TITLE
#1571 Fixed using Response constants in exception codes configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -398,13 +398,13 @@ return $v; })
                                             continue;
                                         }
 
-                                        if (!defined('Symfony\Component\HttpFoundation\Response::' . $item)) {
+                                        if (!defined('Symfony\Component\HttpFoundation\Response::'.$item)) {
                                             throw new InvalidConfigurationException(
                                                 'Invalid HTTP code in fos_rest.exception.codes, see Symfony\Component\HttpFoundation\Response for all valid codes.'
                                             );
                                         }
 
-                                        $item = constant('Symfony\Component\HttpFoundation\Response::' . $item);
+                                        $item = constant('Symfony\Component\HttpFoundation\Response::'.$item);
                                     }
 
                                     return $items;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -411,10 +411,30 @@ return $v; })
                                 })
                             ->end()
                             ->prototype('scalar')->end()
+                            ->validate()
+                                ->ifArray()
+                                ->then(function (array $items) {
+                                    foreach ($items as $class => $code) {
+                                        $this->testExceptionExists($class);
+                                    }
+
+                                    return $items;
+                                })
+                            ->end()
                         ->end()
                         ->arrayNode('messages')
                             ->useAttributeAsKey('name')
                             ->prototype('boolean')->end()
+                            ->validate()
+                                ->ifArray()
+                                ->then(function (array $items) {
+                                    foreach ($items as $class => $nomatter) {
+                                        $this->testExceptionExists($class);
+                                    }
+
+                                    return $items;
+                                })
+                            ->end()
                         ->end()
                         ->booleanNode('debug')
                             ->defaultValue($this->debug)
@@ -422,5 +442,19 @@ return $v; })
                     ->end()
                 ->end()
             ->end();
+    }
+
+    /**
+     * Checks if an exception is loadable.
+     *
+     * @param string $exception Class to test
+     *
+     * @throws InvalidConfigurationException if the class was not found
+     */
+    private function testExceptionExists($exception)
+    {
+        if (!is_subclass_of($exception, \Exception::class) && !is_a($exception, \Exception::class, true)) {
+            throw new InvalidConfigurationException("FOSRestBundle exception mapper: Could not load class '$exception' or the class does not extend from '\\Exception'. Most probably this is a configuration problem.");
+        }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -410,7 +410,7 @@ return $v; })
                                     return $items;
                                 })
                             ->end()
-                            ->prototype('scalar')->end()
+                            ->prototype('integer')->end()
                             ->validate()
                                 ->ifArray()
                                 ->then(function (array $items) {

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -338,18 +338,6 @@ class FOSRestExtension extends Extension
             $container->getDefinition('fos_rest.serializer.exception_normalizer.symfony')
                 ->replaceArgument(1, $config['exception']['debug']);
         }
-
-        foreach ($config['exception']['codes'] as $exception => $code) {
-            if (!is_numeric($code)) {
-                $config['exception']['codes'][$exception] = constant("\Symfony\Component\HttpFoundation\Response::$code");
-            }
-
-            $this->testExceptionExists($exception);
-        }
-
-        foreach ($config['exception']['messages'] as $exception => $message) {
-            $this->testExceptionExists($exception);
-        }
     }
 
     private function loadSerializer(array $config, ContainerBuilder $container)
@@ -414,19 +402,5 @@ class FOSRestExtension extends Extension
         ;
 
         return new Reference($id);
-    }
-
-    /**
-     * Checks if an exception is loadable.
-     *
-     * @param string $exception Class to test
-     *
-     * @throws \InvalidArgumentException if the class was not found
-     */
-    private function testExceptionExists($exception)
-    {
-        if (!is_subclass_of($exception, \Exception::class) && !is_a($exception, \Exception::class, true)) {
-            throw new \InvalidArgumentException("FOSRestBundle exception mapper: Could not load class '$exception' or the class does not extend from '\Exception'. Most probably this is a configuration problem.");
-        }
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\DependencyInjection;
+
+use FOS\RestBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class ConfigurationTest.
+ *
+ * @author Evgenij Efimov <edefimov.it@gmail.com>
+ */
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test object.
+     *
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * Configuration processor.
+     *
+     * @var Processor
+     */
+    private $processor;
+
+    /**
+     * testAcceptsIntegers.
+     */
+    public function testAcceptsIntegers()
+    {
+        $expectedConfig = [
+            md5(microtime()) => mt_rand(200, 599),
+        ];
+
+        $config = $this->processor->processConfiguration(
+            $this->configuration,
+            [
+                [
+                    'exception' => [
+                        'codes' => $expectedConfig,
+                    ],
+                ],
+            ]
+        );
+
+        self::assertSame($expectedConfig, $config['exception']['codes']);
+    }
+
+    /**
+     * testThatResponseConstantsConvertedToCodes.
+     */
+    public function testThatResponseConstantsConvertedToCodes()
+    {
+        $ref = new \ReflectionClass(Response::class);
+        $expectedResult = [];
+        $config = [];
+
+        foreach ($ref->getConstants() as $constantName => $value) {
+            if (strpos($constantName, 'HTTP_') !== 0) {
+                continue;
+            }
+
+            $fakeExceptionClassName = md5(microtime().$constantName);
+            $expectedResult[$fakeExceptionClassName] = $value;
+
+            $config['exception']['codes'][$fakeExceptionClassName] = $constantName;
+        }
+
+        $config = $this->processor->processConfiguration($this->configuration, [$config]);
+
+        self::assertTrue(isset($config['exception']['codes']));
+        self::assertSame($expectedResult, $config['exception']['codes'], 'Response constants were not converted');
+    }
+
+    /**
+     * testThatIfExceptionCodeIncorrectExceptionIsThrown.
+     *
+     * @param mixed $value Test value
+     *
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Invalid HTTP code in fos_rest.exception.codes, see Symfony\Component\HttpFoundation\Response for all valid codes.
+     * @dataProvider incorrectExceptionCodeProvider
+     */
+    public function testThatIfExceptionCodeIncorrectExceptionIsThrown($value)
+    {
+        $this->processor->processConfiguration(
+            $this->configuration,
+            [
+                [
+                    'exception' => [
+                        'codes' => [
+                            'no-matter' => $value,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * incorrectExceptionCodeProvider.
+     *
+     * @return array
+     */
+    public function incorrectExceptionCodeProvider()
+    {
+        return [
+            ['404'], // Integer as string in not acceptable
+            ['Any text'],
+            [true],
+            [false],
+            [null],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->configuration = new Configuration(false);
+        $this->processor = new Processor();
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -39,9 +39,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     private $processor;
 
     /**
-     * testAcceptsIntegers.
+     * testExceptionCodesAcceptsIntegers.
      */
-    public function testAcceptsIntegers()
+    public function testExceptionCodesAcceptsIntegers()
     {
         $expectedConfig = [
             \RuntimeException::class => 500,
@@ -102,7 +102,46 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 [
                     'exception' => [
                         'codes' => [
-                            'no-matter' => $value,
+                            \RuntimeException::class => $value,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testLoadBadMessagesClassThrowsException()
+    {
+        $this->processor->processConfiguration(
+            $this->configuration,
+            [
+                [
+                    'exception' => [
+                        'messages' => [
+                            'UnknownException' => true,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Could not load class 'UnknownException' or the class does not extend from '\Exception'
+     */
+    public function testLoadBadCodesClassThrowsException()
+    {
+        $this->processor->processConfiguration(
+            $this->configuration,
+            [
+                [
+                    'exception' => [
+                        'codes' => [
+                            'UnknownException' => 404,
                         ],
                     ],
                 ],

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -14,6 +14,8 @@ namespace FOS\RestBundle\Tests\DependencyInjection;
 use FOS\RestBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 /**
  * Class ConfigurationTest.
@@ -42,7 +44,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testAcceptsIntegers()
     {
         $expectedConfig = [
-            md5(microtime()) => mt_rand(200, 599),
+            \RuntimeException::class => 500,
         ];
 
         $config = $this->processor->processConfiguration(
@@ -64,20 +66,18 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatResponseConstantsConvertedToCodes()
     {
-        $ref = new \ReflectionClass(Response::class);
-        $expectedResult = [];
-        $config = [];
-
-        foreach ($ref->getConstants() as $constantName => $value) {
-            if (strpos($constantName, 'HTTP_') !== 0) {
-                continue;
-            }
-
-            $fakeExceptionClassName = md5(microtime().$constantName);
-            $expectedResult[$fakeExceptionClassName] = $value;
-
-            $config['exception']['codes'][$fakeExceptionClassName] = $constantName;
-        }
+        $expectedResult = [
+            NotFoundHttpException::class => Response::HTTP_NOT_FOUND,
+            MethodNotAllowedException::class => Response::HTTP_METHOD_NOT_ALLOWED,
+        ];
+        $config = [
+            'exception' => [
+                'codes' => [
+                    NotFoundHttpException::class => 'HTTP_NOT_FOUND',
+                    MethodNotAllowedException::class => 'HTTP_METHOD_NOT_ALLOWED',
+                ],
+            ],
+        ];
 
         $config = $this->processor->processConfiguration($this->configuration, [$config]);
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -457,39 +457,6 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testLoadBadClassThrowsException()
-    {
-        $this->extension->load([
-            'fos_rest' => [
-                'exception' => [
-                    'messages' => [
-                        'UnknownException' => true,
-                    ],
-                ],
-            ],
-        ], $this->container);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not load class 'UnknownException' or the class does not extend from '\Exception'
-     */
-    public function testLoadBadMessagesClassThrowsException()
-    {
-        $this->extension->load([
-            'fos_rest' => [
-                'exception' => [
-                    'codes' => [
-                        'UnknownException' => 404,
-                    ],
-                ],
-            ],
-        ], $this->container);
-    }
-
     public function testLoadOkMessagesClass()
     {
         $this->extension->load([


### PR DESCRIPTION
According to [configuration](http://symfony.com/doc/master/bundles/FOSRestBundle/4-exception-controller-support.html) we can use constants from Symfony Response class as a value for `exception.codes` configuration section.
However when the bundle is configured in such a way, the constant is not converted into corresponding http status code what leads to error during run time. This PR fixes incorrect behavior and converts constant to value during configuration normalization.