### PR TITLE
drop the build job using Symfony 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
     - php: 7.0
       env: SYMFONY_VERSION='2.8.*'
     - php: 7.0
-      env: SYMFONY_VERSION='3.0.*'
-    - php: 7.0
       env: SYMFONY_VERSION='3.1.*'
 
 before_install:


### PR DESCRIPTION
Symfony 3.0 is not forward-compatible with Twig 2.0 (it references Twig
extensions by their name instead of the extension's FQCN) and won't be
updated anymore as it already reached end of maintenance. This currently
lets our Travis CI builds fail.