### PR TITLE
kebab-case key normalizer

### DIFF
--- a/Normalizer/AbstractKeysNormalizer.php
+++ b/Normalizer/AbstractKeysNormalizer.php
@@ -1,13 +1,19 @@
 <?php
-
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace FOS\RestBundle\Normalizer;
-
 
 use FOS\RestBundle\Normalizer\Exception\NormalizationException;
 
 /**
- * Abstract Keys Normalizer
+ * Abstract Keys Normalizer.
  *
  * @author Oleg Andreyev <oleg@andreyev.lv>
  */
@@ -19,6 +25,7 @@ abstract class AbstractKeysNormalizer implements ArrayNormalizerInterface
     public function normalize(array $data): array
     {
         $this->normalizeArray($data);
+
         return $data;
     }
 

--- a/Normalizer/AbstractKeysNormalizer.php
+++ b/Normalizer/AbstractKeysNormalizer.php
@@ -35,6 +35,7 @@ abstract class AbstractKeysNormalizer implements ArrayNormalizerInterface
      * @param array $data
      *
      * @return array
+     *
      * @throws Exception\NormalizationException
      */
     protected function normalizeArray(array $data)

--- a/Normalizer/AbstractKeysNormalizer.php
+++ b/Normalizer/AbstractKeysNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+
+namespace FOS\RestBundle\Normalizer;
+
+
+use FOS\RestBundle\Normalizer\Exception\NormalizationException;
+
+/**
+ * Abstract Keys Normalizer
+ *
+ * @author Oleg Andreyev <oleg@andreyev.lv>
+ */
+abstract class AbstractKeysNormalizer implements ArrayNormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize(array $data): array
+    {
+        $this->normalizeArray($data);
+        return $data;
+    }
+
+    abstract protected function normalizeString(string $string): string;
+
+    /**
+     * Normalizes an array.
+     *
+     * @param array $data
+     *
+     * @throws Exception\NormalizationException
+     */
+    protected function normalizeArray(array &$data)
+    {
+        $normalizedData = [];
+
+        foreach ($data as $key => $val) {
+            $normalizedKey = $this->normalizeString($key);
+
+            if (($normalizedKey !== $key) && array_key_exists($normalizedKey, $normalizedData)) {
+                throw new NormalizationException(sprintf(
+                    'The key "%s" is invalid as it will override the existing key "%s"',
+                    $key,
+                    $normalizedKey
+                ));
+            }
+
+            $normalizedData[$normalizedKey] = $val;
+            $key = $normalizedKey;
+
+            if (is_array($val)) {
+                $this->normalizeArray($normalizedData[$key]);
+            }
+        }
+
+        $data = $normalizedData;
+    }
+}

--- a/Normalizer/AbstractKeysNormalizer.php
+++ b/Normalizer/AbstractKeysNormalizer.php
@@ -24,9 +24,7 @@ abstract class AbstractKeysNormalizer implements ArrayNormalizerInterface
      */
     public function normalize(array $data): array
     {
-        $this->normalizeArray($data);
-
-        return $data;
+        return $this->normalizeArray($data);
     }
 
     abstract protected function normalizeString(string $string): string;
@@ -36,9 +34,10 @@ abstract class AbstractKeysNormalizer implements ArrayNormalizerInterface
      *
      * @param array $data
      *
+     * @return array
      * @throws Exception\NormalizationException
      */
-    protected function normalizeArray(array &$data)
+    protected function normalizeArray(array $data)
     {
         $normalizedData = [];
 
@@ -57,10 +56,10 @@ abstract class AbstractKeysNormalizer implements ArrayNormalizerInterface
             $key = $normalizedKey;
 
             if (is_array($val)) {
-                $this->normalizeArray($normalizedData[$key]);
+                $normalizedData[$key] = $this->normalizeArray($normalizedData[$key]);
             }
         }
 
-        $data = $normalizedData;
+        return $normalizedData;
     }
 }

--- a/Normalizer/ArrayNormalizerInterface.php
+++ b/Normalizer/ArrayNormalizerInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the FOSRestBundle package.
  *

