### PR TITLE
Ordering controllers by filename before load their routes

### DIFF
--- a/Routing/Loader/DirectoryRouteLoader.php
+++ b/Routing/Loader/DirectoryRouteLoader.php
@@ -49,7 +49,7 @@ class DirectoryRouteLoader extends Loader
 
         $finder = new Finder();
 
-        foreach ($finder->in($resource)->name('*.php')->files() as $file) {
+        foreach ($finder->in($resource)->name('*.php')->sortByName()->files() as $file) {
             if ($class = ClassUtils::findClassInFile($file)) {
                 $imported = $this->processor->importResource($this, $class, array(), null, null, 'rest');
                 $collection->addCollection($imported);


### PR DESCRIPTION
Loading routes from all controllers in a directory:

---
    api:
        resource: "@AppBundle/Controller/"
        type: rest
---

The controllers are not loaded in order and this generates different routes lists for different deployments.

This produces different FOSJsRoutingBundle static javascript file for each deploy, using "fos:js-routing:dump".

When combining javascripts files using hash based file name, it will generate different file names per deploy, affecting multiple equal deploys behind a load balancer, trying to load a javascript file that only exists in one of the servers.

My change is to order the controllers by file name, like symfony is doing loading its controllers from a directory:

Symfony\Component\Routing\Loader\AnnotationDirectoryLoader

---
        usort($files, function (\SplFileInfo $a, \SplFileInfo $b) {
            return (string) $a > (string) $b ? 1 : -1;
        });
---

I think this change is harmless, because right now the load is random, and it will avoid this kind of problems.