### PR TITLE
make the exception controller service public

### DIFF
--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -12,7 +12,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="fos_rest.exception.controller" class="FOS\RestBundle\Controller\ExceptionController">
+        <service id="fos_rest.exception.controller" class="FOS\RestBundle\Controller\ExceptionController" public="true">
             <argument type="service" id="fos_rest.view_handler" />
             <argument type="service" id="fos_rest.exception.codes_map" />  <!-- exception codes -->
             <argument /><!-- show exception -->


### PR DESCRIPTION
With Symfony 4.0+, services will be private by default if not configured
differently. A controller that is registered as a service must be public
to allow the resolver to properly retrieve the controller from the
service container.