### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/Context/ContextTest.php
+++ b/Tests/Context/ContextTest.php
@@ -13,11 +13,12 @@ namespace FOS\RestBundle\Tests\Context;
 
 use FOS\RestBundle\Context\Context;
 use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Ener-Getick <egetick@gmail.com>
  */
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends TestCase
 {
     protected $context;
 

--- a/Tests/Controller/Annotations/AbstractParamTest.php
+++ b/Tests/Controller/Annotations/AbstractParamTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\Controller\Annotations;
 
 use FOS\RestBundle\Controller\Annotations;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\Validator\Constraints;
  *
  * @author Ener-Getick <egetick@gmail.com>
  */
-class AbstractParamTest extends \PHPUnit_Framework_TestCase
+class AbstractParamTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Controller/Annotations/AbstractScalarParamTest.php
+++ b/Tests/Controller/Annotations/AbstractScalarParamTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\Controller\Annotations;
 
 use FOS\RestBundle\Validator\Constraints\Regex;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\Validator\Constraints;
  *
  * @author Ener-Getick <egetick@gmail.com>
  */
-class AbstractScalarParamTest extends \PHPUnit_Framework_TestCase
+class AbstractScalarParamTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Controller/Annotations/FileParamTest.php
+++ b/Tests/Controller/Annotations/FileParamTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\Tests\Controller\Annotations;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\Validator\Constraints;
  *
  * @author Ener-Getick <egetick@gmail.com>
  */
-class FileParamTest extends \PHPUnit_Framework_TestCase
+class FileParamTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Controller/Annotations/QueryParamTest.php
+++ b/Tests/Controller/Annotations/QueryParamTest.php
@@ -11,13 +11,15 @@
 
 namespace FOS\RestBundle\Tests\Controller\Annotations;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * QueryParamTest.
  *
  * @author Eduardo Oliveira <entering@gmail.com>
  * @author Ener-Getick <egetick@gmail.com>
  */
-class QueryParamTest extends \PHPUnit_Framework_TestCase
+class QueryParamTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Controller/Annotations/RequestParamTest.php
+++ b/Tests/Controller/Annotations/RequestParamTest.php
@@ -11,13 +11,15 @@
 
 namespace FOS\RestBundle\Tests\Controller\Annotations;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * RequestParamTest.
  *
  * @author Eduardo Oliveira <entering@gmail.com>
  * @author Ener-Getick <egetick@gmail.com>
  */
-class RequestParamTest extends \PHPUnit_Framework_TestCase
+class RequestParamTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Decoder/JsonToFormDecoderTest.php
+++ b/Tests/Decoder/JsonToFormDecoderTest.php
@@ -12,13 +12,14 @@
 namespace FOS\RestBundle\Tests\Decoder;
 
 use FOS\RestBundle\Decoder\JsonToFormDecoder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the form-like encoder.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class JsonToFormDecoderTest extends \PHPUnit_Framework_TestCase
+class JsonToFormDecoderTest extends TestCase
 {
     public function testDecodeWithRemovingFalseData()
     {

--- a/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\DependencyInjection\Compiler;
 
 use FOS\RestBundle\DependencyInjection\Compiler\ConfigurationCheckPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @author Eriksen Costa <eriksencosta@gmail.com>
  */
-class ConfigurationCheckPassTest extends \PHPUnit_Framework_TestCase
+class ConfigurationCheckPassTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FormatListenerRulesPassTest.php
@@ -12,12 +12,13 @@
 namespace FOS\RestBundle\Tests\DependencyInjection\Compiler;
 
 use FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Eduardo Gulias Davis <me@egulias.com>
  */
-class FormatListenerRulesPassTest extends \PHPUnit_Framework_TestCase
+class FormatListenerRulesPassTest extends TestCase
 {
     public function testRulesAreAddedWhenFormatListenerAndProfilerToolbarAreEnabled()
     {

--- a/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/SerializerConfigurationPassTest.php
@@ -12,12 +12,13 @@
 namespace FOS\RestBundle\Tests\DependencyInjection\Compiler;
 
 use FOS\RestBundle\DependencyInjection\Compiler\SerializerConfigurationPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * SerializerConfigurationPassTest test.
  */
-class SerializerConfigurationPassTest extends \PHPUnit_Framework_TestCase
+class SerializerConfigurationPassTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\DependencyInjection;
 
 use FOS\RestBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -22,7 +23,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  *
  * @author Evgenij Efimov <edefimov.it@gmail.com>
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * Test object.

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\DependencyInjection;
 
 use FOS\RestBundle\DependencyInjection\FOSRestExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -24,7 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
  * @author Bulat Shakirzyanov <avalanche123>
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class FOSRestExtensionTest extends \PHPUnit_Framework_TestCase
+class FOSRestExtensionTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/EventListener/AccessDeniedListenerTest.php
+++ b/Tests/EventListener/AccessDeniedListenerTest.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\EventListener;
 
 use FOS\RestBundle\EventListener\AccessDeniedListener;
 use FOS\RestBundle\FOSRestBundle;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -25,7 +26,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  *
  * @author Boris Guéry <guery.b@gmail.com>
  */
-class AccessDeniedListenerTest extends \PHPUnit_Framework_TestCase
+class AccessDeniedListenerTest extends TestCase
 {
     /**
      * @dataProvider getFormatsDataProvider

--- a/Tests/EventListener/BodyListenerTest.php
+++ b/Tests/EventListener/BodyListenerTest.php
@@ -15,6 +15,7 @@ use FOS\RestBundle\Decoder\ContainerDecoderProvider;
 use FOS\RestBundle\EventListener\BodyListener;
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Normalizer\Exception\NormalizationException;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  * @author Alain Horner <alain.horner@liip.ch>
  * @author Stefan Paschke <stefan.paschke@liip.ch>
  */
-class BodyListenerTest extends \PHPUnit_Framework_TestCase
+class BodyListenerTest extends TestCase
 {
     /**
      * @param bool    $decode                                 use decoder provider

--- a/Tests/EventListener/FormatListenerTest.php
+++ b/Tests/EventListener/FormatListenerTest.php
@@ -15,6 +15,7 @@ use FOS\RestBundle\EventListener\FormatListener;
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Negotiation\FormatNegotiator;
 use Negotiation\Accept;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class FormatListenerTest extends \PHPUnit_Framework_TestCase
+class FormatListenerTest extends TestCase
 {
     public function testOnKernelControllerNegotiation()
     {

--- a/Tests/EventListener/MimeTypeListenerTest.php
+++ b/Tests/EventListener/MimeTypeListenerTest.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\EventListener;
 
 use FOS\RestBundle\EventListener\MimeTypeListener;
 use FOS\RestBundle\FOSRestBundle;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -21,7 +22,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class MimeTypeListenerTest extends \PHPUnit_Framework_TestCase
+class MimeTypeListenerTest extends TestCase
 {
     public function testOnKernelRequest()
     {

--- a/Tests/EventListener/ParamFetcherListenerTest.php
+++ b/Tests/EventListener/ParamFetcherListenerTest.php
@@ -14,12 +14,13 @@ namespace FOS\RestBundle\Tests\EventListener;
 use FOS\RestBundle\EventListener\ParamFetcherListener;
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Tests\Fixtures\Controller\ParamFetcherController;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Param Fetcher Listener Tests.
  */
-class ParamFetcherListenerTest extends \PHPUnit_Framework_TestCase
+class ParamFetcherListenerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/Tests/EventListener/VersionListenerTest.php
+++ b/Tests/EventListener/VersionListenerTest.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\EventListener;
 
 use FOS\RestBundle\EventListener\VersionListener;
 use FOS\RestBundle\FOSRestBundle;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ener-Getick <egetick@gmail.com>
  */
-class VersionListenerTest extends \PHPUnit_Framework_TestCase
+class VersionListenerTest extends TestCase
 {
     /**
      * @var \FOS\RestBundle\View\ConfigurableViewHandlerInterface

--- a/Tests/EventListener/ViewResponseListenerTest.php
+++ b/Tests/EventListener/ViewResponseListenerTest.php
@@ -16,6 +16,7 @@ use FOS\RestBundle\EventListener\ViewResponseListener;
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class ViewResponseListenerTest extends \PHPUnit_Framework_TestCase
+class ViewResponseListenerTest extends TestCase
 {
     /**
      * @var \FOS\RestBundle\EventListener\ViewResponseListener

--- a/Tests/EventListener/ZoneMatcherListenerTest.php
+++ b/Tests/EventListener/ZoneMatcherListenerTest.php
@@ -13,9 +13,10 @@ namespace FOS\RestBundle\Tests\EventListener;
 
 use FOS\RestBundle\EventListener\ZoneMatcherListener;
 use FOS\RestBundle\FOSRestBundle;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-class ZoneMatcherListenerTest extends \PHPUnit_Framework_TestCase
+class ZoneMatcherListenerTest extends TestCase
 {
     public function testNoRequestMatcher()
     {

--- a/Tests/Negotiation/FormatNegotiatorTest.php
+++ b/Tests/Negotiation/FormatNegotiatorTest.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\Negotiatior;
 
 use FOS\RestBundle\Negotiation\FormatNegotiator;
 use Negotiation\Accept;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -21,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ener-Getick <egetick@gmail.com>
  */
-class FormatNegotiatorTest extends \PHPUnit_Framework_TestCase
+class FormatNegotiatorTest extends TestCase
 {
     private $requestStack;
     private $request;

--- a/Tests/Normalizer/CamelKeysNormalizerTest.php
+++ b/Tests/Normalizer/CamelKeysNormalizerTest.php
@@ -13,8 +13,9 @@ namespace FOS\RestBundle\Tests\Normalizer;
 
 use FOS\RestBundle\Normalizer\CamelKeysNormalizer;
 use FOS\RestBundle\Normalizer\CamelKeysNormalizerWithLeadingUnderscore;
+use PHPUnit\Framework\TestCase;
 
-class CamelKeysNormalizerTest extends \PHPUnit_Framework_TestCase
+class CamelKeysNormalizerTest extends TestCase
 {
     /**
      * @expectedException \FOS\RestBundle\Normalizer\Exception\NormalizationException

--- a/Tests/Request/ParamFetcherTest.php
+++ b/Tests/Request/ParamFetcherTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Util\ClassUtils;
 use FOS\RestBundle\Exception\InvalidParameterException;
 use FOS\RestBundle\Request\ParamFetcher;
 use FOS\RestBundle\Request\ParamReaderInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -28,7 +29,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @author Alexander <iam.asm89@gmail.com>
  * @author Boris Guéry <guery.b@gmail.com>
  */
-class ParamFetcherTest extends \PHPUnit_Framework_TestCase
+class ParamFetcherTest extends TestCase
 {
     /**
      * @var callable

--- a/Tests/Request/ParamReaderTest.php
+++ b/Tests/Request/ParamReaderTest.php
@@ -15,6 +15,7 @@ use FOS\RestBundle\Controller\Annotations\ParamInterface;
 use FOS\RestBundle\Controller\Annotations\NamePrefix;
 use FOS\RestBundle\Request\ParamReader;
 use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotNull;
 
 /**
@@ -22,7 +23,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class ParamReaderTest extends \PHPUnit_Framework_TestCase
+class ParamReaderTest extends TestCase
 {
     private $paramReader;
 

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -13,13 +13,14 @@ namespace FOS\RestBundle\Tests\Request;
 
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Request\RequestBodyParamConverter;
+use PHPUnit\Framework\TestCase;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Tyler Stroud <tyler@tylerstroud.com>
  */
-class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
+class RequestBodyParamConverterTest extends TestCase
 {
     protected $serializer;
     protected $converterBuilder;

--- a/Tests/Routing/Loader/LoaderTest.php
+++ b/Tests/Routing/Loader/LoaderTest.php
@@ -17,6 +17,7 @@ use FOS\RestBundle\Request\ParamReader;
 use FOS\RestBundle\Routing\Loader\Reader\RestActionReader;
 use FOS\RestBundle\Routing\Loader\Reader\RestControllerReader;
 use FOS\RestBundle\Routing\Loader\RestRouteLoader;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
 
@@ -25,7 +26,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-abstract class LoaderTest extends \PHPUnit_Framework_TestCase
+abstract class LoaderTest extends TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/Serializer/JMSSerializerAdapterTest.php
+++ b/Tests/Serializer/JMSSerializerAdapterTest.php
@@ -20,8 +20,9 @@ use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use PhpCollection\MapInterface;
+use PHPUnit\Framework\TestCase;
 
-class JMSSerializerAdapterTest extends \PHPUnit_Framework_TestCase
+class JMSSerializerAdapterTest extends TestCase
 {
     private $serializer;
     private $serializationContextFactory;

--- a/Tests/Util/ExceptionValueMapTest.php
+++ b/Tests/Util/ExceptionValueMapTest.php
@@ -12,13 +12,14 @@
 namespace FOS\RestBundle\Tests;
 
 use FOS\RestBundle\Util\ExceptionValueMap;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ExceptionValueMap test.
  *
  * @author Mikhail Shamin <munk13@gmail.com>
  */
-class ExceptionValueMapTest extends \PHPUnit_Framework_TestCase
+class ExceptionValueMapTest extends TestCase
 {
     /**
      * @var ExceptionValueMap

--- a/Tests/View/JsonpHandlerTest.php
+++ b/Tests/View/JsonpHandlerTest.php
@@ -14,6 +14,7 @@ namespace FOS\RestBundle\Tests\View;
 use FOS\RestBundle\View\JsonpHandler;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -23,7 +24,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * @author Victor Berchet <victor@suumit.com>
  * @author Lukas K. Smith <smith@pooteeweet.org>
  */
-class JsonpHandlerTest extends \PHPUnit_Framework_TestCase
+class JsonpHandlerTest extends TestCase
 {
     private $router;
     private $serializer;

--- a/Tests/View/ViewHandlerTest.php
+++ b/Tests/View/ViewHandlerTest.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\View;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandler;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\FormView;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Victor Berchet <victor@suumit.com>
  */
-class ViewHandlerTest extends \PHPUnit_Framework_TestCase
+class ViewHandlerTest extends TestCase
 {
     private $router;
     private $serializer;

--- a/Tests/View/ViewTest.php
+++ b/Tests/View/ViewTest.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\Tests\View;
 
 use FOS\RestBundle\View\View;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Victor Berchet <victor@suumit.com>
  */
-class ViewTest extends \PHPUnit_Framework_TestCase
+class ViewTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).