### PR TITLE
new "parents" option in @RouteResource annotation to defines parents route resources parts

### DIFF
--- a/Controller/Annotations/RouteResource.php
+++ b/Controller/Annotations/RouteResource.php
@@ -27,4 +27,8 @@ class RouteResource
      * @var bool
      */
     public $pluralize = true;
+    /**
+     * @var array
+     */
+    public $parents = array();
 }

--- a/Routing/Loader/Reader/RestControllerReader.php
+++ b/Routing/Loader/Reader/RestControllerReader.php
@@ -83,6 +83,7 @@ class RestControllerReader
         if ($annotation = $this->annotationReader->getClassAnnotation($reflectionClass, Annotations\RouteResource::class)) {
             $resource = explode('_', $annotation->resource);
             $this->actionReader->setPluralize($annotation->pluralize);
+            $this->actionReader->setParents($annotation->parents);
         } elseif ($reflectionClass->implementsInterface(ClassResourceInterface::class)) {
             $resource = preg_split(
                 '/([A-Z][^A-Z]*)Controller/', $reflectionClass->getShortName(), -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE

--- a/Tests/Fixtures/Controller/AnnotatedManyParentsArticleController.php
+++ b/Tests/Fixtures/Controller/AnnotatedManyParentsArticleController.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Controller\Annotations as Rest;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @author Bartłomiej Nowak <barteknowak90@gmail.com>
+ * @Rest\RouteResource("Comment", parents={"Article", "Media"})
+ */
+class AnnotatedManyParentsArticleController extends Controller
+{
+    /**
+     * "get_article_media_comment" [GET] /articles/{slug}/media/{mediaId}/comments/{id}.{_format}
+     */
+    public function getAction($slug, $mediaId, $id)
+    {
+    }
+
+    /**
+     * "get_article_media_comments" [GET] /articles/{slug}/media/{mediaId}/comments.{_format}
+     */
+    public function cgetAction($slug, $mediaId)
+    {
+    }
+}

--- a/Tests/Fixtures/Controller/AnnotatedManyParentsArticleController.php
+++ b/Tests/Fixtures/Controller/AnnotatedManyParentsArticleController.php
@@ -21,14 +21,14 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AnnotatedManyParentsArticleController extends Controller
 {
     /**
-     * "get_article_media_comment" [GET] /articles/{slug}/media/{mediaId}/comments/{id}.{_format}
+     * "get_article_media_comment" [GET] /articles/{slug}/media/{mediaId}/comments/{id}.{_format}.
      */
     public function getAction($slug, $mediaId, $id)
     {
     }
 
     /**
-     * "get_article_media_comments" [GET] /articles/{slug}/media/{mediaId}/comments.{_format}
+     * "get_article_media_comments" [GET] /articles/{slug}/media/{mediaId}/comments.{_format}.
      */
     public function cgetAction($slug, $mediaId)
     {

--- a/Tests/Fixtures/Controller/AnnotatedParentsArticleController.php
+++ b/Tests/Fixtures/Controller/AnnotatedParentsArticleController.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Controller\Annotations as Rest;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @author Bartłomiej Nowak <barteknowak90@gmail.com>
+ * @Rest\RouteResource("Comment", parents={"Article"})
+ */
+class AnnotatedParentsArticleController extends Controller
+{
+    /**
+     * "get_article_comment" [GET] /articles/{slug}/comments/{id}.{_format}
+     */
+    public function getAction($slug, $id)
+    {
+    }
+
+    /**
+     * "get_article_comments" [GET] /articles/{slug}/comments.{_format}
+     */
+    public function cgetAction($slug)
+    {
+    }
+}

--- a/Tests/Fixtures/Controller/AnnotatedParentsArticleController.php
+++ b/Tests/Fixtures/Controller/AnnotatedParentsArticleController.php
@@ -21,14 +21,14 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AnnotatedParentsArticleController extends Controller
 {
     /**
-     * "get_article_comment" [GET] /articles/{slug}/comments/{id}.{_format}
+     * "get_article_comment" [GET] /articles/{slug}/comments/{id}.{_format}.
      */
     public function getAction($slug, $id)
     {
     }
 
     /**
-     * "get_article_comments" [GET] /articles/{slug}/comments.{_format}
+     * "get_article_comments" [GET] /articles/{slug}/comments.{_format}.
      */
     public function cgetAction($slug)
     {

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -371,6 +371,32 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
+     * Test parents option with one value in @FOS\RestBundle\Controller\Annotations\RouteResource annotation
+     */
+    public function testAnnotatedParentsArticleFixture()
+    {
+        $collection = $this->loadFromControllerFixture('AnnotatedParentsArticleController');
+
+        $this->assertNotNull($collection->get('get_article_comment'), 'route for "get_article_comment" does not exist');
+        $this->assertEquals('/articles/{slug}/comments/{id}.{_format}', $collection->get('get_article_comment')->getPath());
+        $this->assertNotNull($collection->get('get_article_comments'), 'route for "get_article_comments" does not exist');
+        $this->assertEquals('/articles/{slug}/comments.{_format}', $collection->get('get_article_comments')->getPath());
+    }
+
+    /**
+     * Test parents option with many values in @FOS\RestBundle\Controller\Annotations\RouteResource annotation
+     */
+    public function testAnnotatedManyParentsArticleFixture()
+    {
+        $collection = $this->loadFromControllerFixture('AnnotatedManyParentsArticleController');
+
+        $this->assertNotNull($collection->get('get_article_media_comment'), 'route for "get_article_media_comment" does not exist');
+        $this->assertEquals('/articles/{slug}/media/{mediaId}/comments/{id}.{_format}', $collection->get('get_article_media_comment')->getPath());
+        $this->assertNotNull($collection->get('get_article_media_comments'), 'route for "get_article_media_comments" does not exist');
+        $this->assertEquals('/articles/{slug}/media/{mediaId}/comments.{_format}', $collection->get('get_article_media_comments')->getPath());
+    }
+
+    /**
      * Load routes collection from fixture class under Tests\Fixtures directory.
      *
      * @param string $fixtureName     name of the class fixture

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -371,7 +371,7 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
-     * Test parents option with one value in @FOS\RestBundle\Controller\Annotations\RouteResource annotation
+     * Test parents option with one value in @FOS\RestBundle\Controller\Annotations\RouteResource annotation.
      */
     public function testAnnotatedParentsArticleFixture()
     {
@@ -384,7 +384,7 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
-     * Test parents option with many values in @FOS\RestBundle\Controller\Annotations\RouteResource annotation
+     * Test parents option with many values in @FOS\RestBundle\Controller\Annotations\RouteResource annotation.
      */
     public function testAnnotatedManyParentsArticleFixture()
     {


### PR DESCRIPTION
With that option we can define parents of route resource directly in @FOS\RestBundle\Controller\Annotations\RouteResource annotation. So we don't have to define routing in yml or xml files when we want to use seperate controllers for subresources.

I figured out that this case can be also cover by:
```php
use FOS\RestBundle\Controller\FOSRestController;

/**
 * @Rest\RouteResource("User")
 */
class UserController extends FOSRestController
{
    public function getAction($id)
    {} // "get_user" [GET] /users/{id}
}

/**
 * @Rest\RouteResource("User")
 */
class UserCommentsController extends FOSRestController
{
    public function cgetCommentsAction($userId)
    {} // "get_user_comments" [GET] /users/{userId}/comments
}
```

but when we have two or more words in subresource name route loader break every word into separate route resources:

```php
/**
 * @Rest\RouteResource("User")
 */
class PhoneNumberController extends FOSRestController
{
    public function cgetPhoneNumbersAction($userId)
    {} // "get_user_phone_numbers" [GET] /users/{userId}/phone/numbers
}
```