### PR TITLE
Use JMS Serializer Context Factories to create new contextes

### DIFF
--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -11,6 +11,8 @@
     <services>
         <service id="fos_rest.serializer.jms" class="FOS\RestBundle\Serializer\JMSSerializerAdapter" public="false" lazy="true">
             <argument type="service" id="jms_serializer.serializer" />
+            <argument type="service" id="jms_serializer.serialization_context_factory" />
+            <argument type="service" id="jms_serializer.deserialization_context_factory" />
         </service>
 
         <service id="fos_rest.serializer.symfony" class="FOS\RestBundle\Serializer\SymfonySerializerAdapter" public="false" lazy="true">

--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -43,8 +43,7 @@ class JMSSerializerAdapter implements Serializer
         SerializerInterface $serializer,
         SerializationContextFactoryInterface $serializationContextFactory = null,
         DeserializationContextFactoryInterface $deserializationContextFactory = null
-    )
-    {
+    ) {
         $this->serializer = $serializer;
         $this->serializationContextFactory = $serializationContextFactory;
         $this->deserializationContextFactory = $deserializationContextFactory;

--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -13,8 +13,10 @@ namespace FOS\RestBundle\Serializer;
 
 use FOS\RestBundle\Context\Context;
 use JMS\Serializer\Context as JMSContext;
-use JMS\Serializer\DeserializationContext as JMSDeserializationContext;
-use JMS\Serializer\SerializationContext as JMSSerializationContext;
+use JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface;
+use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 
 /**
@@ -34,10 +36,24 @@ class JMSSerializerAdapter implements Serializer
     const DESERIALIZATION = 1;
 
     private $serializer;
+    /**
+     * @var SerializationContextFactoryInterface
+     */
+    private $serializationContextFactory;
+    /**
+     * @var DeserializationContextFactoryInterface
+     */
+    private $deserializationContextFactory;
 
-    public function __construct(SerializerInterface $serializer)
+    public function __construct(
+        SerializerInterface $serializer,
+        SerializationContextFactoryInterface $serializationContextFactory = null,
+        DeserializationContextFactoryInterface $deserializationContextFactory = null
+    )
     {
         $this->serializer = $serializer;
+        $this->serializationContextFactory = $serializationContextFactory;
+        $this->deserializationContextFactory = $deserializationContextFactory;
     }
 
     /**
@@ -69,9 +85,13 @@ class JMSSerializerAdapter implements Serializer
     private function convertContext(Context $context, $direction)
     {
         if ($direction === self::SERIALIZATION) {
-            $jmsContext = JMSSerializationContext::create();
+            $jmsContext = $this->serializationContextFactory
+                ? $this->serializationContextFactory->createSerializationContext()
+                : SerializationContext::create();
         } else {
-            $jmsContext = JMSDeserializationContext::create();
+            $jmsContext = $this->deserializationContextFactory
+                ? $this->deserializationContextFactory->createDeserializationContext()
+                : DeserializationContext::create();
             $maxDepth = $context->getMaxDepth(false);
             if (null !== $maxDepth) {
                 for ($i = 0; $i < $maxDepth; ++$i) {
@@ -97,7 +117,7 @@ class JMSSerializerAdapter implements Serializer
             $jmsContext->setSerializeNull($context->getSerializeNull());
         }
 
-        foreach($context->getExclusionStrategies() as $strategy) {
+        foreach ($context->getExclusionStrategies() as $strategy) {
             $jmsContext->addExclusionStrategy($strategy);
         }
 

--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -36,13 +36,7 @@ class JMSSerializerAdapter implements Serializer
     const DESERIALIZATION = 1;
 
     private $serializer;
-    /**
-     * @var SerializationContextFactoryInterface
-     */
     private $serializationContextFactory;
-    /**
-     * @var DeserializationContextFactoryInterface
-     */
     private $deserializationContextFactory;
 
     public function __construct(

--- a/Tests/Serializer/JMSSerializerAdapterTest.php
+++ b/Tests/Serializer/JMSSerializerAdapterTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Serializer;
+
+use FOS\RestBundle\Context\Context;
+use FOS\RestBundle\Serializer\JMSSerializerAdapter;
+use JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface;
+use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\SerializerInterface;
+use PhpCollection\MapInterface;
+
+class JMSSerializerAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    private $serializer;
+    private $serializationContextFactory;
+    private $deserializationContextFactory;
+    private $adapter;
+
+    protected function setUp()
+    {
+        $this->serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
+
+        $this->serializationContextFactory = $this
+            ->getMockBuilder(SerializationContextFactoryInterface::class)->getMock();
+        $this->deserializationContextFactory = $this
+            ->getMockBuilder(DeserializationContextFactoryInterface::class)->getMock();
+
+        $this->adapter = new JMSSerializerAdapter(
+            $this->serializer,
+            $this->serializationContextFactory,
+            $this->deserializationContextFactory
+        );
+    }
+
+    public function testBasicSerializeAdapterWithoutContextFactories()
+    {
+        $jmsContext = SerializationContext::create();
+        $adapter = new JMSSerializerAdapter($this->serializer);
+        $this->serializer->expects($this->once())->method('serialize')->with('foo', 'json', $jmsContext);
+
+        $adapter->serialize('foo', 'json', new Context());
+    }
+
+    public function testBasicDeSerializeAdapterWithoutContextFactories()
+    {
+        $jmsContext = DeserializationContext::create();
+        $adapter = new JMSSerializerAdapter($this->serializer);
+        $this->serializer->expects($this->once())->method('deserialize')->with('foo', 'string', 'json', $jmsContext);
+
+        $adapter->deserialize('foo', 'string', 'json', new Context());
+    }
+
+    public function testBasicSerializeAdapter()
+    {
+        $jmsContext = $this->getMockBuilder(SerializationContext::class)->getMock();
+
+        $this->serializer->expects($this->once())->method('serialize')->with('foo', 'json', $jmsContext);
+        $this->serializationContextFactory->expects($this->once())->method('createSerializationContext')
+            ->willReturn($jmsContext);
+
+        $this->adapter->serialize('foo', 'json', new Context());
+    }
+
+    public function testBasicDeserializeAdapter()
+    {
+        $jmsContext = $this->getMockBuilder(DeserializationContext::class)->getMock();
+
+        $this->serializer->expects($this->once())->method('deserialize')->with('foo', 'string', 'json', $jmsContext);
+        $this->deserializationContextFactory->expects($this->once())->method('createDeserializationContext')
+            ->willReturn($jmsContext);
+
+        $this->adapter->deserialize('foo', 'string', 'json', new Context());
+    }
+
+    public function testContextInfoAreConverted()
+    {
+        $exclusion = $this->getMockBuilder(ExclusionStrategyInterface::class)->getMock();
+
+        $jmsContext = $this->getMockBuilder(SerializationContext::class)->getMock();
+        $jmsContext->attributes = $this->getMockBuilder(MapInterface::class)->getMock();
+
+        $jmsContext->expects($this->once())->method('setGroups')->with(['foo']);
+        $jmsContext->expects($this->once())->method('setSerializeNull')->with(true);
+        $jmsContext->expects($this->once())->method('enableMaxDepthChecks');
+        $jmsContext->expects($this->once())->method('setVersion')->with('5.0.1');
+        $jmsContext->expects($this->once())->method('addExclusionStrategy')->with($exclusion);
+
+        $jmsContext->attributes->expects($this->once())->method('set')->with('foo', 'bar');
+
+        $this->serializationContextFactory->method('createSerializationContext')->willReturn($jmsContext);
+
+        $fosContext = new Context();
+        $fosContext->setAttribute('foo', 'bar');
+        $fosContext->setGroups(['foo']);
+        $fosContext->setSerializeNull(true);
+        $fosContext->setVersion('5.0.1');
+        $fosContext->enableMaxDepth();
+        $fosContext->addExclusionStrategy($exclusion);
+
+        $this->adapter->serialize('foo', 'json', $fosContext);
+    }
+}

--- a/Tests/Serializer/JMSSerializerAdapterTest.php
+++ b/Tests/Serializer/JMSSerializerAdapterTest.php
@@ -30,6 +30,10 @@ class JMSSerializerAdapterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        if (!class_exists('JMS\SerializerBundle\JMSSerializerBundle')) {
+            $this->markTestSkipped('JMSSerializerBundle is not installed.');
+        }
+
         $this->serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
 
         $this->serializationContextFactory = $this

--- a/Tests/View/ViewHandlerTest.php
+++ b/Tests/View/ViewHandlerTest.php
@@ -447,6 +447,7 @@ class ViewHandlerTest extends \PHPUnit_Framework_TestCase
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')
             ->setMethods(['createView', 'getData'])
             ->disableOriginalConstructor()
+            ->disableOriginalClone()
             ->getMock();
         $form
             ->expects($this->once())

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "symfony/expression-language": "~2.7|^3.0|^4.0",
         "symfony/css-selector": "^2.7|^3.0|^4.0",
         "phpoption/phpoption": "^1.1",
-        "jms/serializer-bundle": "^1.0",
+        "jms/serializer-bundle": "^1.2",
         "psr/http-message": "^1.0"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "symfony/expression-language": "~2.7|^3.0|^4.0",
         "symfony/css-selector": "^2.7|^3.0|^4.0",
         "phpoption/phpoption": "^1.1",
-        "jms/serializer-bundle": "^1.2",
+        "jms/serializer-bundle": "^1.2|^2.0",
         "psr/http-message": "^1.0"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
     },
     "conflict": {
         "sensio/framework-extra-bundle": "<3.0.13",
+        "jms/serializer-bundle": "<1.2.0",
         "jms/serializer": "1.3.0"
     },
     "extra": {


### PR DESCRIPTION
As of jms/serializer 1.4.0 (and jms/serializer-bundle 1.2.0) is possible to configure the default context via services ([doc](http://jmsyst.com/libs/serializer/master/configuration#setting-a-default-serializationcontext-factory)).

This PR improves the integration with FOS Rest and JMS serializer

(I have also added some extra tests for the `JMSSerializerAdapter` class)