### PR TITLE
Add the possibility to resolve the controller name

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -168,6 +168,7 @@ final class Configuration implements ConfigurationInterface
         $this->addBodyListenerSection($rootNode);
         $this->addFormatListenerSection($rootNode);
         $this->addVersioningSection($rootNode);
+        $this->addResolveControllerNameSection($rootNode);
 
         return $treeBuilder;
     }
@@ -462,6 +463,20 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    private function addResolveControllerNameSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('resolve_controller_name_listener')
+                ->canBeEnabled()
+                ->children()
+                    ->booleanNode('enabled')->defaultFalse()->end()
+                    ->scalarNode('service')->defaultNull()->end()
+                ->end()
+            ->end()
+        ;
     }
 
     /**

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -89,6 +89,7 @@ class FOSRestExtension extends Extension
         $this->loadAllowedMethodsListener($config, $loader, $container);
         $this->loadAccessDeniedListener($config, $loader, $container);
         $this->loadZoneMatcherListener($config, $loader, $container);
+        $this->loadResolveControllerName($config, $loader, $container);
 
         // Needs RequestBodyParamConverter and View Handler loaded.
         $this->loadSerializer($config, $container);
@@ -428,5 +429,17 @@ class FOSRestExtension extends Extension
         ;
 
         return new Reference($id);
+    }
+
+    private function loadResolveControllerName(array $config, XmlFileLoader $loader, ContainerBuilder $container)
+    {
+        if ($config['resolve_controller_name_listener']['enabled']) {
+            $loader->load('resolve_controller_name_listener.xml');
+
+            if (!empty($config['resolve_controller_name_listener']['service'])) {
+                $listener = $container->getDefinition('fos_rest.resolve_controller_name_listener');
+                $listener->clearTag('kernel.event_listener');
+            }
+        }
     }
 }

--- a/EventListener/ResolveControllerNameListener.php
+++ b/EventListener/ResolveControllerNameListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FOS\RestBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * Guarantees that the _controller key is parsed into its final format.
+ *
+ * @author Geoffrey Pécro <geoffrey.pecro@gmail.com>
+ */
+class ResolveControllerNameListener
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $controller = $event->getRequest()->attributes->get('_controller');
+
+        if (is_string($controller) && 1 === substr_count($controller, ':')) {
+            $parts = explode(':', $controller);
+
+            if (class_exists($parts[0])) {
+                $controller = sprintf('%s::%s', $parts[0], $parts[1]);
+
+                $event->getRequest()->attributes->set('_controller', $controller);
+            }
+        }
+    }
+}

--- a/Resources/config/resolve_controller_name_listener.xml
+++ b/Resources/config/resolve_controller_name_listener.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_rest.resolve_controller_name_listener" class="FOS\RestBundle\EventListener\ResolveControllerNameListener">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="23" />
+        </service>
+
+    </services>
+</container>


### PR DESCRIPTION
Controller name looks like `App\MyController:myAction` when a controller is defined as a service.
The goal of this PR is to add the possibility to resolve the controller name in order to have `App\MyController::myAction`

#1891 