### PR TITLE
Have REST route generator ignore request body ParamConverters

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -475,6 +475,17 @@ class RestActionReader
         // ignore all query params
         $params = $this->paramReader->getParamsFromMethod($method);
 
+        // check if a parameter is coming from the request body
+        $ignoreParameters = [];
+        if (class_exists('Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\ParamConverter')) {
+            $ignoreParameters = array_map(function ($annotation) {
+                return
+                    $annotation instanceof \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter &&
+                    $annotation->getConverter() === 'fos_rest.request_body'
+                    ? $annotation->getName() : null;
+            }, $this->annotationReader->getMethodAnnotations($method));
+        }
+
         // ignore several type hinted arguments
         $ignoreClasses = [
             \Symfony\Component\HttpFoundation\Request::class,
@@ -498,6 +509,10 @@ class RestActionReader
                         continue 2;
                     }
                 }
+            }
+
+            if (in_array($argument->getName(), $ignoreParameters)) {
+                continue;
             }
 
             $arguments[] = $argument;


### PR DESCRIPTION
When fetching a list of function parameters from a controller action
for use as URL parameters, check for the @ParamConverter
annotation. If a parameter has the annotation with the
"fos_rest.request_body" converter, then ignore it and do not include
it in the list of parameters (thus removing it from the URL).

This allows automatic route generation and ParamConverter to co-exist,
as otherwise a parameter that is expected to be derived from the body
would also be included as a URL parameter, requiring the developer to
manually specify the route.

Fixes #1198