### PR TITLE
Use twig as templating engine when available

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationCheckPass.php
+++ b/DependencyInjection/Compiler/ConfigurationCheckPass.php
@@ -39,10 +39,10 @@ final class ConfigurationCheckPass implements CompilerPassInterface
 
         if (!$container->has((string) $container->getAlias('fos_rest.templating'))) {
             $container->removeAlias('fos_rest.templating');
-        }
 
-        if ($container->hasDefinition('twig')) {
-            $container->setAlias('fos_rest.templating', 'twig');
+            if ($container->hasDefinition('twig')) {
+                $container->setAlias('fos_rest.templating', 'twig');
+            }
         }
     }
 }

--- a/DependencyInjection/Compiler/ConfigurationCheckPass.php
+++ b/DependencyInjection/Compiler/ConfigurationCheckPass.php
@@ -40,5 +40,9 @@ final class ConfigurationCheckPass implements CompilerPassInterface
         if (!$container->has((string) $container->getAlias('fos_rest.templating'))) {
             $container->removeAlias('fos_rest.templating');
         }
+
+        if ($container->hasDefinition('twig')) {
+            $container->setAlias('fos_rest.templating', 'twig');
+        }
     }
 }

--- a/DependencyInjection/Compiler/ConfigurationCheckPass.php
+++ b/DependencyInjection/Compiler/ConfigurationCheckPass.php
@@ -38,10 +38,10 @@ final class ConfigurationCheckPass implements CompilerPassInterface
         }
 
         if (!$container->has((string) $container->getAlias('fos_rest.templating'))) {
-            $container->removeAlias('fos_rest.templating');
-
-            if ($container->hasDefinition('twig')) {
+            if ($container->has('twig')) {
                 $container->setAlias('fos_rest.templating', 'twig');
+            } else {
+                $container->removeAlias('fos_rest.templating');
             }
         }
     }

--- a/Tests/Functional/ConfigurationTest.php
+++ b/Tests/Functional/ConfigurationTest.php
@@ -24,9 +24,17 @@ class ConfigurationTest extends WebTestCase
         $this->assertFalse($container->has('fos_rest.templating'));
     }
 
+    public function testEnabledTemplatingWithTwig()
+    {
+        $kernel = self::bootKernel(['test_case' => 'ConfigurationWithTwig']);
+        $container = $kernel->getContainer();
+
+        $this->assertTrue($container->has('fos_rest.templating'));
+    }
+
     public function testToolbar()
     {
-        $client = $this->createClient(['test_case' => 'Configuration']);
+        $client = $this->createClient(['test_case' => 'ConfigurationWithTwig']);
         $client->request(
                 'GET',
                 '/_profiler/empty/search/results?limit=10',

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -40,6 +40,7 @@ while ($dir !== $lastDir) {
 
 use Psr\Log\NullLogger;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
@@ -49,7 +50,7 @@ use Symfony\Component\HttpKernel\Kernel;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class AppKernel extends Kernel
+class AppKernel extends Kernel implements CompilerPassInterface
 {
     private $testCase;
     private $rootConfig;
@@ -120,5 +121,13 @@ class AppKernel extends Kernel
         $parameters['kernel.test_case'] = $this->testCase;
 
         return $parameters;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        // Avoid inlining of fos_rest.templating service to test if service really exist
+        if ($container->has('fos_rest.templating')) {
+            $container->getAlias('fos_rest.templating')->setPublic(true);
+        }
     }
 }

--- a/Tests/Functional/app/Configuration/config.yml
+++ b/Tests/Functional/app/Configuration/config.yml
@@ -12,7 +12,7 @@ framework:
 fos_rest:
     view:
         mime_types: true
-        view_response_listener: true
+        view_response_listener: false
     param_fetcher_listener: true
     disable_csrf_role: foo
     allowed_methods_listener: true
@@ -26,9 +26,3 @@ fos_rest:
         rules:
             - { path: '^/', priorities: ['xml'], fallback_format: ~ }
     versioning: true
-
-web_profiler:
-    toolbar: true
-
-twig:
-    strict_variables: '%kernel.debug%'

--- a/Tests/Functional/app/ConfigurationWithTwig/bundles.php
+++ b/Tests/Functional/app/ConfigurationWithTwig/bundles.php
@@ -11,6 +11,8 @@
 
 return [
     new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \Symfony\Bundle\TwigBundle\TwigBundle(),
+    new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle(),
     new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
     new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
     new \FOS\RestBundle\FOSRestBundle(),

--- a/Tests/Functional/app/ConfigurationWithTwig/config.yml
+++ b/Tests/Functional/app/ConfigurationWithTwig/config.yml
@@ -1,0 +1,12 @@
+imports:
+    - { resource: ../Configuration/config.yml }
+
+fos_rest:
+    view:
+        view_response_listener: true
+
+web_profiler:
+    toolbar: false
+
+twig:
+    strict_variables: '%kernel.debug%'

--- a/Tests/Functional/app/ConfigurationWithTwig/routing.yml
+++ b/Tests/Functional/app/ConfigurationWithTwig/routing.yml
@@ -1,0 +1,7 @@
+_wdt:
+    resource: "@WebProfilerBundle/Resources/config/routing/wdt.xml"
+    prefix:   /_wdt
+
+_profiler:
+    resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
+    prefix:   /_profiler

--- a/Tests/Functional/app/ConfigurationWithTwig/security.php
+++ b/Tests/Functional/app/ConfigurationWithTwig/security.php
@@ -1,0 +1,23 @@
+<?php
+
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\Controller\UserValueResolver;
+
+$defaultFirewall = [
+    'anonymous' => null,
+];
+
+if (method_exists(Security::class, 'getUser') && !class_exists(UserValueResolver::class)) {
+    $defaultFirewall['logout_on_user_change'] = true;
+}
+
+$container->loadFromExtension('security', [
+    'providers' => [
+        'in_memory' => [
+            'memory' => null,
+        ],
+    ],
+    'firewalls' => [
+        'default' => $defaultFirewall,
+    ],
+]);


### PR DESCRIPTION
Currently if `symfony/templating` is not installed the following error could happen:

> An instance of Symfony\Component\Templating\EngineInterface must be injected in FOS\RestBundle\View\ViewHandler to render templates.

thats because templating is set as default value. If templating is not available but twig it should use twig instead.