### PR TITLE
Fix null prefix in RestYamlCollectionLoader

### DIFF
--- a/Routing/Loader/RestYamlCollectionLoader.php
+++ b/Routing/Loader/RestYamlCollectionLoader.php
@@ -121,7 +121,9 @@ class RestYamlCollectionLoader extends YamlFileLoader
                     $imported->setHost($host);
                 }
 
-                $imported->addPrefix($prefix);
+                if (null !== $prefix) {
+                    $imported->addPrefix($prefix);
+                }
 
                 // Add name prefix from parent config files
                 $imported = $this->addParentNamePrefix($imported, $namePrefix);


### PR DESCRIPTION
```` text
Argument 1 passed to Symfony\Component\Routing\RouteCollection::addPrefix() must be of the type string, null given, called in /home/[...]/[...]/vendor/friendsofsymfony/rest-bundle/Routing/Loader/RestYamlCollectionLoader.php on line 124
````