### PR TITLE
Drop jms/serializer <1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "conflict": {
         "sensio/framework-extra-bundle": "<3.0.13",
         "jms/serializer-bundle": "<2.0.0",
-        "jms/serializer": "1.3.0"
+        "jms/serializer": "<1.13.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
~~`GraphNavigatorInterface` has been introduced in JMS Serializer v1.12.0. We should use `GraphNavigator` instead to maintain backward compatibility with v1.11.0 and lower.~~

#1899 breaks compatibility with `jms/serializer <1.13.0` by using:

- `JMS\Serializer\GraphNavigatorInterface` (>=1.12)
- `JMS\Serializer\Context::hasAttribute()` (>=1.13)
- `JMS\Serializer\Context::getAttribute()` (>=1.13)

However, it is still possible to install older version of `jms/serializer` together with FOSRestBundle. This PR fixes it by updating a `conflict` constraint. 