### PR TITLE
[WIP] Added priority to form type extension for compatibility with Symfony 3.2

### DIFF
--- a/Resources/config/forms.xml
+++ b/Resources/config/forms.xml
@@ -9,6 +9,7 @@
             <argument type="service" id="security.token_storage" />
             <argument /> <!-- disable CSRF role -->
             <argument type="service" id="security.authorization_checker" />
+            <tag name="form.type_extension" priority="-5" extended-type="Symfony\Component\Form\Extension\AbstractTypeExtension" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Fixes #1602 by introducing a priority for the form extension type.

Can someone with a Symfony version < 3.2 test this change to see if it working without any problems?