### PR TITLE
Fix getBest declaration

### DIFF
--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -47,7 +47,7 @@ class FormatNegotiator extends BaseNegotiator
      *
      * @throws StopFormatListenerException
      */
-    public function getBest($header, array $priorities = [])
+    public function getBest($header, array $priorities = [], $strict = false)
     {
         $request = $this->getRequest();
         $header = $header ?: $request->headers->get('Accept');


### PR DESCRIPTION
Fix declaration of FOS\\RestBundle\\Negotiation\\FormatNegotiator::getBest() to be compatible with Negotiation\\AbstractNegotiator::getBest($header, array $priorities, $strict = false) since last commit : https://github.com/willdurand/Negotiation/commit/56f51ee4af8294d1eae12e186623ee7f2f0d5a2f

`public function getBest($header, array $priorities = [], $strict = false)`

Fix error "Runtime Notice: Declaration of FOS\\RestBundle\\Negotiation\\FormatNegotiator::getBest() should be compatible with Negotiation\\AbstractNegotiator::getBest($header, array $priorities, $strict = false)" if you used composer update since tomorrow