### PR TITLE
Refactoring tests

### DIFF
--- a/Tests/Context/ContextTest.php
+++ b/Tests/Context/ContextTest.php
@@ -30,7 +30,7 @@ class ContextTest extends TestCase
     public function testDefaultValues()
     {
         $this->assertEquals([], $this->context->getAttributes());
-        $this->assertEquals(null, $this->context->getGroups());
+        $this->assertNull($this->context->getGroups());
     }
 
     public function testAttributes()
@@ -98,7 +98,7 @@ class ContextTest extends TestCase
     {
         $this->context->setSerializeNull(true);
 
-        $this->assertEquals(true, $this->context->getSerializeNull());
+        $this->assertTrue($this->context->getSerializeNull());
     }
 
     public function testExclusionStrategy()

--- a/Tests/Controller/Annotations/AbstractParamTest.php
+++ b/Tests/Controller/Annotations/AbstractParamTest.php
@@ -34,12 +34,12 @@ class AbstractParamTest extends TestCase
 
     public function testDefaultValues()
     {
-        $this->assertEquals(null, $this->param->name);
-        $this->assertEquals(null, $this->param->key);
-        $this->assertEquals(null, $this->param->default);
-        $this->assertEquals(null, $this->param->description);
-        $this->assertEquals(false, $this->param->strict);
-        $this->assertEquals(false, $this->param->nullable);
+        $this->assertNull($this->param->name);
+        $this->assertNull($this->param->key);
+        $this->assertNull($this->param->default);
+        $this->assertNull($this->param->description);
+        $this->assertFalse($this->param->strict);
+        $this->assertFalse($this->param->nullable);
         $this->assertEquals(array(), $this->param->incompatibles);
     }
 

--- a/Tests/Controller/Annotations/AbstractScalarParamTest.php
+++ b/Tests/Controller/Annotations/AbstractScalarParamTest.php
@@ -34,7 +34,7 @@ class AbstractScalarParamTest extends TestCase
 
     public function testDefaultValues()
     {
-        $this->assertEquals(null, $this->param->requirements);
+        $this->assertNull($this->param->requirements);
         $this->assertFalse($this->param->map);
         $this->assertTrue($this->param->allowBlank);
     }

--- a/Tests/Decoder/JsonToFormDecoderTest.php
+++ b/Tests/Decoder/JsonToFormDecoderTest.php
@@ -37,8 +37,8 @@ class JsonToFormDecoderTest extends TestCase
         $decoder = new JsonToFormDecoder();
         $decoded = $decoder->decode(json_encode($data));
 
-        $this->assertTrue(is_array($decoded));
-        $this->assertTrue(is_array($decoded['arrayKey']));
+        $this->assertInternalType('array', $decoded);
+        $this->assertInternalType('array', $decoded['arrayKey']);
         $this->assertNull($decoded['arrayKey']['falseKey']);
         $this->assertEquals('foo', $decoded['arrayKey']['stringKey']);
         $this->assertNull($decoded['falseKey']);

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -82,7 +82,7 @@ class ConfigurationTest extends TestCase
 
         $config = $this->processor->processConfiguration($this->configuration, [$config]);
 
-        self::assertTrue(isset($config['exception']['codes']));
+        self::assertArrayHasKey('codes', $config['exception']);
         self::assertSame($expectedResult, $config['exception']['codes'], 'Response constants were not converted');
     }
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -129,7 +129,7 @@ class FOSRestExtensionTest extends TestCase
         $this->assertCount(4, $bodyListener->getArguments());
         $this->assertInstanceOf(Reference::class, $normalizerArgument);
         $this->assertEquals('fos_rest.normalizer.camel_keys', (string) $normalizerArgument);
-        $this->assertEquals(false, $normalizeForms);
+        $this->assertFalse($normalizeForms);
     }
 
     public function testLoadBodyListenerWithNormalizerArrayAndForms()
@@ -151,7 +151,7 @@ class FOSRestExtensionTest extends TestCase
         $this->assertCount(4, $bodyListener->getArguments());
         $this->assertInstanceOf(Reference::class, $normalizerArgument);
         $this->assertEquals('fos_rest.normalizer.camel_keys', (string) $normalizerArgument);
-        $this->assertEquals(true, $normalizeForms);
+        $this->assertTrue($normalizeForms);
     }
 
     public function testDisableFormatListener()
