### PR TITLE
Changed \Exception to \Throwable for Symfony 4.4 compatibility

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -80,7 +80,7 @@ class ExceptionController
     }
 
     /**
-     * @param \Exception $exception
+     * @param \Throwable $exception
      * @param int        $code
      * @param array      $templateData
      * @param Request    $request
@@ -88,8 +88,14 @@ class ExceptionController
      *
      * @return View
      */
-    protected function createView(\Exception $exception, $code, array $templateData, Request $request, $showException)
+    protected function createView(\Throwable $exception, $code, array $templateData, Request $request, $showException)
     {
+        if (class_exists(FlattenException::class)) {
+            $exception = FlattenException::createFromThrowable($exception);
+        } else {
+            $exception = LegacyFlattenException::create($exception);
+        }
+
         $view = new View($exception, $code, $exception instanceof HttpExceptionInterface ? $exception->getHeaders() : []);
         $view->setTemplateVar('raw_exception', false);
         $view->setTemplateData($templateData, false);
@@ -114,12 +120,12 @@ class ExceptionController
      *
      * @param string               $currentContent
      * @param int                  $code
-     * @param \Exception           $exception
+     * @param \Throwable           $exception
      * @param DebugLoggerInterface $logger
      *
      * @return array
      */
-    private function getTemplateData($currentContent, $code, \Exception $exception, DebugLoggerInterface $logger = null)
+    private function getTemplateData($currentContent, $code, \Throwable $exception, DebugLoggerInterface $logger = null)
     {
         if (class_exists(FlattenException::class)) {
             $exception = FlattenException::createFromThrowable($exception);

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -80,15 +80,15 @@ class ExceptionController
     }
 
     /**
-     * @param \Throwable $exception
-     * @param int        $code
-     * @param array      $templateData
-     * @param Request    $request
-     * @param bool       $showException
+     * @param \Exception|\Throwable     $exception
+     * @param int                       $code
+     * @param array                     $templateData
+     * @param Request                   $request
+     * @param bool                      $showException
      *
      * @return View
      */
-    protected function createView(\Throwable $exception, $code, array $templateData, Request $request, $showException)
+    protected function createView($exception, $code, array $templateData, Request $request, $showException)
     {
         if (class_exists(FlattenException::class)) {
             $exception = FlattenException::createFromThrowable($exception);
@@ -118,14 +118,14 @@ class ExceptionController
     /**
      * Determines the template parameters to pass to the view layer.
      *
-     * @param string               $currentContent
-     * @param int                  $code
-     * @param \Throwable           $exception
-     * @param DebugLoggerInterface $logger
+     * @param string                    $currentContent
+     * @param int                       $code
+     * @param \Exception|\Throwable     $exception
+     * @param DebugLoggerInterface      $logger
      *
      * @return array
      */
-    private function getTemplateData($currentContent, $code, \Throwable $exception, DebugLoggerInterface $logger = null)
+    private function getTemplateData($currentContent, $code, $exception, DebugLoggerInterface $logger = null)
     {
         if (class_exists(FlattenException::class)) {
             $exception = FlattenException::createFromThrowable($exception);

--- a/Controller/TwigExceptionController.php
+++ b/Controller/TwigExceptionController.php
@@ -28,7 +28,7 @@ class TwigExceptionController extends TemplatingExceptionController
     /**
      * {@inheritdoc}
      */
-    protected function createView(\Exception $exception, $code, array $templateData, Request $request, $showException)
+    protected function createView(\Throwable $exception, $code, array $templateData, Request $request, $showException)
     {
         $view = parent::createView($exception, $code, $templateData, $request, $showException);
         $view->setTemplate($this->findTemplate($request, $code, $showException), false);

--- a/Controller/TwigExceptionController.php
+++ b/Controller/TwigExceptionController.php
@@ -28,7 +28,7 @@ class TwigExceptionController extends TemplatingExceptionController
     /**
      * {@inheritdoc}
      */
-    protected function createView(\Throwable $exception, $code, array $templateData, Request $request, $showException)
+    protected function createView($exception, $code, array $templateData, Request $request, $showException)
     {
         $view = parent::createView($exception, $code, $templateData, $request, $showException);
         $view->setTemplate($this->findTemplate($request, $code, $showException), false);


### PR DESCRIPTION
I tested #2093 on my project. I have got this problem:
`Argument 3 passed to FOS\RestBundle\Controller\ExceptionController::getTemplateData() must be an instance of Exception, instance of Error given, called in /home/vagrant/web/projectx/vendor/friendsofsymfony/rest-bundle/Controller/ExceptionController.php on line 74`
I changed \Exception to \Throwable and 1 copy paste it worked

Open for suggestions