### PR TITLE
run checks after SensioFrameworkExtraBundle

### DIFF
--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -35,7 +35,7 @@ class FOSRestBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new SerializerConfigurationPass());
-        $container->addCompilerPass(new ConfigurationCheckPass());
+        $container->addCompilerPass(new ConfigurationCheckPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
         $container->addCompilerPass(new FormatListenerRulesPass());
         $container->addCompilerPass(new TwigExceptionPass());
         $container->addCompilerPass(new JMSFormErrorHandlerPass());


### PR DESCRIPTION
This does not solve the root issue of #1812. However, it will throw a meaningful error during container compilation so that users can find out how to work around (by enabling TwigBundle).