### PR TITLE
Easier Custom Form Error Handler

### DIFF
--- a/Serializer/Normalizer/FormErrorHandler.php
+++ b/Serializer/Normalizer/FormErrorHandler.php
@@ -86,7 +86,7 @@ class FormErrorHandler extends JMSFormErrorHandler
         return $result;
     }
 
-    private function adaptFormArray(\ArrayObject $serializedForm, Context $context = null)
+    protected function adaptFormArray(\ArrayObject $serializedForm, Context $context = null)
     {
         $statusCode = $this->getStatusCode($context);
         if (null !== $statusCode) {
@@ -100,7 +100,7 @@ class FormErrorHandler extends JMSFormErrorHandler
         return $serializedForm;
     }
 
-    private function getStatusCode(Context $context = null)
+    protected function getStatusCode(Context $context = null)
     {
         if (null === $context) {
             return;


### PR DESCRIPTION
I am suggesting we change private methods to protected so that someone can easily change the response of a form error.  Here an example:

https://github.com/phptuts/symfonystarter/blob/f67743e1398b986206d6f721ca2b85a556fb9bd3/src/CoreBundle/Handler/FormErrorHandler.php#L16-L16

Right now I have to over ride to 2 function in order to get what I need done when it would be easier if   it was protected and I just had to over ride one function.  First time doing this so if I am breaking a rule let me know.

Thank you

Noah