### PR TITLE
Added translation domain to FormErrorNormalizer and FormErrorHandler

### DIFF
--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -17,6 +17,7 @@
         <!-- Normalizes FormInterface when using the symfony serializer -->
         <service id="fos_rest.serializer.form_error_normalizer" class="FOS\RestBundle\Serializer\Normalizer\FormErrorNormalizer" public="false">
             <argument type="service" id="translator" />
+            <argument>%validator.translation_domain%</argument>
             <tag name="serializer.normalizer" priority="-10" />
         </service>
     </services>

--- a/Serializer/Normalizer/FormErrorHandler.php
+++ b/Serializer/Normalizer/FormErrorHandler.php
@@ -26,10 +26,10 @@ class FormErrorHandler extends JMSFormErrorHandler
 {
     private $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator, $translationDomain = 'validators')
     {
         $this->translator = $translator;
-        parent::__construct($translator);
+        parent::__construct($translator, $translationDomain);
     }
 
     public function serializeFormToXml(XmlSerializationVisitor $visitor, Form $form, array $type, Context $context = null)

--- a/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/Serializer/Normalizer/FormErrorNormalizer.php
@@ -25,9 +25,12 @@ class FormErrorNormalizer implements NormalizerInterface
 {
     private $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    private $translationDomain;
+
+    public function __construct(TranslatorInterface $translator, $translationDomain = 'validators')
     {
         $this->translator = $translator;
+        $this->translationDomain = $translationDomain;
     }
 
     /**
@@ -82,9 +85,9 @@ class FormErrorNormalizer implements NormalizerInterface
     private function getErrorMessage(FormError $error)
     {
         if (null !== $error->getMessagePluralization()) {
-            return $this->translator->transChoice($error->getMessageTemplate(), $error->getMessagePluralization(), $error->getMessageParameters(), 'validators');
+            return $this->translator->transChoice($error->getMessageTemplate(), $error->getMessagePluralization(), $error->getMessageParameters(), $this->translationDomain);
         }
 
-        return $this->translator->trans($error->getMessageTemplate(), $error->getMessageParameters(), 'validators');
+        return $this->translator->trans($error->getMessageTemplate(), $error->getMessageParameters(), $this->translationDomain);
     }
 }

--- a/Tests/Serializer/Normalizer/FormErrorNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/FormErrorNormalizerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Serializer\Normalizer;
+
+use FOS\RestBundle\Serializer\Normalizer\FormErrorNormalizer;
+use Symfony\Component\Translation\Translator;
+
+class FormErrorNormalizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultTranslationDomain()
+    {
+        /** @var Translator|\PHPUnit_Framework_MockObject_MockObject $translator */
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+
+        $normalizer = new FormErrorNormalizer($translator);
+
+        $translator->expects($this->once())
+            ->method('trans')
+            ->with(
+                $this->equalTo('error!'),
+                $this->equalTo([]),
+                $this->equalTo('validators')
+            );
+
+        $formError = $this->getMockBuilder('Symfony\Component\Form\FormError')->disableOriginalConstructor()->getMock();
+        $formError->expects($this->once())->method('getMessageTemplate')->willReturn('error!');
+        $formError->expects($this->once())->method('getMessagePluralization')->willReturn(null);
+        $formError->expects($this->once())->method('getMessageParameters')->willReturn([]);
+
+        $this->invokeMethod($normalizer, 'getErrorMessage', [$formError]);
+    }
+
+    public function testDefaultTranslationDomainWithPluralTranslation()
+    {
+        /** @var Translator|\PHPUnit_Framework_MockObject_MockObject $translator */
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+
+        $normalizer = new FormErrorNormalizer($translator);
+
+        $translator->expects($this->once())
+            ->method('transChoice')
+            ->with(
+                $this->equalTo('error!'),
+                $this->equalTo(0),
+                $this->equalTo([]),
+                $this->equalTo('validators')
+            );
+
+        $formError = $this->getMockBuilder('Symfony\Component\Form\FormError')->disableOriginalConstructor()->getMock();
+        $formError->expects($this->once())->method('getMessageTemplate')->willReturn('error!');
+        $formError->expects($this->exactly(2))->method('getMessagePluralization')->willReturn(0);
+        $formError->expects($this->once())->method('getMessageParameters')->willReturn([]);
+
+        $this->invokeMethod($normalizer, 'getErrorMessage', [$formError]);
+    }
+
+    public function testCustomTranslationDomain()
+    {
+        /** @var Translator|\PHPUnit_Framework_MockObject_MockObject $translator */
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+
+        $normalizer = new FormErrorNormalizer($translator, 'custom_domain');
+
+        $translator->expects($this->once())
+            ->method('trans')
+            ->with(
+                $this->equalTo('error!'),
+                $this->equalTo([]),
+                $this->equalTo('custom_domain')
+            );
+
+        $formError = $this->getMockBuilder('Symfony\Component\Form\FormError')->disableOriginalConstructor()->getMock();
+        $formError->expects($this->once())->method('getMessageTemplate')->willReturn('error!');
+        $formError->expects($this->once())->method('getMessagePluralization')->willReturn(null);
+        $formError->expects($this->once())->method('getMessageParameters')->willReturn([]);
+
+        $this->invokeMethod($normalizer, 'getErrorMessage', [$formError]);
+    }
+
+    public function testCustomTranslationDomainWithPluralTranslation()
+    {
+        /** @var Translator|\PHPUnit_Framework_MockObject_MockObject $translator */
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+
+        $normalizer = new FormErrorNormalizer($translator, 'custom_domain');
+
+        $translator->expects($this->once())
+            ->method('transChoice')
+            ->with(
+                $this->equalTo('error!'),
+                $this->equalTo(0),
+                $this->equalTo([]),
+                $this->equalTo('custom_domain')
+            );
+
+        $formError = $this->getMockBuilder('Symfony\Component\Form\FormError')->disableOriginalConstructor()->getMock();
+        $formError->expects($this->once())->method('getMessageTemplate')->willReturn('error!');
+        $formError->expects($this->exactly(2))->method('getMessagePluralization')->willReturn(0);
+        $formError->expects($this->once())->method('getMessageParameters')->willReturn([]);
+
+        $this->invokeMethod($normalizer, 'getErrorMessage', [$formError]);
+    }
+
+    private function invokeMethod($object, $method, array $args = [])
+    {
+        $reflectionMethod = new \ReflectionMethod($object, $method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invokeArgs($object, $args);
+    }
+}


### PR DESCRIPTION
Added a translation domain parameter (validator.translation_domain) to the FormErrorNormalizer to be able to use actual translation domain from config.yml instead of 'validators' one. Also, I've added translation domain parameter to FormErrorHandler in order to be compatible with a new constructor signature of JMS Serializer's FormErrorHandler. Please take a look.

```
framework:
    validation:      { translation_domain: messages }
```

```
parameters:
    validator.translation_domain: messages
```