### PR TITLE
The "Sensio\Bundle\FrameworkExtraBundle\Configuration\Route" annotati…

### DIFF
--- a/Controller/Annotations/Route.php
+++ b/Controller/Annotations/Route.php
@@ -11,7 +11,7 @@
 
 namespace FOS\RestBundle\Controller\Annotations;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route as BaseRoute;
+use Symfony\Component\Routing\Annotation\Route as BaseRoute;
 
 /**
  * Route annotation class.


### PR DESCRIPTION
…on is deprecated since version 5.2. Use "Symfony\Component\Routing\Annotation\Route" instead

BTW, why is [sensio/framework-extra-bundle](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/composer.json#L49) dev dependency?