### PR TITLE
fix listener priorities for the access denied listener and the exception listener

### DIFF
--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -47,7 +47,7 @@ class ExceptionListener extends HttpKernelExceptionListener
     public static function getSubscribedEvents()
     {
         return array(
-            KernelEvents::EXCEPTION => array('onKernelException', -100),
+            KernelEvents::EXCEPTION => array('onKernelException', 3),
         );
     }
 


### PR DESCRIPTION
@xabbuh why did you set the listener priority to `-100` https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1410/files#diff-324b1abf8a181b12c840bf5baefb86f3R50 ?

fixes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1538