### PR TITLE
[Doc] Fix invalid usuage of annitation

### DIFF
--- a/Resources/doc/view_response_listener.rst
+++ b/Resources/doc/view_response_listener.rst
@@ -72,9 +72,10 @@ you should return a ``$view`` object with the data set by ``setTemplateData``.
     <?php
 
     use FOS\RestBundle\View\View;
+    use FOS\RestBundle\Controller\Annotations\View as ViewAnnotation;
 
     /**
-     * @View()
+     * @ViewAnnotation()
      */
     public function getUsersAction()
     {


### PR DESCRIPTION
Using View for both creating View and as annotations cause error 
`The class \"FOS\\RestBundle\\View\\View\" is not annotated with @Annotation`

Fixed to use `View` for creating object and `ViewAnnotation` as annotation