### PR TITLE
Fixed regular expression pattern used to detect custom routes in RestRouteCollection.

### DIFF
--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -76,9 +76,9 @@ class RestRouteCollection extends RouteCollection
      */
     public function all()
     {
-        $regex = '/' .
-            '(_|^)' .
-            '(get|post|put|delete|patch|head|options|mkcol|propfind|proppatch|lock|unlock|move|copy|link|unlink)_' . // allowed http methods
+        $regex = '/'.
+            '(_|^)'.
+            '(get|post|put|delete|patch|head|options|mkcol|propfind|proppatch|lock|unlock|move|copy|link|unlink)_'. // allowed http methods
             '/i';
 
         $routes = parent::all();

--- a/Routing/RestRouteCollection.php
+++ b/Routing/RestRouteCollection.php
@@ -76,10 +76,10 @@ class RestRouteCollection extends RouteCollection
      */
     public function all()
     {
-        $regex = '/
-    (_|^)
-    (get|post|put|delete|patch|head|options|mkcol|propfind|proppatch|lock|unlock|move|copy|link|unlink)_ # allowed http methods
-        /i';
+        $regex = '/' .
+            '(_|^)' .
+            '(get|post|put|delete|patch|head|options|mkcol|propfind|proppatch|lock|unlock|move|copy|link|unlink)_' . // allowed http methods
+            '/i';
 
         $routes = parent::all();
         $customMethodRoutes = [];

--- a/Tests/Fixtures/Controller/OrdersController.php
+++ b/Tests/Fixtures/Controller/OrdersController.php
@@ -15,19 +15,21 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class OrdersController extends Controller
 {
-    // conventional HATEOAS action after REST action
-
-    public function newFoosAction()
-    {
-    }
-
-    // [GET] /foos/new
-
+    /**
+     * [GET] /foos.
+     */
     public function getFoosAction()
     {
     }
 
-    // [GET] /foos
+    // conventional HATEOAS action after REST action
+
+    /**
+     * [GET] /foos/new.
+     */
+    public function newFoosAction()
+    {
+    }
 
     // conventional HATEOAS action before REST action
 


### PR DESCRIPTION
The regex pattern in RestRouteCollection::all() was including the whitespace and the comment, causing it to fail against all route names (thinking they are all custom). This broke the sorting that allowed routes like `get_user` to be defined before routes like `new_user` and `remove_user` without breaking them. 

This bug was introduced between 1.8 and 2.0, when the pattern was pulled out of the foreach loop.