### PR TITLE
Added path version resolver, to resolve versions passed via URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * deprecated using the `ParamFetcher` class without passing a validator as the third argument, this
   argument will become mandatory in 3.0
+* added `PathVersionResolver` for better version resolution when version is passed via placeholder in URI
 
 2.5.0
 -----

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -397,19 +397,28 @@ final class Configuration implements ConfigurationInterface
                                     ->scalarNode('regex')->defaultValue('/(v|version)=(?P<version>[0-9\.]+)/')->end()
                                 ->end()
                             ->end()
+                            ->arrayNode('path')
+                                ->canBeDisabled()
+                                ->children()
+                                    ->scalarNode('regex')
+                                        ->defaultValue('/\\/(?P<version>v?[0-9\.]+)\\//')
+                                        ->info('If your version is in path like so /api/{version}/action the following regex could be used: /^\\/api\/(?P<version>v?[0-9\\.]+)\\//')
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode('guessing_order')
-                        ->defaultValue(['query', 'custom_header', 'media_type'])
+                        ->defaultValue(['query', 'custom_header', 'media_type', 'path'])
                         ->validate()
                             ->ifTrue(function ($v) {
                                 foreach ($v as $resolver) {
-                                    if (!in_array($resolver, ['query', 'custom_header', 'media_type'])) {
+                                    if (!in_array($resolver, ['query', 'custom_header', 'media_type', 'path'])) {
                                         return true;
                                     }
                                 }
                             })
-                            ->thenInvalid('Versioning guessing order can only contain "query", "custom_header", "media_type".')
+                            ->thenInvalid('Versioning guessing order can only contain "query", "custom_header", "media_type", "path".')
                         ->end()
                         ->prototype('scalar')->end()
                     ->end()

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -218,6 +218,10 @@ class FOSRestExtension extends Extension
                 $resolvers['media_type'] = $container->getDefinition('fos_rest.versioning.media_type_resolver');
                 $resolvers['media_type']->replaceArgument(0, $config['versioning']['resolvers']['media_type']['regex']);
             }
+            if ($config['versioning']['resolvers']['path']['enabled']) {
+                $resolvers['path'] = $container->getDefinition('fos_rest.versioning.path_resolver');
+                $resolvers['path']->replaceArgument(0, $config['versioning']['resolvers']['path']['regex']);
+            }
 
             $chainResolver = $container->getDefinition('fos_rest.versioning.chain_resolver');
             foreach ($config['versioning']['guessing_order'] as $resolver) {

--- a/Resources/config/versioning.xml
+++ b/Resources/config/versioning.xml
@@ -28,6 +28,10 @@
             <argument /> <!-- regex -->
         </service>
 
+        <service id="fos_rest.versioning.path_resolver" class="FOS\RestBundle\Version\Resolver\PathVersionResolver" public="false">
+            <argument /> <!-- regex -->
+        </service>
+
         <service id="fos_rest.versioning.query_parameter_resolver" class="FOS\RestBundle\Version\Resolver\QueryParameterVersionResolver" public="false">
             <argument /> <!-- request parameter name -->
         </service>

--- a/Tests/Functional/Bundle/TestBundle/Controller/VersionPrefixController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/VersionPrefixController.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use FOS\RestBundle\Controller\AbstractFOSRestController;
+use FOS\RestBundle\Controller\Annotations\Get;
+use FOS\RestBundle\Controller\Annotations\Version;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * @Version({"1.2"})
+ */
+class VersionPrefixController extends AbstractFOSRestController
+{
+    /**
+     * @Get("/version")
+     */
+    public function versionAction($version)
+    {
+        return new JsonResponse(array('version' => $version));
+    }
+}

--- a/Tests/Functional/Bundle/TestBundle/Resources/config/rest_routing.yml
+++ b/Tests/Functional/Bundle/TestBundle/Resources/config/rest_routing.yml
@@ -1,0 +1,3 @@
+test_version_prefix:
+    resource: FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller\VersionPrefixController
+    type: rest

--- a/Tests/Functional/RoutingConditionsTest.php
+++ b/Tests/Functional/RoutingConditionsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FOS\RestBundle\Tests\Functional;
+
+class RoutingConditionsTest extends WebTestCase
+{
+    private $client;
+
+    public function setUp()
+    {
+        $this->client = $this->createClient(['test_case' => 'RoutingConditions']);
+    }
+
+    public function testVersionInPathWithPrefix()
+    {
+        $this->client->request(
+            'GET',
+            '/api/1.2/version',
+            [],
+            [],
+            ['HTTP_Accept' => 'application/json']
+        );
+        $this->assertEquals(
+            '{"version":"1.2"}',
+            $this->client->getResponse()->getContent()
+        );
+    }
+}

--- a/Tests/Functional/app/RoutingConditions/bundles.php
+++ b/Tests/Functional/app/RoutingConditions/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \FOS\RestBundle\FOSRestBundle(),
+    new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
+];

--- a/Tests/Functional/app/RoutingConditions/config.yml
+++ b/Tests/Functional/app/RoutingConditions/config.yml
@@ -1,0 +1,16 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    serializer:
+        enabled: true
+    router: { resource: "%kernel.root_dir%/RoutingConditions/routing.yml" }
+
+fos_rest:
+    versioning:
+        default_version: 3.4.2
+        resolvers:
+            path:
+                regex: '/^\/api\/(?P<version>v?[0-9\.]+)\//'
+        guessing_order:
+            - path

