### PR TITLE
[DOC] Adds missing use statement in order to constraints

### DIFF
--- a/Resources/doc/param_fetcher_listener.rst
+++ b/Resources/doc/param_fetcher_listener.rst
@@ -20,6 +20,7 @@ configured for the matched controller so that the user does not need to do this 
     use FOS\RestBundle\Controller\Annotations\RequestParam;
     use FOS\RestBundle\Controller\Annotations\QueryParam;
     use FOS\RestBundle\Controller\Annotations\FileParam;
+    use Symfony\Component\Validator\Constraints;
     use Acme\FooBundle\Validation\Constraints\MyComplexConstraint;
 
     class FooController extends Controller


### PR DESCRIPTION
use statement is required to use Symfony constraints in the requirements annotations