### PR TITLE
do not silence error logs

### DIFF
--- a/Tests/Functional/app/config/default.yml
+++ b/Tests/Functional/app/config/default.yml
@@ -1,6 +1,2 @@
 imports:
     - { resource: framework.yml }
-
-services:
-    logger:
-        class: Psr\Log\NullLogger

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="./vendor/autoload.php" colors="true">
+    <php>
+        <env name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
     <testsuites>
         <testsuite name="FOSRestBundle test suite">
             <directory suffix="Test.php">./Tests</directory>


### PR DESCRIPTION
The change done in #1797 had the disadvantage that it silenced all
log entries. Using the `SHELL_VERBOSITY` env var allows to define a
level for which log entries should still be shown.