### PR TITLE
Depreciate null validator on ParamFetcher constructor

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -52,6 +52,10 @@ class ParamFetcher implements ParamFetcherInterface
      */
     public function __construct(ContainerInterface $container, ParamReaderInterface $paramReader, RequestStack $requestStack, ValidatorInterface $validator = null)
     {
+        if (null === $validator) {
+            @trigger_error(sprintf('Using no validator is deprecated since FOSRestBundle 2.6. The `$validator` constructor argument of the `%s` will become mandatory in 3.0.', __CLASS__), E_USER_DEPRECATED);
+        }
+
         $this->container = $container;
         $this->requestStack = $requestStack;
         $this->validator = $validator;

--- a/Tests/Request/ParamFetcherTest.php
+++ b/Tests/Request/ParamFetcherTest.php
@@ -83,6 +83,15 @@ class ParamFetcherTest extends TestCase
         $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
     }
 
+    /**
+     * @expectedDeprecation Using no validator is deprecated since FOSRestBundle 2.6. The `$validator` constructor argument of the `FOS\RestBundle\Request\ParamFetcher` will become mandatory in 3.0.
+     * @group legacy
+     */
+    public function testConstructorCallWithNullValidatorShouldTriggerDeprecation()
+    {
+        new ParamFetcher($this->container, $this->paramReader, $this->requestStack, null);
+    }
+
     public function testParamDynamicCreation()
     {
         $fetcher = $this->paramFetcherBuilder->getMock();
@@ -165,6 +174,8 @@ class ParamFetcherTest extends TestCase
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage The ParamFetcher requirements feature requires the symfony/validator component.
+     *
+     * @group legacy
      */
     public function testEmptyValidator()
     {


### PR DESCRIPTION
Depreciate null validator on ParamFetcher constructor to remove runtime check (see below) at the next major version.

https://github.com/FriendsOfSymfony/FOSRestBundle/blob/a5fc73b84bdb2f0fdf58a717b322ceb6997f7bf3/Request/ParamFetcher.php#L137