### PR TITLE
Add prefix to route name

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -279,7 +279,14 @@ class RestActionReader
             $resources[] = null;
         }
 
-        $routeName = $httpMethod.$this->generateRouteName($resources);
+        $baseRouteName = preg_replace(array(
+            '/(bundle|controller)_?/',
+            '/__/',
+        ), array(
+            '_',
+            '_',
+        ), strtolower(str_replace('\\', '_', $method->getDeclaringClass()->name)));
+        $routeName = $baseRouteName.$httpMethod.$this->generateRouteName($resources);
         $urlParts = $this->generateUrlParts($resources, $arguments, $httpMethod);
 
         // if passed method is not valid HTTP method then it's either


### PR DESCRIPTION
When having multiple controller with same action name, routes are overwritten. This set a prefix using the controller's name to ensure uniqueness.

EDIT: I forgot to edit unit tests. Feel free to discuss about this PR, I'll edit them later.