### PR TITLE
Support dot notation for resources in symfony flex

### DIFF
--- a/Routing/Loader/DirectoryRouteLoader.php
+++ b/Routing/Loader/DirectoryRouteLoader.php
@@ -37,7 +37,7 @@ class DirectoryRouteLoader extends Loader
      */
     public function load($resource, $type = null)
     {
-        if (isset($resource[0]) && '@' === $resource[0]) {
+        if (isset($resource[0]) && in_array($resource[0], ['@', '.'], true)) {
             $resource = $this->fileLocator->locate($resource);
         }
 
@@ -68,7 +68,7 @@ class DirectoryRouteLoader extends Loader
             return false;
         }
 
-        if (isset($resource[0]) && '@' === $resource[0]) {
+        if (isset($resource[0]) && in_array($resource[0], ['@', '.'], true)) {
             $resource = $this->fileLocator->locate($resource);
         }
 


### PR DESCRIPTION
Symfony Flex introduced a new notation for routes resources:

```
controllers:
    resource: "../src/Controller"
```

The current implementation of `DirecotryRouteLoader` supports only @ notation to locate a resource by file locator. That PR fix it for Symfony Flex notation.