### PR TITLE
manually decorate the core JMS handler registry

### DIFF
--- a/DependencyInjection/Compiler/HandlerRegistryDecorationPass.php
+++ b/DependencyInjection/Compiler/HandlerRegistryDecorationPass.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\DependencyInjection\Compiler;
+
+use FOS\RestBundle\Serializer\JMSHandlerRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Decorates the handler registry from JMSSerializerBundle.
+ *
+ * The logic is borrowed from the core Symfony DecoratorServicePass, but is implemented here to respect the fact that
+ * custom handlers are registered in JMSSerializerBundle in a compiler pass that is executed after decorated services
+ * have been resolved.
+ *
+ * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
+ */
+class HandlerRegistryDecorationPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('fos_rest.serializer.jms_handler_registry')) {
+            return;
+        }
+
+        $jmsHandlerRegistry = $container->findDefinition('fos_rest.serializer.jms_handler_registry');
+        $public = $jmsHandlerRegistry->isPublic();
+        $jmsHandlerRegistry->setPublic(false);
+        $container->setDefinition('fos_rest.serializer.jms_handler_registry.inner', $jmsHandlerRegistry);
+
+        $fosRestHandlerRegistry = $container->register('jms_serializer.handler_registry', JMSHandlerRegistry::class)
+            ->setPublic($public)
+            ->addArgument(new Reference('fos_rest.serializer.jms_handler_registry.inner'));
+
+        // remap existing aliases (they have already been replaced with the actual definition by Symfony's ReplaceAliasByActualDefinitonPass)
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if ('fos_rest.serializer.jms_handler_registry.inner' !== $id && $definition === $jmsHandlerRegistry) {
+                $container->setDefinition($id, $fosRestHandlerRegistry);
+            }
+        }
+    }
+}

--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle;
 
 use FOS\RestBundle\DependencyInjection\Compiler\ConfigurationCheckPass;
+use FOS\RestBundle\DependencyInjection\Compiler\HandlerRegistryDecorationPass;
 use FOS\RestBundle\DependencyInjection\Compiler\JMSFormErrorHandlerPass;
 use FOS\RestBundle\DependencyInjection\Compiler\JMSHandlersPass;
 use FOS\RestBundle\DependencyInjection\Compiler\FormatListenerRulesPass;
@@ -40,5 +41,6 @@ class FOSRestBundle extends Bundle
         $container->addCompilerPass(new TwigExceptionPass());
         $container->addCompilerPass(new JMSFormErrorHandlerPass());
         $container->addCompilerPass(new JMSHandlersPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
+        $container->addCompilerPass(new HandlerRegistryDecorationPass(), PassConfig::TYPE_AFTER_REMOVING);
     }
 }


### PR DESCRIPTION
This works around the fact that custom handlers are processed in
JMSSerializerBundle after Symfony's DecoratorServicePass has been
executed (which means that we cannot use proper service decoration).

The old code still used to work on Symfony 2.x applications where
FOSRestBundle was registered after JMSSerializerBundle. In those cases,
custom handlers were processed before the handler registry was replaced
by the compiler pass coming from FOSRestBundle.

More recent Symfony applications have not been affected by this bug as
the compiler pass priority would have ensured the correct order in which
the passes would have been executed.