### PR TITLE
tests for definitions before they might be removed

### DIFF
--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -39,6 +39,6 @@ class FOSRestBundle extends Bundle
         $container->addCompilerPass(new FormatListenerRulesPass());
         $container->addCompilerPass(new TwigExceptionPass());
         $container->addCompilerPass(new JMSFormErrorHandlerPass());
-        $container->addCompilerPass(new JMSHandlersPass(), PassConfig::TYPE_REMOVE);
+        $container->addCompilerPass(new JMSHandlersPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
     }
 }

--- a/Tests/Functional/DependencyInjectionTest.php
+++ b/Tests/Functional/DependencyInjectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Functional;
+
+use FOS\RestBundle\FOSRestBundle;
+use FOS\RestBundle\Serializer\JMSHandlerRegistry;
+use FOS\RestBundle\Serializer\Normalizer\FormErrorHandler;
+use JMS\SerializerBundle\JMSSerializerBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class DependencyInjectionTest extends KernelTestCase
+{
+    public function testSerializerRelatedServicesAreNotRemovedWhenJmsSerializerBundleIsEnabled()
+    {
+        self::bootKernel();
+        $container = self::$kernel->getContainer();
+
+        $this->assertSame(FormErrorHandler::class, $container->getParameter('jms_serializer.form_error_handler.class'));
+        $this->assertInstanceOf(JMSHandlerRegistry::class, $container->get('test.jms_serializer.handler_registry'));
+    }
+
+    protected static function getKernelClass()
+    {
+        return TestKernel::class;
+    }
+}
+
+class TestKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new FOSRestBundle(),
+            new JMSSerializerBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'secret' => 'test',
+                'router' => array(
+                    'resource' => '%kernel.root_dir%/config/routing.yml',
+                ),
+            ]);
+            $container->loadFromExtension('fos_rest', [
+                'exception' => null,
+            ]);
+            $container->setAlias('test.jms_serializer.handler_registry', new Alias('jms_serializer.handler_registry', true));
+        });
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/'.str_replace('\\', '-', get_class($this)).'/cache/'.$this->environment;
+    }
+}


### PR DESCRIPTION
If the `JMSHandlersPass` is registered as a `TYPE_REMOVE` pass, the
definitions it depends on may already be removed before by the built-in
`RemoveUnusedDefinitionsPass`. That compiler pass removes private
services that are not referenced. This becomes critical, for example,
when running a Symfony 4 based application where services will be
private by default.

This is the first PR of a series of changes we need to do to fully solve
#1790.