### PR TITLE
Add validation groups callback

### DIFF
--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -108,7 +108,13 @@ class RequestBodyParamConverter implements ParamConverterInterface
         if (null !== $this->validator && (!isset($options['validate']) || $options['validate'])) {
             $validatorOptions = $this->getValidatorOptions($options);
 
-            $errors = $this->validator->validate($object, null, $validatorOptions['groups']);
+            $groups = $validatorOptions['groups'];
+            if (\is_callable($groups)) {
+                // If the groups option is callable, resolve it
+                $groups = $groups($object, $request);
+            }
+
+            $errors = $this->validator->validate($object, null, $groups);
 
             $request->attributes->set(
                 $this->validationErrorsArgument,

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -150,6 +150,30 @@ class RequestBodyParamConverterTest extends TestCase
         $this->assertEquals('fooError', $request->attributes->get('errors'));
     }
 
+    public function testValidatorGroupsCallback()
+    {
+        $this->serializer
+             ->expects($this->once())
+             ->method('deserialize')
+             ->willReturn('Object');
+
+        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')->getMock();
+        $validator
+            ->expects($this->once())
+            ->method('validate')
+            ->with('Object', null, ['Group', 'Object', 'json']);
+
+        $converter = new RequestBodyParamConverter($this->serializer, null, null, $validator, 'errors');
+
+        $groupsCallback = static function ($object, Request $request) {
+            return ['Group', $object, $request->getContentType()];
+        };
+
+        $request = $this->createRequest(null, 'application/json');
+        $configuration = $this->createConfiguration(null, null, ['validator' => ['groups' => $groupsCallback]]);
+        $this->launchExecution($converter, $request, $configuration);
+    }
+
     public function testValidatorSkipping()
     {
         $this->serializer


### PR DESCRIPTION
I've got the need to allow the validation groups to be set after the request body is deserialised.

This allows the validator groups option to be callable and resolve the groups just before the validator runs.