### PR TITLE
Fix typo in RuntimeException

### DIFF
--- a/Util/ResolverTrait.php
+++ b/Util/ResolverTrait.php
@@ -54,7 +54,6 @@ trait ResolverTrait
             throw new \RuntimeException(sprintf(
                     'The container parameter "%s" must be a string or numeric, but it is of type %s.',
                     $match[1],
-                    $value,
                     gettype($resolved)
                 )
             );


### PR DESCRIPTION
There was 3 variables for 2 placeholders