### PR TITLE
View::setSerializationContext inexistant

### DIFF
--- a/Resources/doc/view_response_listener.rst
+++ b/Resources/doc/view_response_listener.rst
@@ -168,7 +168,7 @@ You can also define your serializer options dynamically:
         $context->setVersion('1.0');
         $context->addGroup('user');
 
-        $view->setSerializationContext($context);
+        $view->setContext($context);
 
         // ...
         $view


### PR DESCRIPTION
Replaced View::setSerializationContext call in example with View::setContext as previous method does not exist anymore