### PR TITLE
Improve Context for "Overriding Groups of Deeper Branches of the Graph"

### DIFF
--- a/Context/Context.php
+++ b/Context/Context.php
@@ -127,17 +127,22 @@ final class Context
     /**
      * Adds a normalization group.
      *
-     * @param string $group
+     * @param string      $group
+     * @param null|string $key
      *
      * @return self
      */
-    public function addGroup($group)
+    public function addGroup($group, $key = null)
     {
         if (null === $this->groups) {
             $this->groups = [];
         }
         if (!in_array($group, $this->groups)) {
-            $this->groups[] = $group;
+            if(is_string($key)){
+                $this->groups[$key] = $group;
+            } else {
+                $this->groups[] = $group;
+            }
         }
 
         return $this;
@@ -152,8 +157,8 @@ final class Context
      */
     public function addGroups(array $groups)
     {
-        foreach ($groups as $group) {
-            $this->addGroup($group);
+        foreach ($groups as $key => $group) {
+            $this->addGroup($group, is_string($key) ? $key : null);
         }
 
         return $this;


### PR DESCRIPTION
[Exclusion Strategies](http://jmsyst.com/libs/serializer/master/cookbook/exclusion_strategies#overriding-groups-of-deeper-branches-of-the-graph)
My PR is just for having the possibility to put in annotation ```@View()``` the full serialization context example:
```
use JMS\Serializer\SerializationContext;

$context = SerializationContext::create()->setGroups(array(
    'Default', // Serialize John's name
    'manager_group', // Serialize John's manager
    'friends_group', // Serialize John's friends

    'manager' => array( // Override the groups for the manager of John
        'Default', // Serialize John manager's name
        'friends_group', // Serialize John manager's friends. If you do not override the groups for the friends, it will default to Default.
    ),

    'friends' => array( // Override the groups for the friends of John
        'manager_group' // Serialize John friends' managers.

        'manager' => array( // Override the groups for the John friends' manager
            'Default', // This would be the default if you did not override the groups of the manager property.
        ),
    ),
));
$serializer->serialize($john, 'json', $context);
```

```
<?php
//MyController.php
use FOS\RestBundle\Controller\Annotations as Rest;
/**
 * @Rest\View(serializerGroups={
 *    "Default",
 *    "manager_group",
 *    "friends_group",
 *    "manager":{
 *                 "Default",
 *                 "friends_group"
 *              },
 *    "friends":{
 *                 "manager_group",
 *                 "manager":{
 *                               "Default"
 *                           }
 *
 *              },
 *    "manager":{"Default","friends_group"}
 *   })
 *
 *
 *
 */
 public function exampleAction()
 {
    //...
 }

```