### PR TITLE
Reset internal state of ViewHandler at the end of request

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -382,22 +382,24 @@ class FOSRestExtension extends Extension
     {
         $bodyConverter = $container->hasDefinition('fos_rest.converter.request_body') ? $container->getDefinition('fos_rest.converter.request_body') : null;
         $viewHandler = $container->getDefinition('fos_rest.view_handler.default');
+        $options = array();
 
         if (!empty($config['serializer']['version'])) {
             if ($bodyConverter) {
                 $bodyConverter->replaceArgument(2, $config['serializer']['version']);
             }
-            $viewHandler->addMethodCall('setExclusionStrategyVersion', array($config['serializer']['version']));
+            $options['exclusionStrategyVersion'] = $config['serializer']['version'];
         }
 
         if (!empty($config['serializer']['groups'])) {
             if ($bodyConverter) {
                 $bodyConverter->replaceArgument(1, $config['serializer']['groups']);
             }
-            $viewHandler->addMethodCall('setExclusionStrategyGroups', array($config['serializer']['groups']));
+            $options['exclusionStrategyGroups'] = $config['serializer']['groups'];
         }
 
-        $viewHandler->addMethodCall('setSerializeNullStrategy', array($config['serializer']['serialize_null']));
+        $options['serializeNullStrategy'] = $config['serializer']['serialize_null'];
+        $viewHandler->addArgument($options);
     }
 
     private function loadZoneMatcherListener(array $config, XmlFileLoader $loader, ContainerBuilder $container)

--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -17,6 +17,7 @@
             <argument /> <!-- serialize null -->
             <argument type="collection" /> <!-- force redirects -->
             <argument /> <!-- default engine -->
+            <tag name="kernel.reset" method="reset" />
         </service>
 
         <service id="FOS\RestBundle\View\ViewHandlerInterface" alias="fos_rest.view_handler.default" />

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -502,4 +502,14 @@ class ViewHandler implements ConfigurableViewHandlerInterface
 
         return $form;
     }
+
+    /**
+     * Resets internal object state at the end of the request
+     */
+    public function reset()
+    {
+        $this->exclusionStrategyGroups = [];
+        $this->exclusionStrategyVersion = null;
+        $this->serializeNullStrategy = null;
+    }
 }

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -117,6 +117,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface
      * @param bool                  $serializeNull        Whether or not to serialize null view data
      * @param array                 $forceRedirects       If to force a redirect for the given key format, with value being the status code to use
      * @param string                $defaultEngine        default engine (twig, php ..)
+     * @param array                 $options              config options
      */
     public function __construct(
         UrlGeneratorInterface $urlGenerator,
@@ -129,7 +130,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface
         $serializeNull = false,
         array $forceRedirects = null,
         $defaultEngine = 'twig',
-        array $options
+        array $options = []
     ) {
         $this->urlGenerator = $urlGenerator;
         $this->serializer = $serializer;
@@ -141,7 +142,11 @@ class ViewHandler implements ConfigurableViewHandlerInterface
         $this->serializeNull = $serializeNull;
         $this->forceRedirects = (array) $forceRedirects;
         $this->defaultEngine = $defaultEngine;
-        $this->options = $options;
+        $this->options = $options + [
+            'exclusionStrategyGroups' => [],
+            'exclusionStrategyVersion' => null,
+            'serializeNullStrategy' => null
+            ];
         $this->reset();
     }
 
@@ -513,14 +518,8 @@ class ViewHandler implements ConfigurableViewHandlerInterface
      */
     public function reset()
     {
-        if (isset($this->options['exclusionStrategyGroups'])) {
-            $this->exclusionStrategyGroups = $this->options['exclusionStrategyGroups'];
-        }
-        if (isset($this->options['exclusionStrategyVersion'])) {
-            $this->exclusionStrategyVersion = $this->options['exclusionStrategyVersion'];
-        }
-        if (isset($this->options['serializeNullStrategy'])) {
-            $this->serializeNullStrategy = $this->options['serializeNullStrategy'];
-        }
+        $this->exclusionStrategyGroups = $this->options['exclusionStrategyGroups'];
+        $this->exclusionStrategyVersion = $this->options['exclusionStrategyVersion'];
+        $this->serializeNullStrategy = $this->options['serializeNullStrategy'];
     }
 }

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -504,7 +504,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface
     }
 
     /**
-     * Resets internal object state at the end of the request
+     * Resets internal object state at the end of the request.
      */
     public function reset()
     {

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -145,7 +145,7 @@ class ViewHandler implements ConfigurableViewHandlerInterface
         $this->options = $options + [
             'exclusionStrategyGroups' => [],
             'exclusionStrategyVersion' => null,
-            'serializeNullStrategy' => null
+            'serializeNullStrategy' => null,
             ];
         $this->reset();
     }

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -102,6 +102,8 @@ class ViewHandler implements ConfigurableViewHandlerInterface
     private $templating;
     private $requestStack;
 
+    private $options;
+
     /**
      * Constructor.
      *
@@ -126,7 +128,8 @@ class ViewHandler implements ConfigurableViewHandlerInterface
         $emptyContentCode = Response::HTTP_NO_CONTENT,
         $serializeNull = false,
         array $forceRedirects = null,
-        $defaultEngine = 'twig'
+        $defaultEngine = 'twig',
+        array $options
     ) {
         $this->urlGenerator = $urlGenerator;
         $this->serializer = $serializer;
@@ -138,6 +141,8 @@ class ViewHandler implements ConfigurableViewHandlerInterface
         $this->serializeNull = $serializeNull;
         $this->forceRedirects = (array) $forceRedirects;
         $this->defaultEngine = $defaultEngine;
+        $this->options = $options;
+        $this->reset();
     }
 
     /**
@@ -508,8 +513,14 @@ class ViewHandler implements ConfigurableViewHandlerInterface
      */
     public function reset()
     {
-        $this->exclusionStrategyGroups = [];
-        $this->exclusionStrategyVersion = null;
-        $this->serializeNullStrategy = null;
+        if (isset($this->options['exclusionStrategyGroups'])) {
+            $this->exclusionStrategyGroups = $this->options['exclusionStrategyGroups'];
+        }
+        if (isset($this->options['exclusionStrategyVersion'])) {
+            $this->exclusionStrategyVersion = $this->options['exclusionStrategyVersion'];
+        }
+        if (isset($this->options['serializeNullStrategy'])) {
+            $this->serializeNullStrategy = $this->options['serializeNullStrategy'];
+        }
     }
 }


### PR DESCRIPTION
ViewHandler keeps an internal state of the variables

- exclusionStrategyGroups
- exclusionStrategyVersion
- serializeNullStrategy

which causes inconsistencies when used with [PHP-PM](https://github.com/php-pm/php-pm). This PR fixes this by utilizing the "kernel.reset" tag introduced for this purpose in https://github.com/symfony/symfony/issues/23984 to reset the state of these variables after each request.