### PR TITLE
Fixed exception handling bug in showAction (ExceptionController)

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -70,15 +70,11 @@ class ExceptionController
             $code = $this->getStatusCode($exception);
         } else {
             $code = $this->getStatusCodeFromThrowable($exception);
+            $exception = new \Exception($exception->getMessage(), $code);
         }
         $templateData = $this->getTemplateData($currentContent, $code, $exception, $logger);
-
-        if ($exception instanceof \Exception) {
-            $view = $this->createView($exception, $code, $templateData, $request, $this->showException);
-        } else {
-            $view = $this->createViewFromThrowable($exception, $code, $templateData, $request, $this->showException);
-        }
-
+        $view = $this->createView($exception, $code, $templateData, $request, $this->showException);
+        
         $response = $this->viewHandler->handle($view);
 
         return $response;

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -70,7 +70,7 @@ class ExceptionController
             $code = $this->getStatusCode($exception);
         } else {
             $code = $this->getStatusCodeFromThrowable($exception);
-            $exception = new \Exception($exception->getMessage(), $code);
+            $exception = new \Exception($exception->getMessage(), $code, $exception->getPrevious());
         }
         $templateData = $this->getTemplateData($currentContent, $code, $exception, $logger);
         $view = $this->createView($exception, $code, $templateData, $request, $this->showException);


### PR DESCRIPTION
Refactored showAction in ExceptionController to fix exception handling and a recent thrown exception bug:
`Undefined property : App\Kernel::$freshCache` exception related to jms-serializer

The current exception is being launched on handleView in case of none \Exception instance of an exception.
This  has been **fixed** by transforming all none \Exception instances (such as TypeError) to \Exception.
