### PR TITLE
Fix failing tests

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -115,10 +115,12 @@ final class Configuration implements ConfigurationInterface
                             ->defaultFalse()
                             ->beforeNormalization()
                                 ->ifTrue()
-                                ->then(function () {
+                                ->then(function ($value) {
                                     if (!class_exists(OptionsResolver::class)) {
                                         throw new InvalidConfigurationException("'body_converter.validate: true' requires OptionsResolver component installation ( composer require symfony/options-resolver )");
                                     }
+
+                                    return $value;
                                 })
                             ->end()
                         ->end()


### PR DESCRIPTION
fix error introduced with https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1912

Because of it `body_converter.validate` is always `NULL`