### PR TITLE
Make translator dependency optional

### DIFF
--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -16,7 +16,7 @@
 
         <!-- Normalizes FormInterface when using the symfony serializer -->
         <service id="fos_rest.serializer.form_error_normalizer" class="FOS\RestBundle\Serializer\Normalizer\FormErrorNormalizer" public="false">
-            <argument type="service" id="translator" />
+            <argument type="service" id="translator" on-invalid="null"/>
             <tag name="serializer.normalizer" priority="-10" />
         </service>
     </services>

--- a/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/Serializer/Normalizer/FormErrorNormalizer.php
@@ -23,9 +23,12 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class FormErrorNormalizer implements NormalizerInterface
 {
+    /**
+     * @var TranslatorInterface|null
+     */
     private $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator = null)
     {
         $this->translator = $translator;
     }
@@ -81,6 +84,9 @@ class FormErrorNormalizer implements NormalizerInterface
 
     private function getErrorMessage(FormError $error)
     {
+        if (null === $this->translator) {
+            return $error->getMessage();
+        }
         if (null !== $error->getMessagePluralization()) {
             return $this->translator->transChoice($error->getMessageTemplate(), $error->getMessagePluralization(), $error->getMessageParameters(), 'validators');
         }


### PR DESCRIPTION
The translator service is not really required and it works well without having it.

Fixes #1883