### PR TITLE
Handle SF4.1 Deprecation

### DIFF
--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -8,7 +8,7 @@
         <service id="fos_rest.exception_listener" class="FOS\RestBundle\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
-            <argument>fos_rest.exception.controller:showAction</argument>
+            <argument>fos_rest.exception.controller::showAction</argument>
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 


### PR DESCRIPTION
Resolves this issue

`Referencing controllers with a single colon is deprecated since Symfony 4.1. Use fos_rest.exception.twig_controller::showAction instead.`