### PR TITLE
fix route generator not ignoring body param converters

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -477,7 +477,7 @@ class RestActionReader
 
         // check if a parameter is coming from the request body
         $ignoreParameters = [];
-        if (class_exists('Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\ParamConverter')) {
+        if (class_exists(\Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter::class)) {
             $ignoreParameters = array_map(function ($annotation) {
                 return
                     $annotation instanceof \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter &&

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -240,7 +240,7 @@ class RestActionReader
      * Reads action route.
      *
      * @param RestRouteCollection $collection
-     * @param ReflectionMethod   $method
+     * @param ReflectionMethod    $method
      * @param string[]            $resource
      *
      * @throws \InvalidArgumentException
@@ -431,7 +431,7 @@ class RestActionReader
      * Returns HTTP method and resources list from method signature.
      *
      * @param ReflectionMethod $method
-     * @param string[]          $resource
+     * @param string[]         $resource
      *
      * @return bool|array
      */
@@ -565,9 +565,9 @@ class RestActionReader
     /**
      * Generates URL parts for route from resources list.
      *
-     * @param string[]               $resources
+     * @param string[]              $resources
      * @param ReflectionParameter[] $arguments
-     * @param string                 $httpMethod
+     * @param string                $httpMethod
      *
      * @return array
      */
@@ -609,8 +609,8 @@ class RestActionReader
     /**
      * Returns custom HTTP method for provided list of resources, arguments, method.
      *
-     * @param string                 $httpMethod current HTTP method
-     * @param string[]               $resources  resources list
+     * @param string                $httpMethod current HTTP method
+     * @param string[]              $resources  resources list
      * @param ReflectionParameter[] $arguments  list of method arguments
      *
      * @return string
@@ -671,7 +671,7 @@ class RestActionReader
      * Reads method annotations.
      *
      * @param ReflectionMethod $reflectionMethod
-     * @param string            $annotationName
+     * @param string           $annotationName
      *
      * @return RouteAnnotation|null
      */
@@ -688,7 +688,7 @@ class RestActionReader
      * Reads method annotations.
      *
      * @param ReflectionMethod $reflectionMethod
-     * @param string            $annotationName
+     * @param string           $annotationName
      *
      * @return RouteAnnotation[]
      */

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -475,6 +475,17 @@ class RestActionReader
         // ignore all query params
         $params = $this->paramReader->getParamsFromMethod($method);
 
+        // check if a parameter is coming from the request body
+        $ignoreParameters = [];
+        if (class_exists('Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\ParamConverter')) {
+            $ignoreParameters = array_map(function ($annotation) {
+                return
+                    $annotation instanceof \Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter &&
+                    'fos_rest.request_body' === $annotation->getConverter()
+                        ? $annotation->getName() : null;
+            }, $this->annotationReader->getMethodAnnotations($method));
+        }
+
         // ignore several type hinted arguments
         $ignoreClasses = [
             \Symfony\Component\HttpFoundation\Request::class,
@@ -498,6 +509,10 @@ class RestActionReader
                         continue 2;
                     }
                 }
+            }
+
+            if (in_array($argument->getName(), $ignoreParameters)) {
+                continue;
             }
 
             $arguments[] = $argument;

--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -18,8 +18,6 @@ use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\Request\ParamReaderInterface;
 use FOS\RestBundle\Routing\RestRouteCollection;
 use Psr\Http\Message\MessageInterface;
-use ReflectionMethod;
-use ReflectionParameter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
@@ -240,14 +238,14 @@ class RestActionReader
      * Reads action route.
      *
      * @param RestRouteCollection $collection
-     * @param ReflectionMethod    $method
+     * @param \ReflectionMethod   $method
      * @param string[]            $resource
      *
      * @throws \InvalidArgumentException
      *
      * @return Route
      */
-    public function read(RestRouteCollection $collection, ReflectionMethod $method, $resource)
+    public function read(RestRouteCollection $collection, \ReflectionMethod $method, $resource)
     {
         // check that every route parent has non-empty singular name
         foreach ($this->parents as $parent) {
@@ -401,11 +399,11 @@ class RestActionReader
     /**
      * Checks whether provided method is readable.
      *
-     * @param ReflectionMethod $method
+     * @param \ReflectionMethod $method
      *
      * @return bool
      */
-    private function isMethodReadable(ReflectionMethod $method)
+    private function isMethodReadable(\ReflectionMethod $method)
     {
         // if method starts with _ - skip
         if ('_' === substr($method->getName(), 0, 1)) {
@@ -430,12 +428,12 @@ class RestActionReader
     /**
      * Returns HTTP method and resources list from method signature.
      *
-     * @param ReflectionMethod $method
-     * @param string[]         $resource
+     * @param \ReflectionMethod $method
+     * @param string[]          $resource
      *
      * @return bool|array
      */
-    private function getHttpMethodAndResourcesFromMethod(ReflectionMethod $method, $resource)
+    private function getHttpMethodAndResourcesFromMethod(\ReflectionMethod $method, $resource)
     {
         // if method doesn't match regex - skip
         if (!preg_match('/([a-z][_a-z0-9]+)(.*)Action/', $method->getName(), $matches)) {
@@ -472,11 +470,11 @@ class RestActionReader
     /**
      * Returns readable arguments from method.
      *
-     * @param ReflectionMethod $method
+     * @param \ReflectionMethod $method
      *
-     * @return ReflectionParameter[]
+     * @return \ReflectionParameter[]
      */
-    private function getMethodArguments(ReflectionMethod $method)
+    private function getMethodArguments(\ReflectionMethod $method)
     {
         // ignore all query params
         $params = $this->paramReader->getParamsFromMethod($method);
@@ -565,9 +563,9 @@ class RestActionReader
     /**
      * Generates URL parts for route from resources list.
      *
-     * @param string[]              $resources
-     * @param ReflectionParameter[] $arguments
-     * @param string                $httpMethod
+     * @param string[]               $resources
+     * @param \ReflectionParameter[] $arguments
+     * @param string                 $httpMethod
      *
      * @return array
      */
@@ -609,9 +607,9 @@ class RestActionReader
     /**
      * Returns custom HTTP method for provided list of resources, arguments, method.
      *
-     * @param string                $httpMethod current HTTP method
-     * @param string[]              $resources  resources list
-     * @param ReflectionParameter[] $arguments  list of method arguments
+     * @param string                 $httpMethod current HTTP method
+     * @param string[]               $resources  resources list
+     * @param \ReflectionParameter[] $arguments  list of method arguments
      *
      * @return string
      */
@@ -635,11 +633,11 @@ class RestActionReader
     /**
      * Returns first route annotation for method.
      *
-     * @param ReflectionMethod $reflectionMethod
+     * @param \ReflectionMethod $reflectionMethod
      *
      * @return RouteAnnotation[]
      */
-    private function readRouteAnnotation(ReflectionMethod $reflectionMethod)
+    private function readRouteAnnotation(\ReflectionMethod $reflectionMethod)
     {
         $annotations = [];
 
@@ -670,12 +668,12 @@ class RestActionReader
     /**
      * Reads method annotations.
      *
-     * @param ReflectionMethod $reflectionMethod
-     * @param string           $annotationName
+     * @param \ReflectionMethod $reflectionMethod
+     * @param string            $annotationName
      *
      * @return RouteAnnotation|null
      */
-    private function readMethodAnnotation(ReflectionMethod $reflectionMethod, $annotationName)
+    private function readMethodAnnotation(\ReflectionMethod $reflectionMethod, $annotationName)
     {
         $annotationClass = "FOS\\RestBundle\\Controller\\Annotations\\$annotationName";
 
@@ -687,12 +685,12 @@ class RestActionReader
     /**
      * Reads method annotations.
      *
-     * @param ReflectionMethod $reflectionMethod
-     * @param string           $annotationName
+     * @param \ReflectionMethod $reflectionMethod
+     * @param string            $annotationName
      *
      * @return RouteAnnotation[]
      */
-    private function readMethodAnnotations(ReflectionMethod $reflectionMethod, $annotationName)
+    private function readMethodAnnotations(\ReflectionMethod $reflectionMethod, $annotationName)
     {
         $annotations = [];
         $annotationClass = "FOS\\RestBundle\\Controller\\Annotations\\$annotationName";

--- a/Tests/Fixtures/Controller/ParamConverterController.php
+++ b/Tests/Fixtures/Controller/ParamConverterController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+/**
+ * @author Toni Van de Voorde <toni.vdv@gmail.com>
+ */
+class ParamConverterController
+{
+    /**
+     * @ParamConverter("something", converter="fos_rest.request_body")
+     *
+     * @param Something $something
+     */
+    public function postSomethingAction(Something $something)
+    {
+    }
+}
+
+final class Something
+{
+    public $id;
+}

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -378,9 +378,7 @@ class RestRouteLoaderTest extends LoaderTest
         $collection = $this->loadFromControllerFixture('ParamConverterController');
 
         $this->assertNotNull($collection->get('post_something'), 'route for "post_something" does not exist');
-        $this->assertEquals('/somethings.{_format}', $collection->get('post_something')->getPath());
-
-        $this->assertTrue(true);
+        $this->assertSame('/somethings.{_format}', $collection->get('post_something')->getPath());
     }
 
     /**

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -371,6 +371,19 @@ class RestRouteLoaderTest extends LoaderTest
     }
 
     /**
+     * @see https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1198
+     */
+    public function testParamConverterIsIgnoredInRouteGenerationCorrectly()
+    {
+        $collection = $this->loadFromControllerFixture('ParamConverterController');
+
+        $this->assertNotNull($collection->get('post_something'), 'route for "post_something" does not exist');
+        $this->assertEquals('/somethings.{_format}', $collection->get('post_something')->getPath());
+
+        $this->assertTrue(true);
+    }
+
+    /**
      * Load routes collection from fixture class under Tests\Fixtures directory.
      *
      * @param string $fixtureName     name of the class fixture


### PR DESCRIPTION
### This is an update on PR #1771 with the missing test case. All credits should go to @Parent5446 

When fetching a list of function parameters from a controller action
for use as URL parameters, check for the @ParamConverter
annotation. If a parameter has the annotation with the
"fos_rest.request_body" converter, then ignore it and do not include
it in the list of parameters (thus removing it from the URL).

This allows automatic route generation and ParamConverter to co-exist,
as otherwise a parameter that is expected to be derived from the body
would also be included as a URL parameter, requiring the developer to
manually specify the route.

fixes #1198