### PR TITLE
make the view handler alias public

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -68,7 +69,11 @@ class FOSRestExtension extends Extension
             }
 
             if (null !== $service) {
-                $container->setAlias('fos_rest.'.$key, $service);
+                if ('view_handler' === $key) {
+                    $container->setAlias('fos_rest.'.$key, new Alias($service, true));
+                } else {
+                    $container->setAlias('fos_rest.'.$key, $service);
+                }
             }
         }
 

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Tests\DependencyInjection;
 
 use FOS\RestBundle\DependencyInjection\FOSRestExtension;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -238,6 +239,14 @@ class FOSRestExtensionTest extends TestCase
         $this->extension->load([], $this->container);
 
         $this->assertAlias('fos_rest.view_handler.default', 'fos_rest.view_handler');
+
+        $viewHandlerAlias = $this->container->getAlias('fos_rest.view_handler');
+
+        $this->assertTrue($viewHandlerAlias->isPublic());
+
+        if (method_exists(Alias::class, 'isPrivate')) {
+            $this->assertFalse($viewHandlerAlias->isPrivate());
+        }
     }
 
     public function testDisableViewResponseListener()


### PR DESCRIPTION
The alias will be fetched from the container when using the built-in
FOSRestController class. Thus, we must ensure that it can still be
located when using Symfony 4.0 or higher.