### PR TITLE
Update controller prefix if it is defined as service with class name as id

### DIFF
--- a/Routing/Loader/RestRouteLoader.php
+++ b/Routing/Loader/RestRouteLoader.php
@@ -116,7 +116,8 @@ class RestRouteLoader extends Loader
 
         if ($this->container->has($controller)) {
             // service_id
-            $prefix = $controller.':';
+            $separator = class_exists($controller) ? '::' : ':';
+            $prefix = $controller.$separator;
             $useScope = method_exists($this->container, 'enterScope') && $this->container->hasScope('request');
             if ($useScope) {
                 $this->container->enterScope('request');

--- a/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestYamlCollectionLoaderTest.php
@@ -216,9 +216,8 @@ class RestYamlCollectionLoaderTest extends LoaderTest
 
         $route = $collection->get('get_users');
 
-        // We check that it's "controller:method" (controller as service) and not "controller::method"
         $this->assertEquals(
-            'FOS\RestBundle\Tests\Fixtures\Controller\UsersController:getUsersAction',
+            'FOS\RestBundle\Tests\Fixtures\Controller\UsersController::getUsersAction',
             $route->getDefault('_controller')
         );
 


### PR DESCRIPTION
When a controller is defined as service, for example when using the `controller.service_arguments` tag, `$request->attributes->get('_controller')` looks like this `App\MyController:myAction`.

The goal of the PR is to have `App\MyController::myAction` instead. IMHO I doesn't make sense that the `_controller` parameter is different depending on whether it is defined as a service or not. Unless there is a reason but I do not see which one.