### PR TITLE
Remove multiline exception cause of “Header may not contain more than…

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -239,10 +239,7 @@ class RestActionReader
         // check that every route parent has non-empty singular name
         foreach ($this->parents as $parent) {
             if (empty($parent) || '/' === substr($parent, -1)) {
-                throw new \InvalidArgumentException(
-                    "Every parent controller must have `get{SINGULAR}Action(\$id)` method\n".
-                    'where {SINGULAR} is a singular form of associated object'
-                );
+                throw new \InvalidArgumentException('Every parent controller must have `get{SINGULAR}Action(\$id)` method where {SINGULAR} is a singular form of associated object');
             }
         }
 


### PR DESCRIPTION
… a single header”, see https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1693