### PR TITLE
Fixed use statement for symfony 4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+* [BC BREAK] The `@Route` annotation and all its children no longer extend SensioFrameworkExtraBundle's annotation.
+  The main effect is that `@Route::$service` is no longer available.
+
 2.3.1
 -----
 

--- a/Controller/Annotations/Route.php
+++ b/Controller/Annotations/Route.php
@@ -11,7 +11,7 @@
 
 namespace FOS\RestBundle\Controller\Annotations;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route as BaseRoute;
+use Symfony\Component\Routing\Annotation\Route as BaseRoute;
 
 /**
  * Route annotation class.

--- a/Resources/doc/annotations-reference.rst
+++ b/Resources/doc/annotations-reference.rst
@@ -128,5 +128,5 @@ Example syntax:
     * @Route("", condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'")
     */
 
-.. _`@Route Symfony annotation`: http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/routing.html
+.. _`@Route Symfony annotation`: https://symfony.com/doc/current/routing.html
 .. _`Routing Conditions`: http://symfony.com/doc/current/book/routing.html#book-routing-conditions


### PR DESCRIPTION
The @Route annotations is in a different namespace for symfony 4. I guess this will break compatibility with symfony < 4, so I'm not sure what is the best way to handle this. But currently, this fixes

`In Route.php line 21:
Attempted to load class "Route" from namespace "Sensio\Bundle\FrameworkExtraBundle\Configuration".                                                      
Did you forget a "use" statement for e.g. "Symfony\Component\Routing\Annotation\Route" or "Symfony\Component\Routing\Route"?`

for me.