### PR TITLE
fixes #1617

### DIFF
--- a/EventListener/MimeTypeListener.php
+++ b/EventListener/MimeTypeListener.php
@@ -55,7 +55,7 @@ class MimeTypeListener
             foreach ($this->mimeTypes as $format => $mimeTypes) {
                 if (method_exists(Request::class, 'getMimeTypes')) {
                     $mimeTypesForFormat = Request::getMimeTypes($format);
-                    $mimeTypes = $mimeTypesForFormat ? array_merge($mimeTypes,$mimeTypesForFormat) : $mimeTypes;
+                    $mimeTypes = $mimeTypesForFormat ? array_merge($mimeTypes, $mimeTypesForFormat) : $mimeTypes;
                 } elseif (null !== $request->getMimeType($format)) {
                     $class = new \ReflectionClass(Request::class);
                     $properties = $class->getStaticProperties();

--- a/EventListener/MimeTypeListener.php
+++ b/EventListener/MimeTypeListener.php
@@ -54,7 +54,8 @@ class MimeTypeListener
         if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
             foreach ($this->mimeTypes as $format => $mimeTypes) {
                 if (method_exists(Request::class, 'getMimeTypes')) {
-                    $mimeTypes = array_merge($mimeTypes, Request::getMimeTypes($format));
+                    $mimeTypesForFormat = Request::getMimeTypes($format);
+                    $mimeTypes = $mimeTypesForFormat ? array_merge($mimeTypes,$mimeTypesForFormat) : $mimeTypes;
                 } elseif (null !== $request->getMimeType($format)) {
                     $class = new \ReflectionClass(Request::class);
                     $properties = $class->getStaticProperties();


### PR DESCRIPTION
Check if the `$format` exists (is an array) before merging into `$mimeTypes`.