### PR TITLE
Fixed prefer_extension content negotiation

### DIFF
--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -77,7 +77,7 @@ class FormatNegotiator extends BaseNegotiator
                     $extensionHeader = $request->getMimeType($extension);
 
                     if ($extensionHeader) {
-                        $header = $extensionHeader.'; q='.$options['prefer_extension'].','.$header;
+                        $header = $extensionHeader.'; q='.$options['prefer_extension'].($header ? ','.$header : '');
                     }
                 }
             }

--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -75,10 +75,10 @@ class FormatNegotiator extends BaseNegotiator
                 if (!empty($extension)) {
                     // $extensionHeader will now be either a non empty string or an empty string
                     $extensionHeader = $request->getMimeType($extension);
-                    if ($header && $extensionHeader) {
-                        $header .= ',';
+
+                    if ($extensionHeader) {
+                        $header = $extensionHeader.'; q='.$options['prefer_extension'].','.$header;
                     }
-                    $header .= $extensionHeader.'; q='.$options['prefer_extension'];
                 }
             }
 

--- a/Tests/Negotiation/FormatNegotiatorTest.php
+++ b/Tests/Negotiation/FormatNegotiatorTest.php
@@ -109,18 +109,18 @@ class FormatNegotiatorTest extends \PHPUnit_Framework_TestCase
         $this->addRequestMatcher(true, ['priorities' => $priorities, 'prefer_extension' => '2.0']);
 
         $reflectionClass = new \ReflectionClass(get_class($this->request));
-        $reflectionProperty = $reflectionClass->getProperty('requestUri');
+        $reflectionProperty = $reflectionClass->getProperty('pathInfo');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($this->request, 'http://example.com/file.json');
+        $reflectionProperty->setValue($this->request, '/file.json');
 
         // Without extension mime-type in Accept header
 
-        $this->request->headers->set('Accept', 'text/html');
+        $this->request->headers->set('Accept', 'text/html; q=1.0');
         $this->assertEquals(new Accept('application/json'), $this->negotiator->getBest(''));
 
         // With low q extension mime-type in Accept header
 
-        $this->request->headers->set('Accept', 'text/html, application/json; q=0.1');
+        $this->request->headers->set('Accept', 'text/html; q=1.0, application/json; q=0.1');
         $this->assertEquals(new Accept('application/json'), $this->negotiator->getBest(''));
 
         $reflectionProperty->setValue($this->request, null);
@@ -132,9 +132,9 @@ class FormatNegotiatorTest extends \PHPUnit_Framework_TestCase
         $this->addRequestMatcher(true, ['priorities' => $priorities, 'prefer_extension' => '2.0']);
 
         $reflectionClass = new \ReflectionClass(get_class($this->request));
-        $reflectionProperty = $reflectionClass->getProperty('requestUri');
+        $reflectionProperty = $reflectionClass->getProperty('pathInfo');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($this->request, 'http://example.com/file.123456789');
+        $reflectionProperty->setValue($this->request, '/file.123456789');
 
         $this->request->headers->set('Accept', 'text/html, application/json');
         $this->assertEquals(new Accept('text/html'), $this->negotiator->getBest(''));

--- a/Tests/Negotiation/FormatNegotiatorTest.php
+++ b/Tests/Negotiation/FormatNegotiatorTest.php
@@ -103,6 +103,45 @@ class FormatNegotiatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Accept('application/json;version=1.0'), $this->negotiator->getBest(''));
     }
 
+    public function testGetBestWithPreferExtension()
+    {
+        $priorities = ['text/html', 'application/json'];
+        $this->addRequestMatcher(true, ['priorities' => $priorities, 'prefer_extension' => '2.0']);
+
+        $reflectionClass = new \ReflectionClass(get_class($this->request));
+        $reflectionProperty = $reflectionClass->getProperty('requestUri');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($this->request, 'http://example.com/file.json');
+
+        // Without extension mime-type in Accept header
+
+        $this->request->headers->set('Accept', 'text/html');
+        $this->assertEquals(new Accept('application/json'), $this->negotiator->getBest(''));
+
+        // With low q extension mime-type in Accept header
+
+        $this->request->headers->set('Accept', 'text/html, application/json; q=0.1');
+        $this->assertEquals(new Accept('application/json'), $this->negotiator->getBest(''));
+
+        $reflectionProperty->setValue($this->request, null);
+    }
+
+    public function testGetBestWithPreferExtensionAndUnknownExtension()
+    {
+        $priorities = ['text/html', 'application/json'];
+        $this->addRequestMatcher(true, ['priorities' => $priorities, 'prefer_extension' => '2.0']);
+
+        $reflectionClass = new \ReflectionClass(get_class($this->request));
+        $reflectionProperty = $reflectionClass->getProperty('requestUri');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($this->request, 'http://example.com/file.123456789');
+
+        $this->request->headers->set('Accept', 'text/html, application/json');
+        $this->assertEquals(new Accept('text/html'), $this->negotiator->getBest(''));
+
+        $reflectionProperty->setValue($this->request, null);
+    }
+
     public function testGetBestWithFormatWithRequestMimeTypeFallback()
     {
         $negotiator = new FormatNegotiator($this->requestStack);


### PR DESCRIPTION
Fixes issue #1661 

When prefer_extension is set, the Accept header will be prepended to instead of appended to. This ensures that the Accept header cannot override the qvalue of the extension mime-type, like in this scenario:

```
Location: http://example.com/file.json
Accept: text/html, application/json; q=0.1
```

If no mime-type can be found for the extension, the Accept header will not be modified.

Added unit tests for prefer_extension to ensure content negotiation remains predictable. 