### PR TITLE
Use `controller.service_arguments` with FOS

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -105,6 +105,7 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('default_format')->defaultNull()->end()
                         ->scalarNode('prefix_methods')->defaultTrue()->end()
                         ->scalarNode('include_format')->defaultTrue()->end()
+                        ->scalarNode('routing_ignore_classes')->defaultValue([])->end()
                     ->end()
                 ->end()
                 ->arrayNode('body_converter')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -106,6 +106,7 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('prefix_methods')->defaultTrue()->end()
                         ->scalarNode('include_format')->defaultTrue()->end()
                         ->scalarNode('routing_ignore_classes')->defaultValue([])->end()
+                        ->scalarNode('routing_ignore_types')->defaultValue([])->end()
                     ->end()
                 ->end()
                 ->arrayNode('body_converter')

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -60,6 +60,7 @@ class FOSRestExtension extends Extension
         $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(3, $config['routing_loader']['include_format']);
         $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(5, $config['routing_loader']['prefix_methods']);
         $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(6, $config['routing_loader']['routing_ignore_classes']);
+        $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(7, $config['routing_loader']['routing_ignore_types']);
 
         foreach ($config['service'] as $key => $service) {
             if ('validator' === $service && empty($config['body_converter']['validate'])) {

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -59,6 +59,7 @@ class FOSRestExtension extends Extension
         $container->getDefinition('fos_rest.routing.loader.xml_collection')->replaceArgument(2, $config['routing_loader']['include_format']);
         $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(3, $config['routing_loader']['include_format']);
         $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(5, $config['routing_loader']['prefix_methods']);
+        $container->getDefinition('fos_rest.routing.loader.reader.action')->replaceArgument(6, $config['routing_loader']['routing_ignore_classes']);
 
         foreach ($config['service'] as $key => $service) {
             if ('validator' === $service && empty($config['body_converter']['validate'])) {

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -53,6 +53,7 @@
             <argument /> <!-- include format -->
             <argument type="collection" /> <!-- formats -->
             <argument /> <!-- prefix_methods bool -->
+            <argument type="collection" /> <!-- routing_ignore_classes -->
         </service>
 
         <service id="fos_rest.inflector.doctrine" class="FOS\RestBundle\Inflector\DoctrineInflector" public="false" />

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -54,6 +54,7 @@
             <argument type="collection" /> <!-- formats -->
             <argument /> <!-- prefix_methods bool -->
             <argument type="collection" /> <!-- routing_ignore_classes -->
+            <argument type="collection" /> <!-- routing_ignore_types -->
         </service>
 
         <service id="fos_rest.inflector.doctrine" class="FOS\RestBundle\Inflector\DoctrineInflector" public="false" />

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
@@ -423,6 +423,18 @@ Your controller will be :
                 - 'Psr\Log\LoggerInterface'
 
 
+If you are using php7, You can also exclude a type of variable.
+To exclude all object from your routing, you have to add :
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_rest:
+        routing_loader:
+            routing_ignore_types:
+                - 'object'
+
+
 
 Changing pluralization in generated routes
 ------------------------------------------

--- a/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
+++ b/Resources/doc/5-automatic-route-generation_single-restful-controller.rst
@@ -380,6 +380,50 @@ to limit or add a custom format, you can do so by overriding it with the
         // ...
     }
 
+Use `controller.service_arguments` with FOS
+---------------------------
+
+By using `controller.service_arguments` tags you need to exclude classes.
+
+.. code-block:: yaml
+
+    # app/config/services.yml
+    services:
+        # ...
+
+        # controllers are imported separately to make sure they're public
+        # and have a tag that allows actions to type-hint services
+        AppBundle\Controller\:
+            resource: '../../src/AppBundle/Controller'
+            public: true
+            tags: ['controller.service_arguments']
+
+
+Your controller will be :
+
+.. code-block:: php
+
+    use Psr\Log\LoggerInterface;
+
+    class InvoiceController extends Controller
+    {
+        public function listAction(LoggerInterface $logger)
+        {
+            $logger->info('A new way to access services!');
+        }
+    }
+
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_rest:
+        routing_loader:
+            routing_ignore_classes:
+                - 'Psr\Log\LoggerInterface'
+
+
+
 Changing pluralization in generated routes
 ------------------------------------------
 

--- a/Resources/doc/configuration-reference.rst
+++ b/Resources/doc/configuration-reference.rst
@@ -27,6 +27,7 @@ Full default configuration
             default_format:       null
             include_format:       true
             prefix_methods:       true
+            routing_ignore_classes: []
         body_converter:
             enabled:              false
             validate:             false

--- a/Resources/doc/configuration-reference.rst
+++ b/Resources/doc/configuration-reference.rst
@@ -28,6 +28,7 @@ Full default configuration
             include_format:       true
             prefix_methods:       true
             routing_ignore_classes: []
+            routing_ignore_types: []
         body_converter:
             enabled:              false
             validate:             false

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -111,6 +111,12 @@ class RestActionReader
     private $hasMethodPrefix;
 
     /**
+     * Ignore custom classes form route generator
+     * @var array
+     */
+    private $ignoreClasses = [];
+
+    /**
      * Initializes controller reader.
      *
      * @param Reader               $annotationReader
@@ -120,7 +126,7 @@ class RestActionReader
      * @param array                $formats
      * @param bool                 $hasMethodPrefix
      */
-    public function __construct(Reader $annotationReader, ParamReaderInterface $paramReader, InflectorInterface $inflector, $includeFormat, array $formats = [], $hasMethodPrefix = true)
+    public function __construct(Reader $annotationReader, ParamReaderInterface $paramReader, InflectorInterface $inflector, $includeFormat, array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [])
     {
         $this->annotationReader = $annotationReader;
         $this->paramReader = $paramReader;
@@ -128,6 +134,7 @@ class RestActionReader
         $this->includeFormat = $includeFormat;
         $this->formats = $formats;
         $this->hasMethodPrefix = $hasMethodPrefix;
+        $this->ignoreClasses = $ignoreClasses;
     }
 
     /**
@@ -476,13 +483,13 @@ class RestActionReader
         $params = $this->paramReader->getParamsFromMethod($method);
 
         // ignore several type hinted arguments
-        $ignoreClasses = [
+        $ignoreClasses = array_merge([
             \Symfony\Component\HttpFoundation\Request::class,
             \FOS\RestBundle\Request\ParamFetcherInterface::class,
             \Symfony\Component\Validator\ConstraintViolationListInterface::class,
             \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter::class,
             MessageInterface::class,
-        ];
+        ], $this->ignoreClasses);
 
         $arguments = [];
         foreach ($method->getParameters() as $argument) {

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -118,6 +118,13 @@ class RestActionReader
     private $ignoreClasses = [];
 
     /**
+     * Ignore type var form route generator.
+     *
+     * @var array
+     */
+    private $ignoreTypes = [];
+
+    /**
      * Initializes controller reader.
      *
      * @param Reader               $annotationReader
@@ -126,8 +133,10 @@ class RestActionReader
      * @param bool                 $includeFormat
      * @param array                $formats
      * @param bool                 $hasMethodPrefix
+     * @param array                $ignoreClasses
+     * @param array                $ignoreTypes
      */
-    public function __construct(Reader $annotationReader, ParamReaderInterface $paramReader, InflectorInterface $inflector, $includeFormat, array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [])
+    public function __construct(Reader $annotationReader, ParamReaderInterface $paramReader, InflectorInterface $inflector, $includeFormat, array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [], array $ignoreTypes = [])
     {
         $this->annotationReader = $annotationReader;
         $this->paramReader = $paramReader;
@@ -136,6 +145,7 @@ class RestActionReader
         $this->formats = $formats;
         $this->hasMethodPrefix = $hasMethodPrefix;
         $this->ignoreClasses = $ignoreClasses;
+        $this->ignoreTypes = $ignoreTypes;
     }
 
     /**
@@ -504,6 +514,18 @@ class RestActionReader
                 foreach ($ignoreClasses as $class) {
                     if ($className === $class || is_subclass_of($className, $class)) {
                         continue 2;
+                    }
+                }
+            }
+
+            // Dont break php5 compatibility
+            if (method_exists($argument, 'getType')) {
+                $argumentType = $argument->getType();
+                if ($argumentType) {
+                    foreach ($this->ignoreTypes as $type) {
+                        if ($argumentType === $type) {
+                            continue 2;
+                        }
                     }
                 }
             }

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -111,7 +111,8 @@ class RestActionReader
     private $hasMethodPrefix;
 
     /**
-     * Ignore custom classes form route generator
+     * Ignore custom classes form route generator.
+     *
      * @var array
      */
     private $ignoreClasses = [];

--- a/Tests/Fixtures/Controller/ArticleController.php
+++ b/Tests/Fixtures/Controller/ArticleController.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\Fixtures\Controller;
 
 use FOS\RestBundle\Controller\ControllerTrait;
 use FOS\RestBundle\Routing\ClassResourceInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -244,6 +245,16 @@ class ArticleController extends Controller implements ClassResourceInterface
      * @param Request $request
      */
     public function getFoosAction($slug, Request $request)
+    {
+    }
+
+    /**
+     * [GET] /article/exclude.
+     *
+     * @param $slug
+     * @param Request $request
+     */
+    public function getExcludeAction(LoggerInterface $loggerInterface, Request $request)
     {
     }
 }

--- a/Tests/Fixtures/Controller/ArticleController.php
+++ b/Tests/Fixtures/Controller/ArticleController.php
@@ -257,4 +257,14 @@ class ArticleController extends Controller implements ClassResourceInterface
     public function getExcludeAction(LoggerInterface $loggerInterface, Request $request)
     {
     }
+
+    /**
+     * [GET] /article/excludetype.
+     *
+     * @param $slug
+     * @param Request $request
+     */
+    public function getExcludetypeAction(Request $request, array $myArray)
+    {
+    }
 }

--- a/Tests/Fixtures/Etalon/resource_controller.yml
+++ b/Tests/Fixtures/Etalon/resource_controller.yml
@@ -97,3 +97,8 @@ get_article_foos:
   methods: [GET]
   path:    /articles/{slug}/foos.{_format}
   controller: ::getFoosAction
+
+get_article_exclude:
+  methods: [GET]
+  path:    /article/exclude.{_format}
+  controller: ::getExcludeAction

--- a/Tests/Fixtures/Etalon/resource_controller.yml
+++ b/Tests/Fixtures/Etalon/resource_controller.yml
@@ -102,3 +102,9 @@ get_article_exclude:
   methods: [GET]
   path:    /article/exclude.{_format}
   controller: ::getExcludeAction
+
+# Will fail on php5 test
+#get_article_excludetype:
+#  methods: [GET]
+#  path:    /article/excludetype.{_format}
+#  controller: ::getExcludetypeAction

--- a/Tests/Routing/Loader/LoaderTest.php
+++ b/Tests/Routing/Loader/LoaderTest.php
@@ -57,7 +57,7 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @return RestRouteLoader
      */
-    protected function getControllerLoader(array $formats = [], $hasMethodPrefix = true)
+    protected function getControllerLoader(array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [])
     {
         // This check allows to override the container
         if ($this->container === null) {
@@ -77,7 +77,7 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
         $paramReader = new ParamReader($annotationReader);
         $inflector = new DoctrineInflector();
 
-        $ar = new RestActionReader($annotationReader, $paramReader, $inflector, true, $formats, $hasMethodPrefix);
+        $ar = new RestActionReader($annotationReader, $paramReader, $inflector, true, $formats, $hasMethodPrefix, $ignoreClasses);
         $cr = new RestControllerReader($ar, $annotationReader);
 
         return new RestRouteLoader($this->container, $l, $p, $cr, 'html');

--- a/Tests/Routing/Loader/LoaderTest.php
+++ b/Tests/Routing/Loader/LoaderTest.php
@@ -57,7 +57,7 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @return RestRouteLoader
      */
-    protected function getControllerLoader(array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [])
+    protected function getControllerLoader(array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [], array $ignoreTypes = [])
     {
         // This check allows to override the container
         if ($this->container === null) {
@@ -77,7 +77,7 @@ abstract class LoaderTest extends \PHPUnit_Framework_TestCase
         $paramReader = new ParamReader($annotationReader);
         $inflector = new DoctrineInflector();
 
-        $ar = new RestActionReader($annotationReader, $paramReader, $inflector, true, $formats, $hasMethodPrefix, $ignoreClasses);
+        $ar = new RestActionReader($annotationReader, $paramReader, $inflector, true, $formats, $hasMethodPrefix, $ignoreClasses, $ignoreTypes);
         $cr = new RestControllerReader($ar, $annotationReader);
 
         return new RestRouteLoader($this->container, $l, $p, $cr, 'html');

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -47,11 +47,11 @@ class RestRouteLoaderTest extends LoaderTest
      */
     public function testResourceFixture()
     {
-        $collection = $this->loadFromControllerFixture('ArticleController');
+        $collection = $this->loadFromControllerFixture('ArticleController', null, [], true, [\Psr\Log\LoggerInterface::class]);
         $etalonRoutes = $this->loadEtalonRoutesInfo('resource_controller.yml');
 
         $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(24, count($collection->all()));
+        $this->assertEquals(25, count($collection->all()));
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);
@@ -380,9 +380,9 @@ class RestRouteLoaderTest extends LoaderTest
      *
      * @return RestRouteCollection
      */
-    protected function loadFromControllerFixture($fixtureName, $namePrefix = null, array $formats = [], $hasMethodPrefix = true)
+    protected function loadFromControllerFixture($fixtureName, $namePrefix = null, array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [])
     {
-        $loader = $this->getControllerLoader($formats, $hasMethodPrefix);
+        $loader = $this->getControllerLoader($formats, $hasMethodPrefix, $ignoreClasses);
         $loader->getControllerReader()->getActionReader()->setNamePrefix($namePrefix);
 
         return $loader->load('FOS\RestBundle\Tests\Fixtures\Controller\\'.$fixtureName, 'rest');

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -47,11 +47,11 @@ class RestRouteLoaderTest extends LoaderTest
      */
     public function testResourceFixture()
     {
-        $collection = $this->loadFromControllerFixture('ArticleController', null, [], true, [\Psr\Log\LoggerInterface::class]);
+        $collection = $this->loadFromControllerFixture('ArticleController', null, [], true, [\Psr\Log\LoggerInterface::class], ['array']);
         $etalonRoutes = $this->loadEtalonRoutesInfo('resource_controller.yml');
 
         $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(25, count($collection->all()));
+        $this->assertEquals(26, count($collection->all()));
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);
@@ -380,9 +380,9 @@ class RestRouteLoaderTest extends LoaderTest
      *
      * @return RestRouteCollection
      */
-    protected function loadFromControllerFixture($fixtureName, $namePrefix = null, array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [])
+    protected function loadFromControllerFixture($fixtureName, $namePrefix = null, array $formats = [], $hasMethodPrefix = true, array $ignoreClasses = [], array $ignoreTypes = [])
     {
-        $loader = $this->getControllerLoader($formats, $hasMethodPrefix, $ignoreClasses);
+        $loader = $this->getControllerLoader($formats, $hasMethodPrefix, $ignoreClasses, $ignoreTypes);
         $loader->getControllerReader()->getActionReader()->setNamePrefix($namePrefix);
 
         return $loader->load('FOS\RestBundle\Tests\Fixtures\Controller\\'.$fixtureName, 'rest');


### PR DESCRIPTION
By using `controller.service_arguments` with sf 3.3 (http://symfony.com/doc/master/service_container/3.3-di-changes.html#controllers-are-registered-as-services) FOS route generator failed and add dependency to your URL so you need to exclude somes classes.

Exemple : 

    # app/config/services.yml
    services:
        # ...
        # controllers are imported separately to make sure they're public
        # and have a tag that allows actions to type-hint services
        AppBundle\Controller\:
            resource: '../../src/AppBundle/Controller'
            public: true
            tags: ['controller.service_arguments']

Your controller will be :

    use Psr\Log\LoggerInterface;

    class InvoiceController extends Controller
    {
        public function getListAction(LoggerInterface $logger)
        {
            $logger->info('A new way to access services!');
        }
    }

So you need to add class to your FOS configuration to get route `GET /list` and not `GET /list/{logger}` :

    # app/config/config.yml
    fos_rest:
        routing_loader:
            routing_ignore_classes:
                - 'Psr\Log\LoggerInterface'
