### PR TITLE
Require TwigBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "symfony/routing": "^2.7|^3.0|^4.0",
         "symfony/security-core": "^2.7|^3.0|^4.0",
         "symfony/templating": "^2.7|^3.0|^4.0",
+        "symfony/twig-bundle": "^2.7|^3.0|^4.0",
         "doctrine/inflector": "^1.0",
         "willdurand/negotiation": "^2.0",
         "willdurand/jsonp-callback-validator": "^1.0"
@@ -55,7 +56,6 @@
         "symfony/yaml": "^2.7|^3.0|^4.0",
         "symfony/security-bundle": "^2.7|^3.0|^4.0",
         "symfony/web-profiler-bundle": "^2.7|^3.0|^4.0",
-        "symfony/twig-bundle": "^2.7|^3.0|^4.0",
         "symfony/browser-kit": "^2.7|^3.0|^4.0",
         "symfony/dependency-injection": "^2.7|^3.0|^4.0",
         "symfony/expression-language": "~2.7|^3.0|^4.0",


### PR DESCRIPTION
As per this commen's suggestion https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1812#issuecomment-349930668 Twig Bundle is required to prevent a thrown exception:
```
Warning: ReflectionObject::__construct() expects parameter 1 to be object, null given
```
Doesn't make sense - to me - to install this package as part of `require-dev` but not on `require` due - in the end - we are unable to render the responses without it.

Thoughts?