### PR TITLE
Allow disabling the Templating component

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationCheckPass.php
+++ b/DependencyInjection/Compiler/ConfigurationCheckPass.php
@@ -34,5 +34,9 @@ final class ConfigurationCheckPass implements CompilerPassInterface
                 throw new \RuntimeException('You must enable the SensioFrameworkExtraBundle view annotations to use the ViewResponseListener.');
             }
         }
+
+        if (!$container->has((string) $container->getAlias('fos_rest.templating'))) {
+            $container->removeAlias('fos_rest.templating');
+        }
     }
 }

--- a/Tests/Functional/ConfigurationTest.php
+++ b/Tests/Functional/ConfigurationTest.php
@@ -16,26 +16,20 @@ namespace FOS\RestBundle\Tests\Functional;
  */
 class ConfigurationTest extends WebTestCase
 {
-    private $client;
-
-    public function setUp()
+    public function testDisabledTemplating()
     {
-        $this->client = $this->createClient(['test_case' => 'Configuration']);
-    }
-
-    public function testConfiguration()
-    {
-        // Just create a client
+        $this->createClient(['test_case' => 'Templating']);
     }
 
     public function testToolbar()
     {
-        $this->client->request(
-            'GET',
-            '/_profiler/empty/search/results?limit=10',
-            [],
-            [],
-            ['HTTP_Accept' => 'application/json']
-        );
+        $this->createClient(['test_case' => 'Configuration'])
+            ->request(
+                'GET',
+                '/_profiler/empty/search/results?limit=10',
+                [],
+                [],
+                ['HTTP_Accept' => 'application/json']
+            );
     }
 }

--- a/Tests/Functional/app/Templating/bundles.php
+++ b/Tests/Functional/app/Templating/bundles.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \FOS\RestBundle\FOSRestBundle(),
+];

--- a/Tests/Functional/app/Templating/config.yml
+++ b/Tests/Functional/app/Templating/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    serializer: true
+    templating: false


### PR DESCRIPTION
Fix https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1652#issuecomment-287586998

I missed a part of the fix in the previous PR... I'm not completely happy with this solution but it is the simplest one.

Imo we should deprecate the `service` section of the config or find a way to make the aliases private to be able to remove this code.