### PR TITLE
Fix removal of fos_rest.exception.twig_controller when templating/twig is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * deprecated using the `ParamFetcher` class without passing a validator as the third argument, this
   argument will become mandatory in 3.0
+* fix compatiblity without the deprecated templating in Symfony 4.3; see #2012 on how to configure the FOSRestBundle
 
 2.5.0
 -----

--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -38,7 +38,8 @@ class FOSRestBundle extends Bundle
         $container->addCompilerPass(new SerializerConfigurationPass());
         $container->addCompilerPass(new ConfigurationCheckPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
         $container->addCompilerPass(new FormatListenerRulesPass());
-        $container->addCompilerPass(new TwigExceptionPass());
+        // must run after \Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\ExtensionPass which removes the templating.engine.twig service when templating is not enabled
+        $container->addCompilerPass(new TwigExceptionPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
         $container->addCompilerPass(new JMSFormErrorHandlerPass());
         $container->addCompilerPass(new JMSHandlersPass(), PassConfig::TYPE_BEFORE_REMOVING, -10);
         $container->addCompilerPass(new HandlerRegistryDecorationPass(), PassConfig::TYPE_AFTER_REMOVING);


### PR DESCRIPTION
Fixes #1772, #1887, #1945, #2002

With that you can remove 

```
framework:
    templating:
        engines: twig
```

which fixes the deprecations and it will use `\FOS\RestBundle\Controller\ExceptionController` instead of `\FOS\RestBundle\Controller\TwigExceptionController` correctly. This in turn means it does not use the TwigBundle error rendering but the implementation using the Serializer (Symfony or JMS). But the error response stays the same because of `\FOS\RestBundle\Serializer\Normalizer\ExceptionHandler::convertToArray` (or the equivalent for Symfony serializer).
So people can disable templating and twig and it should still be BC. If people use TwigBundle but want to disable SF templating part to get rid of deprecations, they need to set

```
fos_rest:
    exception:
        exception_controller: 'fos_rest.exception.controller::showAction'
```

because otherwise the unwanted twig controller get's used again: https://github.com/FriendsOfSymfony/FOSRestBundle/blob/6013d5131f94cd7367c423e52bdfb83c4f0613f9/DependencyInjection/FOSRestExtension.php#L360-L367