### PR TITLE
correct the markup for the zone listener docs

### DIFF
--- a/Resources/doc/3-listener-support.rst
+++ b/Resources/doc/3-listener-support.rst
@@ -196,7 +196,7 @@ You need to enable this listener as follows, as it is disabled by default:
 Note: The access_denied_listener doesn't return a response itself and must be coupled with an exception listener returning a response (see the :doc:`FOSRestBundle exception controller <4-exception-controller-support>`. or the `twig exception controller`_).
 
 Zone Listener
-=============
+-------------
 
 As you can see, FOSRestBundle provides multiple event listeners to enable REST-related features.
 By default, these listeners will be registered to all requests and may conflict with other parts of your application.


### PR DESCRIPTION
@xabbuh is this correct?

right now the section isn't being listed http://symfony.com/doc/current/bundles/FOSRestBundle/3-listener-support.html#security-exception-listener