### PR TITLE
jms/serializer 2.0 compatibility

### DIFF
--- a/DependencyInjection/Compiler/HandlerRegistryDecorationPass.php
+++ b/DependencyInjection/Compiler/HandlerRegistryDecorationPass.php
@@ -12,6 +12,8 @@
 namespace FOS\RestBundle\DependencyInjection\Compiler;
 
 use FOS\RestBundle\Serializer\JMSHandlerRegistry;
+use FOS\RestBundle\Serializer\JMSHandlerRegistryV2;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -38,7 +40,7 @@ class HandlerRegistryDecorationPass implements CompilerPassInterface
         $jmsHandlerRegistry->setPublic(false);
         $container->setDefinition('fos_rest.serializer.jms_handler_registry.inner', $jmsHandlerRegistry);
 
-        $fosRestHandlerRegistry = $container->register('jms_serializer.handler_registry', JMSHandlerRegistry::class)
+        $fosRestHandlerRegistry = $container->register('jms_serializer.handler_registry', interface_exists(SerializationVisitorInterface::class) ? JMSHandlerRegistryV2::class : JMSHandlerRegistry::class)
             ->setPublic($public)
             ->addArgument(new Reference('fos_rest.serializer.jms_handler_registry.inner'));
 

--- a/Serializer/JMSHandlerRegistryV2.php
+++ b/Serializer/JMSHandlerRegistryV2.php
@@ -21,7 +21,7 @@ use JMS\Serializer\Handler\HandlerRegistryInterface;
  *
  * @internal do not depend on this class directly
  */