@@ -588,7 +588,7 @@ class FOSRestExtensionTest extends TestCase
     {
         $arguments = $loader->getArguments();
 
-        $this->assertEquals(5, count($arguments));
+        $this->assertCount(5, $arguments);
         $this->assertEquals('service_container', (string) $arguments[0]);
         $this->assertEquals('file_locator', (string) $arguments[1]);
         $this->assertEquals('controller_name_converter', (string) $arguments[2]);
@@ -615,7 +615,7 @@ class FOSRestExtensionTest extends TestCase
         $processorRef = new Reference('fos_rest.routing.loader.processor');
         $arguments = $loader->getArguments();
 
-        $this->assertEquals(5, count($arguments));
+        $this->assertCount(5, $arguments);
         $this->assertEquals($locatorRef, $arguments[0]);
         $this->assertEquals($processorRef, $arguments[1]);
         $this->assertSame($includeFormat, $arguments[2]);

--- a/Tests/EventListener/ViewResponseListenerTest.php
+++ b/Tests/EventListener/ViewResponseListenerTest.php
@@ -142,7 +142,7 @@ class ViewResponseListenerTest extends TestCase
         $event->expects($this->never())
             ->method('setResponse');
 
-        $this->assertEquals(null, $this->listener->onKernelView($event));
+        $this->assertNull($this->listener->onKernelView($event));
     }
 
     public static function statusCodeProvider()

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -167,7 +167,7 @@ class RequestBodyParamConverterTest extends TestCase
         $request = $this->createRequest();
         $configuration = $this->createConfiguration(null, null, ['validate' => false]);
         $this->launchExecution($converter, $request, $configuration);
-        $this->assertEquals(null, $request->attributes->get('errors'));
+        $this->assertNull($request->attributes->get('errors'));
     }
 
     public function testReturn()

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -28,8 +28,8 @@ class RestRouteLoaderTest extends LoaderTest
         $collection = $this->loadFromControllerFixture('UsersController');
         $etalonRoutes = $this->loadEtalonRoutesInfo('users_controller.yml');
 
-        $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(32, count($collection->all()));
+        $this->assertInstanceOf(RestRouteCollection::class, $collection);
+        $this->assertCount(32, $collection->all());
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);
@@ -50,8 +50,8 @@ class RestRouteLoaderTest extends LoaderTest
         $collection = $this->loadFromControllerFixture('ArticleController');
         $etalonRoutes = $this->loadEtalonRoutesInfo('resource_controller.yml');
 
-        $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(24, count($collection->all()));
+        $this->assertInstanceOf(RestRouteCollection::class, $collection);
+        $this->assertCount(24, $collection->all());
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);
@@ -94,8 +94,8 @@ class RestRouteLoaderTest extends LoaderTest
         $collection = $this->loadFromControllerFixture('AnnotatedUsersController');
         $etalonRoutes = $this->loadEtalonRoutesInfo('annotated_users_controller.yml');
 
-        $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(33, count($collection->all()));
+        $this->assertInstanceOf(RestRouteCollection::class, $collection);
+        $this->assertCount(33, $collection->all());
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);
@@ -142,8 +142,8 @@ class RestRouteLoaderTest extends LoaderTest
         $collection = $this->loadFromControllerFixture('AnnotatedConditionalUsersController');
         $etalonRoutes = $this->loadEtalonRoutesInfo('annotated_conditional_controller.yml');
 
-        $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(22, count($collection->all()));
+        $this->assertInstanceOf(RestRouteCollection::class, $collection);
+        $this->assertCount(22, $collection->all());
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);
@@ -171,8 +171,8 @@ class RestRouteLoaderTest extends LoaderTest
         $collection = $this->loadFromControllerFixture('AnnotatedVersionUserController');
         $etalonRoutes = $this->loadEtalonRoutesInfo('annotated_version_controller.yml');
 
-        $this->assertTrue($collection instanceof RestRouteCollection);
-        $this->assertEquals(3, count($collection->all()));
+        $this->assertInstanceOf(RestRouteCollection::class, $collection);
+        $this->assertCount(3, $collection->all());
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);

--- a/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
@@ -138,7 +138,7 @@ class RestXmlCollectionLoaderTest extends LoaderTest
         $collection = $this->loadFromXmlCollectionFixture('routes_with_options_requirements_and_defaults.xml');
 
         foreach ($collection as $route) {
-            $this->assertTrue('true' === $route->getOption('expose'));
+            $this->assertSame('true', $route->getOption('expose'));
             $this->assertEquals('[a-z]+', $route->getRequirement('slug'));
             $this->assertEquals('home', $route->getDefault('slug'));
         }

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -135,7 +135,7 @@ class RestYamlCollectionLoaderTest extends LoaderTest
         foreach ($collection as $route) {
             $names[] = $route->getPath();
         }
-        $this->assertEquals(count($names), count(array_unique($names)));
+        $this->assertCount(count($names), array_unique($names));
     }
 
     public function testForwardOptionsRequirementsAndDefaults()


### PR DESCRIPTION
I've refactored some tests using:
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertArrayHasKey` instead of `isset` function;
- `assertNull` instead of comparison with `null` keyword;
- `assertFalse` instead of comparison with `false` keyword;
- `assertTrue` instead of comparison with `true` keyword;
- `assertInternalType` instead of `is_*` functions;
- `assertSame` instead of strict comparisons.