### PR TITLE
shrink the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-
 sudo: false
 
 cache:
@@ -22,18 +17,13 @@ matrix:
   include:
     - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 5.6
     - php: 7.0
       env: SYMFONY_VERSION='2.8.*'
-    - php: 7.0
-      env: SYMFONY_VERSION='3.1.*'
-    - php: 7.0
-      env: SYMFONY_VERSION='3.2.*'
     - php: 7.0
       env: SYMFONY_VERSION='3.4.*'
     - php: 7.1
       env: SYMFONY_VERSION='4.0.*'
-    - php: hhvm
-      dist: trusty
 
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi


### PR DESCRIPTION
* drop builds for no longer maintained Symfony versions
* do not run tests on HHVM anymore
* remove generic PHP 5.5 and 7.0 jobs (they are already covered by
  other explicit matrix entries)