--- a/Normalizer/ArrayNormalizerInterface.php
+++ b/Normalizer/ArrayNormalizerInterface.php
@@ -27,5 +27,5 @@ interface ArrayNormalizerInterface
      *
      * @return array The normalized array
      */
-    public function normalize(array $data);
+    public function normalize(array $data): array;
 }

--- a/Normalizer/CamelKeysNormalizer.php
+++ b/Normalizer/CamelKeysNormalizer.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the FOSRestBundle package.
  *

--- a/Normalizer/CamelKeysNormalizer.php
+++ b/Normalizer/CamelKeysNormalizer.php
@@ -11,60 +11,13 @@
 
 namespace FOS\RestBundle\Normalizer;
 
-use FOS\RestBundle\Normalizer\Exception\NormalizationException;
-
 /**
  * Normalizes the array by changing its keys from underscore to camel case.
  *
  * @author Florian Voutzinos <florian@voutzinos.com>
  */
-class CamelKeysNormalizer implements ArrayNormalizerInterface
+class CamelKeysNormalizer extends AbstractKeysNormalizer
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function normalize(array $data)
-    {
-        $this->normalizeArray($data);
-
-        return $data;
-    }
-
-    /**
-     * Normalizes an array.
-     *
-     * @param array &$data
-     *
-     * @throws Exception\NormalizationException
-     */
-    private function normalizeArray(array &$data)
-    {
-        $normalizedData = array();
-
-        foreach ($data as $key => $val) {
-            $normalizedKey = $this->normalizeString($key);
-
-            if ($normalizedKey !== $key) {
-                if (array_key_exists($normalizedKey, $normalizedData)) {
-                    throw new NormalizationException(sprintf(
-                        'The key "%s" is invalid as it will override the existing key "%s"',
-                        $key,
-                        $normalizedKey
-                    ));
-                }
-            }
-
-            $normalizedData[$normalizedKey] = $val;
-            $key = $normalizedKey;
-
-            if (is_array($val)) {
-                $this->normalizeArray($normalizedData[$key]);
-            }
-        }
-
-        $data = $normalizedData;
-    }
-
     /**
      * Normalizes a string.
      *
@@ -72,7 +25,7 @@ class CamelKeysNormalizer implements ArrayNormalizerInterface
      *
      * @return string
      */
