### PR TITLE
Skip abstract classes in route generation

### DIFF
--- a/Routing/Loader/ClassUtils.php
+++ b/Routing/Loader/ClassUtils.php
@@ -36,7 +36,11 @@ class ClassUtils
             }
 
             if (true === $class && T_STRING === $token[0]) {
-                return $namespace.'\\'.$token[1];
+                $fqcn = $namespace.'\\'.$token[1];
+
+                if (class_exists($fqcn) && !(new \ReflectionClass($fqcn))->isAbstract()) {
+                    return $fqcn;
+                }
             }
 
             if (true === $namespace && T_STRING === $token[0]) {

--- a/Routing/Loader/DirectoryRouteLoader.php
+++ b/Routing/Loader/DirectoryRouteLoader.php
@@ -51,7 +51,6 @@ class DirectoryRouteLoader extends Loader
 
         foreach ($finder->in($resource)->name('*.php')->files() as $file) {
             if ($class = ClassUtils::findClassInFile($file)) {
-                if ((new \ReflectionClass($class))->isAbstract()) continue;
                 $imported = $this->processor->importResource($this, $class, array(), null, null, 'rest');
                 $collection->addCollection($imported);
             }

--- a/Routing/Loader/DirectoryRouteLoader.php
+++ b/Routing/Loader/DirectoryRouteLoader.php
@@ -51,6 +51,7 @@ class DirectoryRouteLoader extends Loader
 
         foreach ($finder->in($resource)->name('*.php')->files() as $file) {
             if ($class = ClassUtils::findClassInFile($file)) {
+                if ((new \ReflectionClass($class))->isAbstract()) continue;
                 $imported = $this->processor->importResource($this, $class, array(), null, null, 'rest');
                 $collection->addCollection($imported);
             }

--- a/Tests/Fixtures/Controller/Directory/BaseController.php
+++ b/Tests/Fixtures/Controller/Directory/BaseController.php
@@ -20,5 +20,4 @@ abstract class BaseController extends Controller
     }
 
     // [PUT] /users/{slug}
-
 }

--- a/Tests/Fixtures/Controller/Directory/BaseController.php
+++ b/Tests/Fixtures/Controller/Directory/BaseController.php
@@ -11,24 +11,14 @@
 
 namespace FOS\RestBundle\Tests\Fixtures\Controller\Directory;
 
-class UsersController extends BaseController
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+abstract class BaseController extends Controller
 {
-    public function getUsersAction()
+    public function putUserAction($slug)
     {
     }
 
- // [GET] /users
-
-    public function getUserAction($slug)
-    {
-    }
-
- // [GET] /users/{slug}
-
-    public function postUsersAction()
-    {
-    }
-
- // [POST] /users
+    // [PUT] /users/{slug}
 
 }

--- a/Tests/Fixtures/Controller/Directory/UsersController.php
+++ b/Tests/Fixtures/Controller/Directory/UsersController.php
@@ -30,5 +30,4 @@ class UsersController extends BaseController
     }
 
  // [POST] /users
-
 }


### PR DESCRIPTION
When scanning a directory for controllers to auto-generate routes for, abstract controller classes should be skipped. HTTP requests to those routes cause the controller resolver to try instantiate an abstract class.