### PR TITLE
Update 2-the-view-layer.rst

### DIFF
--- a/Resources/doc/2-the-view-layer.rst
+++ b/Resources/doc/2-the-view-layer.rst
@@ -29,9 +29,9 @@ which adds several convenience methods:
 
     namespace AppBundle\Controller;
 
-    use FOS\RestBundle\Controller\FOSRestController;
+    use FOS\RestBundle\Controller\AbstractFOSRestController;
 
-    class UsersController extends FOSRestController
+    class UsersController extends AbstractFOSRestController
     {
         public function getUsersAction()
         {


### PR DESCRIPTION
According to description of https://github.com/FriendsOfSymfony/FOSRestBundle/releases/tag/2.5.0 class AbstractFOSRestController should be used instead of FOSRestController.