### PR TITLE
add fos_rest.exception.service to configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -406,6 +406,7 @@ final class Configuration implements ConfigurationInterface
                     ->canBeEnabled()
                     ->children()
                         ->scalarNode('exception_controller')->defaultNull()->end()
+                        ->scalarNode('service')->defaultNull()->end()
                         ->arrayNode('codes')
                             ->useAttributeAsKey('name')
                             ->beforeNormalization()

--- a/Resources/doc/configuration-reference.rst
+++ b/Resources/doc/configuration-reference.rst
@@ -76,6 +76,7 @@ Full default configuration
         exception:
             enabled:              false
             exception_controller:  null
+            service:              null
             codes:
 
                 # Prototype


### PR DESCRIPTION
I noticed that for exception.service configuration option was not added with [this commit](https://github.com/FriendsOfSymfony/FOSRestBundle/commit/a3ee6d7c4427d569d577e717ab8dccc1a857abbd). Without this option [FOSRestExtension.php#L328](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/DependencyInjection/FOSRestExtension.php#L328) is unreachable and default ExceptionListener is always registered as an event subscriber.
If there is an actual reason why this listener should always be active, code block in FOSRestExtension should be removed.