### PR TITLE
Update `SerializerConfigurationPass::process()` in order to respect serializer service inference

### DIFF
--- a/DependencyInjection/Compiler/SerializerConfigurationPass.php
+++ b/DependencyInjection/Compiler/SerializerConfigurationPass.php
@@ -41,7 +41,13 @@ final class SerializerConfigurationPass implements CompilerPassInterface
             throw new \InvalidArgumentException('Neither a service called "jms_serializer.serializer" nor "serializer" is available and no serializer is explicitly configured. You must either enable the JMSSerializerBundle, enable the FrameworkBundle serializer or configure a custom serializer.');
         }
 
-        if ($container->has('serializer') || $container->has('jms_serializer.serializer')) {
+        if ($container->has('jms_serializer.serializer')) {
+            $container->setAlias('fos_rest.serializer', 'fos_rest.serializer.jms');
+        } else {
+            $container->removeDefinition('fos_rest.serializer.exception_wrapper_serialize_handler');
+        }
+
+        if ($container->has('serializer')) {
             $class = $container->getParameterBag()->resolveValue(
                 $container->findDefinition(($container->has('jms_serializer.serializer') ? 'jms_serializer.' : '').'serializer')->getClass()
             );
@@ -60,12 +66,6 @@ final class SerializerConfigurationPass implements CompilerPassInterface
             return;
         } else {
             $container->removeDefinition('fos_rest.serializer.exception_wrapper_normalizer');
-        }
-
-        if ($container->has('jms_serializer.serializer')) {
-            $container->setAlias('fos_rest.serializer', 'fos_rest.serializer.jms');
-        } else {
-            $container->removeDefinition('fos_rest.serializer.exception_wrapper_serialize_handler');
         }
     }
 }

--- a/DependencyInjection/Compiler/SerializerConfigurationPass.php
+++ b/DependencyInjection/Compiler/SerializerConfigurationPass.php
@@ -41,18 +41,18 @@ final class SerializerConfigurationPass implements CompilerPassInterface
             throw new \InvalidArgumentException('Neither a service called "jms_serializer.serializer" nor "serializer" is available and no serializer is explicitly configured. You must either enable the JMSSerializerBundle, enable the FrameworkBundle serializer or configure a custom serializer.');
         }
 
-        if ($container->has('serializer')) {
+        if ($container->has('serializer') || $container->has('jms_serializer.serializer')) {
             $class = $container->getParameterBag()->resolveValue(
-                $container->findDefinition('serializer')->getClass()
+                $container->findDefinition(($container->has('jms_serializer.serializer') ? 'jms_serializer.' : '').'serializer')->getClass()
             );
 
-            if (is_subclass_of($class, 'Symfony\Component\Serializer\SerializerInterface')) {
-                $container->setAlias('fos_rest.serializer', 'fos_rest.serializer.symfony');
-                $container->removeDefinition('fos_rest.serializer.exception_wrapper_serialize_handler');
+            if (is_subclass_of($class, 'FOS\RestBundle\Serializer\Serializer')) {
+                $container->setAlias('fos_rest.serializer', 'serializer');
             } elseif (is_subclass_of($class, 'JMS\Serializer\SerializerInterface')) {
                 $container->setAlias('fos_rest.serializer', 'fos_rest.serializer.jms');
-            } elseif (is_subclass_of($class, 'FOS\RestBundle\Serializer\Serializer')) {
-                $container->setAlias('fos_rest.serializer', 'serializer');
+            } elseif (is_subclass_of($class, 'Symfony\Component\Serializer\SerializerInterface')) {
+                $container->setAlias('fos_rest.serializer', 'fos_rest.serializer.symfony');
+                $container->removeDefinition('fos_rest.serializer.exception_wrapper_serialize_handler');
             } else {
                 throw new \InvalidArgumentException(sprintf('"fos_rest.serializer" must implement FOS\RestBundle\Serializer\Serializer (instance of "%s" given).', $class));
             }

--- a/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
@@ -79,7 +79,7 @@ class SerializerConfigurationPassTest extends \PHPUnit_Framework_TestCase
         $compiler = new SerializerConfigurationPass();
         $compiler->process($this->container);
 
-        $this->assertSame('fos_rest.serializer.symfony', (string) $this->container->getAlias('fos_rest.serializer'));
+        $this->assertSame('fos_rest.serializer.jms', (string) $this->container->getAlias('fos_rest.serializer'));
     }
 
     public function testSerializerServiceCanBeJmsSerializer()


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

The alias `serializer` for `jms_serializer.serializer ` service can be disabled via `enable_short_alias` setting. See https://github.com/schmittjoh/JMSSerializerBundle/commit/fec96d9a2ab7260382cbaa43e5744488ee330769.
Without this fix, if this flag is configured as `false`, the expected service inference is not respecting the desired order:
1. The one you configured using fos_rest.service.serializer (if you did).
2. The JMS serializer, if the JMSSerializerBundle is available (and registered).
3. The Symfony Serializer if it's enabled (or any service called serializer).