### PR TITLE
Fix exception controller deprecations for Symfony >= 4.1

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -21,8 +21,9 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Kernel;
 
 class FOSRestExtension extends Extension
 {
@@ -349,6 +350,11 @@ class FOSRestExtension extends Extension
                 $container->getDefinition('fos_rest.exception_listener')->replaceArgument(0, $config['exception']['exception_controller']);
             } elseif (isset($container->getParameter('kernel.bundles')['TwigBundle'])) {
                 $container->getDefinition('fos_rest.exception_listener')->replaceArgument(0, 'fos_rest.exception.twig_controller:showAction');
+            }
+
+            // rewrite default exception controller definition for Symfony >= 4.1; can come from above or from the xml file
+            if (Kernel::VERSION_ID >= 40100 && preg_match('/^fos_rest\.exception\.(twig_)*controller:showAction$/', $container->getDefinition('fos_rest.exception_listener')->getArgument(0), $matches) > 0) {
+                $container->getDefinition('fos_rest.exception_listener')->replaceArgument(0, sprintf('fos_rest.exception.%scontroller::showAction', isset($matches[1]) ? $matches[1] : ''));
             }
 
             $container->getDefinition('fos_rest.exception.codes_map')

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -8,7 +8,7 @@
         <service id="fos_rest.exception_listener" class="FOS\RestBundle\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
-            <argument>fos_rest.exception.controller:showAction</argument>
+            <argument />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 


### PR DESCRIPTION
This extends the work demonstrated in #1898. It's a little tricky because the old-style controller definitions appear in two places, so this accounts for both of them in one spot.

Note that there are a ton of other deprecation notices in the test suite itself, but this fixes only the ones related to the exception controller definition. Many of them could be resolved by loading a different TestBundle routing file for Symfony >= 4.1; I wasn't sure how you'd prefer to handle that.