### PR TITLE
Ignore SessionInterface and UserInterface controller action arguments

### DIFF
--- a/Routing/Loader/Reader/RestActionReader.php
+++ b/Routing/Loader/Reader/RestActionReader.php
@@ -20,7 +20,9 @@ use FOS\RestBundle\Routing\RestRouteCollection;
 use Psr\Http\Message\MessageInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
@@ -528,11 +530,13 @@ class RestActionReader
 
         // ignore several type hinted arguments
         $ignoreClasses = [
-            Request::class,
-            ParamFetcherInterface::class,
             ConstraintViolationListInterface::class,
-            ParamConverter::class,
             MessageInterface::class,
+            ParamConverter::class,
+            ParamFetcherInterface::class,
+            Request::class,
+            SessionInterface::class,
+            UserInterface::class,
         ];
 
         $arguments = [];

--- a/Tests/Fixtures/Controller/UsersController.php
+++ b/Tests/Fixtures/Controller/UsersController.php
@@ -11,8 +11,14 @@
 
 namespace FOS\RestBundle\Tests\Fixtures\Controller;
 
+use FOS\RestBundle\Request\ParamFetcher;
+use Psr\Http\Message\MessageInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 class UsersController extends AbstractController
 {
@@ -290,6 +296,25 @@ class UsersController extends AbstractController
      */
     public function getUserFoosAction($slug, Request $request)
     {
+    }
+
+    // Other ignored parameter types
+
+    /**
+     * [GET] /users/{slug}/bars.
+     *
+     * @param ParamFetcher $paramFetcher
+     * @param $slug
+     */
+    public function getUserBarsAction(
+        ParamFetcher $paramFetcher,
+        MessageInterface $message,
+        ParamConverter $paramConverter,
+        SessionInterface $session,
+        UserInterface $user,
+        ConstraintViolationList $constraintViolationList,
+        $slug
+    ) {
     }
 
     /**

--- a/Tests/Fixtures/Etalon/users_controller.yml
+++ b/Tests/Fixtures/Etalon/users_controller.yml
@@ -128,6 +128,11 @@ get_user_foos:
   path:    /users/{slug}/foos.{_format}
   controller: ::getUserFoosAction
 
+get_user_bars:
+  methods: [GET]
+  path:    /users/{slug}/bars.{_format}
+  controller: ::getUserBarsAction
+
 get_categories:
   methods: [GET]
   path:    /categories.{_format}

--- a/Tests/Routing/Loader/RestRouteLoaderTest.php
+++ b/Tests/Routing/Loader/RestRouteLoaderTest.php
@@ -29,7 +29,7 @@ class RestRouteLoaderTest extends LoaderTest
         $etalonRoutes = $this->loadEtalonRoutesInfo('users_controller.yml');
 
         $this->assertInstanceOf(RestRouteCollection::class, $collection);
-        $this->assertCount(32, $collection->all());
+        $this->assertCount(33, $collection->all());
 
         foreach ($etalonRoutes as $name => $params) {
             $route = $collection->get($name);


### PR DESCRIPTION
Route creation relies on controller actions' method arguments for a couple of things.. as such, some commonly injected arguments [are already filtered](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/e1f91266ca37e423dfae9ec4e641b247fdb2915d/Routing/Loader/Reader/RestActionReader.php#L530-L536). 
This PR includes two more commonly injected interfaces to the exclusion list, as seen in the [list of Symfony's built-in arguments resolvers](https://symfony.com/doc/3.4/controller/argument_value_resolver.html#built-in-value-resolvers).
 
Route name and path can be easily overwritten so this PR is usually easily workaround-able, but there's still one feature which relies on action arguments: controller hierarchy.
It needs at least one method [having exactly one argument](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/e1f91266ca37e423dfae9ec4e641b247fdb2915d/Routing/Loader/Reader/RestActionReader.php#L273-L275) on the parent controller, else you'd face a cryptic exception (#1185) later on during route generation for the child controller.

Moreover, aside from this PR, I feel there still is an open point with "uncommon" injected services (#1733) as sometimes injecting everything in the constructor may not be an option. Using the `@RouteResource` annotation was proposed in the past (#1764) but maybe it lacked the *"this fixes relying on having at least a method with exactly one argument"*.

If @Tobion agrees I'd like to work on an additional PR, following one or both of these approaches:
- resurrecting #1764, adding some test and writing a more helpful error message for the hierarchy exception pointing to the annotation;
- exclude arguments which are injected services, not by config as in #1733 but mimic-ing the [service injector itself](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php#L66-L75) to identify those arguments - we should already have everything that's need (container, `_controller` and the argument name).