### PR TITLE
Update versioning.rst

### DIFF
--- a/Resources/doc/versioning.rst
+++ b/Resources/doc/versioning.rst
@@ -94,7 +94,9 @@ See :doc:`Format Listener <format_listener>`
     fos_rest:
         view:
             mime_types:
-                json: ['application/json', 'application/json;version=1.0', 'application/json;version=1.1']
+                json: ['application/json;version=1.0', 'application/json;version=1.1', 'application/json']
+
+The order of the mime_types matters, since the VersionListener looks for the first one matching.
 
 Note: If you have to handle huge versions and mime types, you can simplify the configuration with a php script:
 


### PR DESCRIPTION
Clarify mime_type ordering actually matters since the VersionListener takes the first result matching.

e.g.

```yaml
fos_rest:
    param_fetcher_listener: true
    body_listener: true
    format_listener:
        rules:
            - { path: ^/, priorities: [ 'html', 'json', 'application/javascript', 'text/css', '*/*'], fallback_format: html, prefer_extension: true }
    body_converter:
        enabled: true
        validate: true
    view:
        mime_types:
            json:
              - 'application/json;version=1.0'
              - 'application/json'
```

If application/json is listed first, and you're using the accept header as your versioning strategy, it will not work.