-    protected function normalizeString($string)
+    protected function normalizeString(string $string): string
     {
         if (false === strpos($string, '_')) {
             return $string;

--- a/Normalizer/CamelKeysNormalizerWithLeadingUnderscore.php
+++ b/Normalizer/CamelKeysNormalizerWithLeadingUnderscore.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the FOSRestBundle package.
  *

--- a/Normalizer/CamelKeysNormalizerWithLeadingUnderscore.php
+++ b/Normalizer/CamelKeysNormalizerWithLeadingUnderscore.php
@@ -26,7 +26,7 @@ class CamelKeysNormalizerWithLeadingUnderscore extends CamelKeysNormalizer
      *
      * @return string
      */
-    protected function normalizeString($string)
+    protected function normalizeString(string $string): string
     {
         if (false === strpos($string, '_')) {
             return $string;

--- a/Normalizer/KebabKeysNormalizer.php
+++ b/Normalizer/KebabKeysNormalizer.php
@@ -11,7 +11,7 @@
 namespace FOS\RestBundle\Normalizer;
 
 /**
- * Normalizes the array by changing its keys from kebab-case to camel case
+ * Normalizes the array by changing its keys from kebab-case to camel case.
  *
  * @author Oleg Andreyev <oleg@andreyev.lv>
  */

--- a/Normalizer/KebabKeysNormalizer.php
+++ b/Normalizer/KebabKeysNormalizer.php
@@ -10,60 +10,13 @@
 
 namespace FOS\RestBundle\Normalizer;
 
-use FOS\RestBundle\Normalizer\Exception\NormalizationException;
-
 /**
- * Normalizes the array by changing its keys from kebab case to camel case.
+ * Normalizes the array by changing its keys from kebab-case to camel case
  *
- * @author Oleg Andreyev <oleg.andreyev@live.com>
+ * @author Oleg Andreyev <oleg@andreyev.lv>
  */
-class KebabKeysNormalizer implements ArrayNormalizerInterface
+class KebabKeysNormalizer extends AbstractKeysNormalizer
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function normalize(array $data)
-    {
-        $this->normalizeArray($data);
-
-        return $data;
-    }
-
-    /**
-     * Normalizes an array.
-     *
-     * @param array &$data
-     *
-     * @throws Exception\NormalizationException
-     */
-    private function normalizeArray(array &$data)
-    {
-        $normalizedData = array();
-
-        foreach ($data as $key => $val) {
-            $normalizedKey = $this->normalizeString($key);
-
-            if ($normalizedKey !== $key) {
-                if (array_key_exists($normalizedKey, $normalizedData)) {
-                    throw new NormalizationException(sprintf(
-                        'The key "%s" is invalid as it will override the existing key "%s"',
-                        $key,
-                        $normalizedKey
-                    ));
-                }
-            }
-
-            $normalizedData[$normalizedKey] = $val;
-            $key = $normalizedKey;
-
-            if (is_array($val)) {
-                $this->normalizeArray($normalizedData[$key]);
-            }
-        }
-
-        $data = $normalizedData;
-    }
-
     /**
      * Normalizes a string.
      *
@@ -71,7 +24,7 @@ class KebabKeysNormalizer implements ArrayNormalizerInterface
      *
      * @return string
      */
-    protected function normalizeString($string)
+    protected function normalizeString(string $string): string
     {
         if (false === strpos($string, '-')) {
             return $string;

--- a/Normalizer/KebabKeysNormalizer.php
+++ b/Normalizer/KebabKeysNormalizer.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Normalizer;
+
+use FOS\RestBundle\Normalizer\Exception\NormalizationException;
+
+/**
+ * Normalizes the array by changing its keys from kebab case to camel case.
+ *
+ * @author Oleg Andreyev <oleg.andreyev@live.com>
+ */
+class KebabKeysNormalizer implements ArrayNormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize(array $data)
+    {
+        $this->normalizeArray($data);
+
+        return $data;
+    }
+
+    /**
+     * Normalizes an array.
+     *
+     * @param array &$data
+     *
+     * @throws Exception\NormalizationException
+     */
+    private function normalizeArray(array &$data)
+    {
+        $normalizedData = array();
+
+        foreach ($data as $key => $val) {
+            $normalizedKey = $this->normalizeString($key);
+
+            if ($normalizedKey !== $key) {
+                if (array_key_exists($normalizedKey, $normalizedData)) {
+                    throw new NormalizationException(sprintf(
+                        'The key "%s" is invalid as it will override the existing key "%s"',
+                        $key,
+                        $normalizedKey
+                    ));
+                }
+            }
+
+            $normalizedData[$normalizedKey] = $val;
+            $key = $normalizedKey;
+
+            if (is_array($val)) {
+                $this->normalizeArray($normalizedData[$key]);
+            }
+        }
+
+        $data = $normalizedData;
+    }
+
+    /**
+     * Normalizes a string.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    protected function normalizeString($string)
+    {
+        if (false === strpos($string, '-')) {
+            return $string;
+        }
+
+        return \preg_replace_callback('/-([a-zA-Z0-9])/', function ($matches) {
+            return strtoupper($matches[1]);
+        }, $string);
+    }
+}

--- a/Resources/config/body_listener.xml
+++ b/Resources/config/body_listener.xml
@@ -6,6 +6,8 @@
 
     <services>
 
+        <service id="fos_rest.normalizer.kebak_keys" class="FOS\RestBundle\Normalizer\KebabKeysNormalizer" />
+
         <service id="fos_rest.normalizer.camel_keys" class="FOS\RestBundle\Normalizer\CamelKeysNormalizer" />
 
         <service id="fos_rest.normalizer.camel_keys_with_leading_underscore" class="FOS\RestBundle\Normalizer\CamelKeysNormalizerWithLeadingUnderscore" />

--- a/Tests/Normalizer/KebabKeysNormalizerTest.php
+++ b/Tests/Normalizer/KebabKeysNormalizerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Normalizer;
+
+use FOS\RestBundle\Normalizer\KebabKeysNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class KebabKeysNormalizerTest extends TestCase
+{
+    /**
+     * @expectedException \FOS\RestBundle\Normalizer\Exception\NormalizationException
+     */
+    public function testNormalizeSameValueException()
+    {
+        $normalizer = new KebabKeysNormalizer();
+        $normalizer->normalize([
+            'foo' => [
+                'foo-bar' => 'foo',
+                'foo-Bar' => 'foo',
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider normalizeProvider
+     */
+    public function testNormalize(array $array, array $expected)
+    {
+        $normalizer = new KebabKeysNormalizer();
+        $this->assertEquals($expected, $normalizer->normalize($array));
+    }
+
+    public function normalizeProvider()
+    {
+        $array = $this->normalizeProviderCommon();
+        $array[] = array(
+            array('_-username' => 'foo', '-password' => 'bar', '-foo-bar' => 'foobar'),
+            array('_Username' => 'foo', 'Password' => 'bar', 'FooBar' => 'foobar'),
+        );
+
+        return $array;
+    }
+
+    private function normalizeProviderCommon()
+    {
+        return array(
+            array(array(), array()),
+            array(
+                array('foo' => array('Foo-bar-baz' => array('foo-Bar' => array('foo-bar' => 'foo_bar'))),
+                    'foo-1ar' => array('foo_bar'),
+                ),
+                array('foo' => array('FooBarBaz' => array('fooBar' => array('fooBar' => 'foo_bar'))),
+                    'foo1ar' => array('foo_bar'),
+                ),
+            ),
+        );
+    }
+}

--- a/Tests/Normalizer/KebabKeysNormalizerTest.php
+++ b/Tests/Normalizer/KebabKeysNormalizerTest.php
@@ -41,26 +41,19 @@ class KebabKeysNormalizerTest extends TestCase
 
     public function normalizeProvider()
     {
-        $array = $this->normalizeProviderCommon();
-        $array[] = array(
-            array('_-username' => 'foo', '-password' => 'bar', '-foo-bar' => 'foobar'),
-            array('_Username' => 'foo', 'Password' => 'bar', 'FooBar' => 'foobar'),
-        );
-
-        return $array;
-    }
-
-    private function normalizeProviderCommon()
-    {
         return array(
             array(array(), array()),
             array(
                 array('foo' => array('Foo-bar-baz' => array('foo-Bar' => array('foo-bar' => 'foo_bar'))),
-                    'foo-1ar' => array('foo_bar'),
+                      'foo-1ar' => array('foo_bar'),
                 ),
                 array('foo' => array('FooBarBaz' => array('fooBar' => array('fooBar' => 'foo_bar'))),
-                    'foo1ar' => array('foo_bar'),
+                      'foo1ar' => array('foo_bar'),
                 ),
+            ),
+            array(
+                array('_-username' => 'foo', '-password' => 'bar', '-foo-bar' => 'foobar'),
+                array('_Username' => 'foo', 'Password' => 'bar', 'FooBar' => 'foobar')
             ),
         );
     }

--- a/Tests/Normalizer/KebabKeysNormalizerTest.php
+++ b/Tests/Normalizer/KebabKeysNormalizerTest.php
@@ -53,7 +53,7 @@ class KebabKeysNormalizerTest extends TestCase
             ),
             array(
                 array('_-username' => 'foo', '-password' => 'bar', '-foo-bar' => 'foobar'),
-                array('_Username' => 'foo', 'Password' => 'bar', 'FooBar' => 'foobar')
+                array('_Username' => 'foo', 'Password' => 'bar', 'FooBar' => 'foobar'),
             ),
         );
     }


### PR DESCRIPTION
[JSON API Specification](http://jsonapi.org/format/) is recommending to use hyphen minus (U+002D HYPHEN-MINUS, “-“) as separator between multiple words

Adding `KebabKeysNormalizer` which will normalize kebab-case into camelCase