--- a/Tests/Functional/app/RoutingConditions/routing.yml
+++ b/Tests/Functional/app/RoutingConditions/routing.yml
@@ -1,0 +1,4 @@
+test_rest_prefix_routes:
+    resource: "@TestBundle/Resources/config/rest_routing.yml"
+    type: rest
+    prefix: /api/{version}

--- a/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
+++ b/Tests/Routing/Loader/RestXmlCollectionLoaderTest.php
@@ -138,7 +138,7 @@ class RestXmlCollectionLoaderTest extends LoaderTest
         $collection = $this->loadFromXmlCollectionFixture('routes_with_options_requirements_and_defaults.xml');
 
         foreach ($collection as $route) {
-            $this->assertSame('true', $route->getOption('expose'));
+            $this->assertTrue($route->getOption('expose'));
             $this->assertEquals('[a-z]+', $route->getRequirement('slug'));
             $this->assertEquals('home', $route->getDefault('slug'));
         }

--- a/Tests/Version/Resolver/PathVersionResolverTest.php
+++ b/Tests/Version/Resolver/PathVersionResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace FOS\RestBundle\Tests\Version\Resolver;
+
+use FOS\RestBundle\Version\Resolver\PathVersionResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class PathVersionResolverTest extends TestCase
+{
+    /**
+     * @covers \FOS\RestBundle\Version\Resolver\PathVersionResolver
+     */
+    public function testResolve()
+    {
+        $resolver = new PathVersionResolver('/^\\/api\\/(?P<version>v?[0-9\.]+)\\//');
+
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/api/v2/some/action']);
+        $version = $resolver->resolve($request);
+
+        $this->assertEquals('v2', $version);
+
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/api/v2.7/some/action']);
+        $version = $resolver->resolve($request);
+
+        $this->assertEquals('v2.7', $version);
+
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/api/1/some/action']);
+        $version = $resolver->resolve($request);
+
+        $this->assertEquals('1', $version);
+
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/api/1.1.1/some/action']);
+        $version = $resolver->resolve($request);
+
+        $this->assertEquals('1.1.1', $version);
+
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/api/some/action']);
+        $version = $resolver->resolve($request);
+
+        $this->assertEquals(false, $version);
+    }
+}

--- a/Version/Resolver/PathVersionResolver.php
+++ b/Version/Resolver/PathVersionResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Version\Resolver;
+
+use FOS\RestBundle\Version\VersionResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class PathVersionResolver implements VersionResolverInterface
+{
+    /**
+     * @var string
+     */
+    private $regex;
+
+    /**
+     * Constructor.
+     *
+     * If your version is in path like so /api/{version}/action the following regex could be used:
+     * /^\/api\/(?P<version>v?[0-9\.]+)\//
+     *
+     * @param string $regex regex containing a group which will result in matches containing 'version' key
+     */
+    public function __construct($regex)
+    {
+        $this->regex = $regex;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request)
+    {
+        $path = $request->getPathInfo();
+
+        if (false === preg_match($this->regex, $path, $matches)) {
+            return false;
+        }
+
+        return isset($matches['version']) ? $matches['version'] : false;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,12 @@
         "willdurand/jsonp-callback-validator": "^1.0"
     },
     "require-dev": {
+        "doctrine/common": "^2.2",
         "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0",
         "symfony/phpunit-bridge": "^4.1.8",
         "symfony/asset": "^3.4|^4.0",
         "symfony/form": "^3.4|^4.0",
+        "symfony/framework-bundle": "^3.4|^4.0,<4.3",
         "symfony/validator": "^3.4|^4.0",
         "symfony/serializer": "^2.7.11|^3.0.4|^4.0",
         "symfony/yaml": "^3.4|^4.0",


### PR DESCRIPTION
### What is the problem
When controller has `@Version` annotation, in some cases the routes for that controller are generated using *requirements* and in others using *conditions* (not sure if this is intended, or can be normalized in a better way, as I'm not expert in routing). 

I have setup the situation in this MR when routing condition DOES get generated in which case the request fails with `404 Not Found` when version is passed via URI path. This is because none of the existing resolvers resolve the path version, so the `Request->attributes['version']` is set to default. Then, during routing, the *condition* evaluation tries uses the `Request->attributes['version']` for matching, which fails because the default version does not match the values from `@Version` annotation. 

> \FOS\RestBundle\Routing\Loader\Reader\RestActionReader::getVersionCondition() sets up the conditions

You can reproduce this by executing `\FOS\RestBundle\Tests\Functional\RoutingConditionsTest::testVersionInPathWithPrefix` and disabling the `path` resolver in `Tests/Functional/app/RoutingConditions/config.yml`.

### What This PR Does
1. Adds `PathVersionResolver`, which is a regex based resolver intended to resolve version passed via URI path prior to `RouterListener` execution.
2. Adds configuration options to customize guessing order and the regex for this resolver
3. Limit *symfony/framework-bundle* in **require-dev** to `<4.3`
    * in 4.3 they introduced static `$client` property in WebTestCase which breaks all tests
4. Fixed Tests/Routing/Loader/RestXmlCollectionLoaderTest.php asserting `'true' === true`
5. Add `doctrine/common` dependency. It was probably sub-dependency of another package previously, but now seems to be missing so tests are failing.
### Other Thoughts
* If you move the **prefix** option from `Tests/Functional/app/RoutingConditions/routing.yml` to `Tests/Functional/Bundle/TestBundle/Resources/config/rest_routing.yml` instead of *condition*, the routes are generated with *requirement* and everything works as expected, because *requirement* does not rely on *version* request attribute (which in this case is still be set to the default value during routing).
* CI failing due to deprecation in recently updated bundles. Sorry, don't have time to fix them here.