### PR TITLE
use ChildDefinition when possible

### DIFF
--- a/DependencyInjection/Compiler/FormatListenerRulesPass.php
+++ b/DependencyInjection/Compiler/FormatListenerRulesPass.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
@@ -82,9 +83,10 @@ final class FormatListenerRulesPass implements CompilerPassInterface
         $id = 'fos_rest.request_matcher.'.md5($serialized).sha1($serialized);
 
         if (!$container->hasDefinition($id)) {
+            $childDefinitionClass = class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
             // only add arguments that are necessary
             $container
-                ->setDefinition($id, new DefinitionDecorator('fos_rest.format_request_matcher'))
+                ->setDefinition($id, new $childDefinitionClass('fos_rest.format_request_matcher'))
                 ->setArguments($arguments);
         }
 

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -240,7 +241,8 @@ class FOSRestExtension extends Extension
     private function loadView(array $config, XmlFileLoader $loader, ContainerBuilder $container)
     {
         if (!empty($config['view']['jsonp_handler'])) {
-            $handler = new DefinitionDecorator($config['service']['view_handler']);
+            $childDefinitionClass = class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
+            $handler = new $childDefinitionClass($config['service']['view_handler']);
             $handler->setPublic(true);
 
             $jsonpHandler = new Reference('fos_rest.view_handler.jsonp');
@@ -402,8 +404,9 @@ class FOSRestExtension extends Extension
             array_pop($arguments);
         }
 
+        $childDefinitionClass = class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
         $container
-            ->setDefinition($id, new DefinitionDecorator('fos_rest.zone_request_matcher'))
+            ->setDefinition($id, new $childDefinitionClass('fos_rest.zone_request_matcher'))
             ->setArguments($arguments)
         ;
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\DependencyInjection;
 
 use FOS\RestBundle\DependencyInjection\FOSRestExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
@@ -634,7 +635,9 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->container->has('fos_rest.view_handler'));
 
         $viewHandler = $this->container->getDefinition('fos_rest.view_handler');
-        $this->assertInstanceOf(DefinitionDecorator::class, $viewHandler);
+
+        $childDefinitionClass = class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
+        $this->assertInstanceOf($childDefinitionClass, $viewHandler);
     }
 
     public function testSerializerExceptionNormalizer()
@@ -672,14 +675,17 @@ class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[0][0]);
         $requestMatcherFirstId = (string) $addRequestMatcherCalls[0][1][0];
         $requestMatcherFirst = $this->container->getDefinition($requestMatcherFirstId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherFirst);
+
+        $childDefinitionClass = class_exists(ChildDefinition::class) ? ChildDefinition::class : DefinitionDecorator::class;
+        $this->assertInstanceOf($childDefinitionClass, $requestMatcherFirst);
         $this->assertEquals('/api/*', $requestMatcherFirst->getArgument(0));
 
         // Second zone
         $this->assertEquals('addRequestMatcher', $addRequestMatcherCalls[1][0]);
         $requestMatcherSecondId = (string) $addRequestMatcherCalls[1][1][0];
         $requestMatcherSecond = $this->container->getDefinition($requestMatcherSecondId);
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $requestMatcherSecond);
+
+        $this->assertInstanceOf($childDefinitionClass, $requestMatcherSecond);
         $this->assertEquals('/^second', $requestMatcherSecond->getArgument(0));
         $this->assertEquals(array('127.0.0.1'), $requestMatcherSecond->getArgument(3));
     }


### PR DESCRIPTION
`ChildDefinition` was introduced in Symfony 3.2 and replaces the `DefinitionDecorator` class which will be removed in Symfony 4.0.