### PR TITLE
Remove redundant unset.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -62,7 +62,6 @@ final class Configuration implements ConfigurationInterface
                     ->beforeNormalization()
                         ->ifArray()->then(function ($v) {
                             if (!empty($v) && empty($v['formats'])) {
-                                unset($v['enabled']);
                                 $v = ['enabled' => true, 'formats' => $v];
                             }
 
@@ -193,7 +192,6 @@ final class Configuration implements ConfigurationInterface
                             ->beforeNormalization()
                                 ->ifArray()->then(function ($v) {
                                     if (!empty($v) && empty($v['formats'])) {
-                                        unset($v['enabled']);
                                         $v = ['enabled' => true, 'formats' => $v];
                                     }
 


### PR DESCRIPTION
`unset($v['enabled']);` is redundant here, because key `enabled` is overriden at the next line.

https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1622#discussion_r91139867