-class JMSHandlerRegistryV2 implements HandlerRegistryInterface
+final class JMSHandlerRegistryV2 implements HandlerRegistryInterface
 {
     private $registry;
 

--- a/Serializer/JMSHandlerRegistryV2.php
+++ b/Serializer/JMSHandlerRegistryV2.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Serializer;
+
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\Handler\HandlerRegistryInterface;
+
+/**
+ * Search in the class parents to find an adapted handler.
+ *
+ * @author Ener-Getick <egetick@gmail.com>
+ *
+ * @internal do not depend on this class directly
+ */
+class JMSHandlerRegistryV2 implements HandlerRegistryInterface
+{
+    private $registry;
+
+    public function __construct(HandlerRegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerSubscribingHandler(SubscribingHandlerInterface $handler): void
+    {
+        $this->registry->registerSubscribingHandler($handler);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerHandler(int $direction, string $typeName, string $format, $handler): void
+    {
+        $this->registry->registerHandler($direction, $typeName, $format, $handler);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandler(int $direction, string $typeName, string $format)
+    {
+        do {
+            $handler = $this->registry->getHandler($direction, $typeName, $format);
+            if (null !== $handler) {
+                return $handler;
+            }
+        } while ($typeName = get_parent_class($typeName));
+    }
+}

--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -95,7 +95,7 @@ class JMSSerializerAdapter implements Serializer
         }
 
         foreach ($context->getAttributes() as $key => $value) {
-            $jmsContext->attributes->set($key, $value);
+            $jmsContext->setAttribute($key, $value);
         }
 
         if (null !== $context->getVersion()) {

--- a/Serializer/Normalizer/FormErrorHandler.php
+++ b/Serializer/Normalizer/FormErrorHandler.php
@@ -40,9 +40,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
     public function serializeFormToXml(XmlSerializationVisitor $visitor, Form $form, array $type, Context $context = null)
     {
         if ($context) {
-
             if ($context->hasAttribute('status_code')) {
-
                 $document = $visitor->getDocument(true);
                 if (!$visitor->getCurrentNode()) {
                     $visitor->createRoot();
@@ -86,7 +84,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
 
     public function serializeFormToYml(YamlSerializationVisitor $visitor, Form $form, array $type, Context $context = null)
     {
-        $isRoot = null === $visitor->getRoot() ;
+        $isRoot = null === $visitor->getRoot();
         $result = $this->adaptFormArray($this->formErrorHandler->serializeFormToYml($visitor, $form, $type), $context);
 
         if ($isRoot) {

--- a/Tests/Functional/DependencyInjectionTest.php
+++ b/Tests/Functional/DependencyInjectionTest.php
@@ -13,7 +13,9 @@ namespace FOS\RestBundle\Tests\Functional;
 
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Serializer\JMSHandlerRegistry;
+use FOS\RestBundle\Serializer\JMSHandlerRegistryV2;
 use FOS\RestBundle\Serializer\Normalizer\FormErrorHandler;
+use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -29,8 +31,12 @@ class DependencyInjectionTest extends KernelTestCase
         self::bootKernel();
         $container = self::$kernel->getContainer();
 
-        $this->assertInstanceOf(FormErrorHandler::class, $container->get('jms_serializer.form_error_handler'));
-        $this->assertInstanceOf(JMSHandlerRegistry::class, $container->get('test.jms_serializer.handler_registry'));
+        $this->assertInstanceOf(FormErrorHandler::class, $container->get('test.jms_serializer.form_error_handler'));
+
+        $this->assertInstanceOf(
+            interface_exists(SerializationVisitorInterface::class) ? JMSHandlerRegistryV2::class : JMSHandlerRegistry::class,
+            $container->get('test.jms_serializer.handler_registry')
+        );
     }
 
     protected static function getKernelClass()
@@ -63,6 +69,7 @@ class TestKernel extends Kernel
                 'exception' => null,
             ]);
             $container->setAlias('test.jms_serializer.handler_registry', new Alias('jms_serializer.handler_registry', true));
+            $container->setAlias('test.jms_serializer.form_error_handler', new Alias('jms_serializer.form_error_handler', true));
         });
     }
 

--- a/Tests/Serializer/JMSSerializerAdapterTest.php
+++ b/Tests/Serializer/JMSSerializerAdapterTest.php
@@ -94,15 +94,13 @@ class JMSSerializerAdapterTest extends TestCase
         $exclusion = $this->getMockBuilder(ExclusionStrategyInterface::class)->getMock();
 
         $jmsContext = $this->getMockBuilder(SerializationContext::class)->getMock();
-        $jmsContext->attributes = $this->getMockBuilder(MapInterface::class)->getMock();
 
         $jmsContext->expects($this->once())->method('setGroups')->with(['foo']);
         $jmsContext->expects($this->once())->method('setSerializeNull')->with(true);
         $jmsContext->expects($this->once())->method('enableMaxDepthChecks');
         $jmsContext->expects($this->once())->method('setVersion')->with('5.0.1');
         $jmsContext->expects($this->once())->method('addExclusionStrategy')->with($exclusion);
-
-        $jmsContext->attributes->expects($this->once())->method('set')->with('foo', 'bar');
+        $jmsContext->expects($this->once())->method('setAttribute')->with('foo', 'bar');
 
         $this->serializationContextFactory->method('createSerializationContext')->willReturn($jmsContext);
 

--- a/Tests/Serializer/JMSSerializerAdapterTest.php
+++ b/Tests/Serializer/JMSSerializerAdapterTest.php
@@ -19,7 +19,6 @@ use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
-use PhpCollection\MapInterface;
 use PHPUnit\Framework\TestCase;
 
 class JMSSerializerAdapterTest extends TestCase

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     },
     "conflict": {
         "sensio/framework-extra-bundle": "<3.0.13",
-        "jms/serializer-bundle": "<1.2.0",
+        "jms/serializer-bundle": "<2.0.0",
         "jms/serializer": "1.3.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -61,12 +61,13 @@
         "symfony/expression-language": "~2.7|^3.0|^4.0",
         "symfony/css-selector": "^2.7|^3.0|^4.0",
         "phpoption/phpoption": "^1.1",
-        "jms/serializer-bundle": "^1.2|^2.0",
+        "jms/serializer-bundle": "^2.0|^3.0",
+        "jms/serializer": "^1.13|^2.0",
         "psr/http-message": "^1.0"
     },
     "suggest": {
         "sensio/framework-extra-bundle": "Add support for the request body converter and the view response listener, requires ^3.0",
-        "jms/serializer-bundle": "Add support for advanced serialization capabilities, recommended, requires ^1.0",
+        "jms/serializer-bundle": "Add support for advanced serialization capabilities, recommended, requires ^2.0|^3.0",
         "symfony/expression-language": "Add support for using the expression language in the routing, requires ^2.7|^3.0",
         "symfony/serializer": "Add support for basic serialization capabilities and xml decoding, requires ^2.7|^3.0",
         "symfony/validator": "Add support for validation capabilities in the ParamFetcher, requires ^2.7|^3.0"


### PR DESCRIPTION
This introduces the changes for supporting the upcoming jms/serializer 2.0 release

Some changes in composer.json and travisci are will not be necessary when serializer v1.13 will be released