### PR TITLE
Mark deprecated since Symfony 4.2 for Controller

### DIFF
--- a/Controller/AbstractFOSRestController.php
+++ b/Controller/AbstractFOSRestController.php
@@ -36,7 +36,7 @@ abstract class AbstractFOSRestController extends AbstractController
     }
 
     /**
-     *
+     * @inheritdoc
      *
      * @return array
      */

--- a/Controller/AbstractFOSRestController.php
+++ b/Controller/AbstractFOSRestController.php
@@ -12,16 +12,12 @@
 namespace FOS\RestBundle\Controller;
 
 use FOS\RestBundle\View\ViewHandlerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 /**
  * Controllers using the View functionality of FOSRestBundle.
- *
- * @deprecated when used with Symfony 4.2, use {@see AbstractFOSRestController} instead.
- *
- * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-abstract class FOSRestController extends Controller
+abstract class AbstractFOSRestController extends AbstractController
 {
     use ControllerTrait;
 

--- a/Controller/AbstractFOSRestController.php
+++ b/Controller/AbstractFOSRestController.php
@@ -34,4 +34,17 @@ abstract class AbstractFOSRestController extends AbstractController
 
         return $this->viewhandler;
     }
+
+    /**
+     *
+     *
+     * @return array
+     */
+    public static function getSubscribedServices()
+    {
+        $subscribedServices = parent::getSubscribedServices();
+        $subscribedServices['fos_rest.view_handler'] = ViewHandlerInterface::class;
+
+        return $subscribedServices;
+    }
 }

--- a/Controller/AbstractFOSRestController.php
+++ b/Controller/AbstractFOSRestController.php
@@ -36,7 +36,7 @@ abstract class AbstractFOSRestController extends AbstractController
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      *
      * @return array
      */

--- a/Controller/FOSRestController.php
+++ b/Controller/FOSRestController.php
@@ -17,7 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 /**
  * Controllers using the View functionality of FOSRestBundle.
  *
- * @deprecated when used with Symfony 4.2, use {@see AbstractFOSRestController} instead.
+ * @deprecated since FOSRestBundle 2.5, use {@see AbstractFOSRestController} instead
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */


### PR DESCRIPTION
Create new `AbstractFOSRestController` and mark `FOSRestController` as deprecated because `Symfony\Bundle\FrameworkBundle\Controller\Controller` is deprecated in Symfony 4.2