### PR TITLE
Fixed explicit disabling of serializer max depth checks

### DIFF
--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -104,7 +104,7 @@ class JMSSerializerAdapter implements Serializer
         if (null !== $context->getGroups()) {
             $jmsContext->setGroups($context->getGroups());
         }
-        if (null !== $context->getMaxDepth(false) || null !== $context->isMaxDepthEnabled()) {
+        if (null !== $context->getMaxDepth(false) || true === $context->isMaxDepthEnabled()) {
             $jmsContext->enableMaxDepthChecks();
         }
         if (null !== $context->getSerializeNull()) {

--- a/Tests/Context/ContextTest.php
+++ b/Tests/Context/ContextTest.php
@@ -94,6 +94,20 @@ class ContextTest extends TestCase
         $this->assertEquals(10, $this->context->getMaxDepth());
     }
 
+    public function testEnableMaxDepth()
+    {
+        $this->context->enableMaxDepth();
+
+        $this->assertTrue($this->context->isMaxDepthEnabled());
+    }
+
+    public function testDisableMaxDepth()
+    {
+        $this->context->disableMaxDepth();
+
+        $this->assertFalse($this->context->isMaxDepthEnabled());
+    }
+
     public function testSerializeNull()
     {
         $this->context->setSerializeNull(true);

--- a/Tests/Serializer/JMSSerializerAdapterTest.php
+++ b/Tests/Serializer/JMSSerializerAdapterTest.php
@@ -113,4 +113,18 @@ class JMSSerializerAdapterTest extends TestCase
 
         $this->adapter->serialize('foo', 'json', $fosContext);
     }
+
+    public function testContextDoesNotEnableMaxDepthChecksWhenExplicitlyDisabled()
+    {
+        $jmsContext = $this->getMockBuilder(SerializationContext::class)->getMock();
+
+        $jmsContext->expects($this->never())->method('enableMaxDepthChecks');
+
+        $this->serializationContextFactory->method('createSerializationContext')->willReturn($jmsContext);
+
+        $fosContext = new Context();
+        $fosContext->disableMaxDepth();
+
+        $this->adapter->serialize('foo', 'json', $fosContext);
+    }
 }


### PR DESCRIPTION
JMS Serializer is configured with max depth checking enabled when method `disableMaxDepth` is called in `FOS\RestBundle\Context\Context`.

This PR fixes the behaviour to actually configure serializer without max depth checking enabled in this scenario.