### PR TITLE
[RequestBodyParamConverter] Force being explicit

### DIFF
--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -124,7 +124,7 @@ class RequestBodyParamConverter implements ParamConverterInterface
      */
     public function supports(ParamConverter $configuration)
     {
-        return null !== $configuration->getClass();
+        return null !== $configuration->getClass() && 'fos_rest.request_body' === $configuration->getConverter();
     }
 
     /**

--- a/Tests/Functional/Bundle/TestBundle/Controller/RequestBodyParamConverterController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/RequestBodyParamConverterController.php
@@ -11,11 +11,15 @@
 
 namespace FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
 class RequestBodyParamConverterController extends Controller
 {
+    /**
+     * @ParamConverter("post", converter="fos_rest.request_body")
+     */
     public function putPostAction(Post $post, \Datetime $date)
     {
         return new Response($post->getName());

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -11,9 +11,10 @@
 
 namespace FOS\RestBundle\Tests\Request;
 
-use Symfony\Component\HttpFoundation\Request;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Request\RequestBodyParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Tyler Stroud <tyler@tylerstroud.com>
@@ -223,32 +224,14 @@ class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
         return $converter->apply($request, $configuration);
     }
 
-    protected function createConfiguration($class = null, $name = null, $options = null)
+    protected function createConfiguration($class = null, $name = null, array $options = array())
     {
-        $config = $this->getMockBuilder('Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter')
-            ->disableOriginalConstructor()
-            ->setMethods(['getClass', 'getAliasName', 'getOptions', 'getName', 'allowArray'])
-            ->getMock();
-
-        if ($name !== null) {
-            $config->expects($this->any())
-                ->method('getName')
-                ->will($this->returnValue($name));
-        }
-
-        if ($class !== null) {
-            $config->expects($this->any())
-                ->method('getClass')
-                ->will($this->returnValue($class));
-        }
-
-        if ($options !== null) {
-            $config->expects($this->any())
-                ->method('getOptions')
-                ->will($this->returnValue($options));
-        }
-
-        return $config;
+        return new ParamConverter([
+            'name' => $name,
+            'class' => $class,
+            'options' => $options,
+            'converter' => 'fos_rest.request_body',
+        ]);
     }
 
     protected function createRequest($body = null, $contentType = null)


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1659

When a parameter is not a class registered in doctrine, the `RequestBodyParamConverter` can be reached without being explicitly asked which is not expected (imo at least).