### PR TITLE
Fix dependency to sensio/framework-extra-bundle

### DIFF
--- a/Request/ParameterBag.php
+++ b/Request/ParameterBag.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\Request;
 
+use Doctrine\Common\Util\ClassUtils;
 use FOS\RestBundle\Controller\Annotations\ParamInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -77,12 +78,12 @@ final class ParameterBag
             );
         }
 
-        $cls = class_exists('\Doctrine\Common\Util\ClassUtils', true)
-            ? \Doctrine\Common\Util\ClassUtils::getClass($controller[0])
+        $class = class_exists(ClassUtils::class, true)
+            ? ClassUtils::getClass($controller[0])
             : get_class($controller[0]);
 
         return $this->params[$requestId]['params'] = $this->paramReader->read(
-            new \ReflectionClass($cls),
+            new \ReflectionClass($class),
             $controller[1]
         );
     }

--- a/Request/ParameterBag.php
+++ b/Request/ParameterBag.php
@@ -66,6 +66,7 @@ final class ParameterBag
      * @param string $requestId
      *
      * @return ParamInterface[]
+     *
      * @throws \InvalidArgumentException
      * @throws \ReflectionException
      */

--- a/Request/ParameterBag.php
+++ b/Request/ParameterBag.php
@@ -79,7 +79,7 @@ final class ParameterBag
             );
         }
 
-        $class = class_exists(ClassUtils::class, true)
+        $class = class_exists(ClassUtils::class)
             ? ClassUtils::getClass($controller[0])
             : get_class($controller[0]);
 

--- a/Request/ParameterBag.php
+++ b/Request/ParameterBag.php
@@ -11,7 +11,6 @@
 
 namespace FOS\RestBundle\Request;
 
-use Doctrine\Common\Util\ClassUtils;
 use FOS\RestBundle\Controller\Annotations\ParamInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -65,7 +64,9 @@ final class ParameterBag
      *
      * @param string $requestId
      *
+     * @return ParamInterface[]
      * @throws \InvalidArgumentException
+     * @throws \ReflectionException
      */
     private function initParams($requestId)
     {
@@ -76,8 +77,12 @@ final class ParameterBag
             );
         }
 
+        $cls = class_exists('\Doctrine\Common\Util\ClassUtils', true)
+            ? \Doctrine\Common\Util\ClassUtils::getClass($controller[0])
+            : get_class($controller[0]);
+
         return $this->params[$requestId]['params'] = $this->paramReader->read(
-            new \ReflectionClass(ClassUtils::getClass($controller[0])),
+            new \ReflectionClass($cls),
             $controller[1]
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "symfony/templating": "^2.7|^3.0|^4.0",
         "doctrine/inflector": "^1.0",
         "willdurand/negotiation": "^2.0",
-        "willdurand/jsonp-callback-validator": "^1.0"
+        "willdurand/jsonp-callback-validator": "^1.0",
+        "doctrine/common": "^2.2"
     },
     "require-dev": {
         "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,10 @@
         "symfony/templating": "^2.7|^3.0|^4.0",
         "doctrine/inflector": "^1.0",
         "willdurand/negotiation": "^2.0",
-        "willdurand/jsonp-callback-validator": "^1.0"
+        "willdurand/jsonp-callback-validator": "^1.0",
+        "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0"
     },
     "require-dev": {
-        "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0",
         "symfony/phpunit-bridge": "^3.2|^4.0",
         "symfony/asset": "^2.7|^3.0|^4.0",
         "symfony/form": "^2.7|^3.0|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,7 @@
         "symfony/templating": "^2.7|^3.0|^4.0",
         "doctrine/inflector": "^1.0",
         "willdurand/negotiation": "^2.0",
-        "willdurand/jsonp-callback-validator": "^1.0",
-        "doctrine/common": "^2.2"
+        "willdurand/jsonp-callback-validator": "^1.0"
     },
     "require-dev": {
         "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,10 @@
         "symfony/templating": "^2.7|^3.0|^4.0",
         "doctrine/inflector": "^1.0",
         "willdurand/negotiation": "^2.0",
-        "willdurand/jsonp-callback-validator": "^1.0",
-        "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0"
+        "willdurand/jsonp-callback-validator": "^1.0"
     },
     "require-dev": {
+        "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0",
         "symfony/phpunit-bridge": "^3.2|^4.0",
         "symfony/asset": "^2.7|^3.0|^4.0",
         "symfony/form": "^2.7|^3.0|^4.0",


### PR DESCRIPTION
\FOS\RestBundle\Request\ParameterBag has a dependency to
\Doctrine\Common\Util\ClassUtils which originates from doctrine/common
which in turn a dependency of sensio/framework-extra-bundle but this is
declared as a dev-dependency. This causes an fatal error with the
message 'Class 'Doctrine\Common\Util\ClassUtils' not found'.

Fixes#259