### PR TITLE
Fixed used alias for "FOS\RestBundle\View\ViewHandlerInterface"

### DIFF
--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -20,7 +20,7 @@
             <tag name="kernel.reset" method="reset" />
         </service>
 
-        <service id="FOS\RestBundle\View\ViewHandlerInterface" alias="fos_rest.view_handler.default" />
+        <service id="FOS\RestBundle\View\ViewHandlerInterface" alias="fos_rest.view_handler" />
 
         <service id="fos_rest.view_handler.jsonp" class="FOS\RestBundle\View\JsonpHandler" public="false">
             <argument /> <!-- JSONP callback parameter -->


### PR DESCRIPTION
Changed `FOS\RestBundle\View\ViewHandlerInterface` to be an alias of "fos_rest.view_handler" instead of "fos_rest.view_handler.default". So in case if a custom ViewHandler has been configured under "fos_rest.service.view_handler" it will be used. Before this change, the used ViewHandler of Controller extending the `AbstractFOSRestController` would always have been pointing to `fos_rest.view_handler.default` because the service subscriber definition is `$subscribedServices['fos_rest.view_handler'] = ViewHandlerInterface::class;`.

This should fix #2029 
