### PR TITLE
decorate the exception_listener

### DIFF
--- a/DependencyInjection/Compiler/ErrorListenerPass.php
+++ b/DependencyInjection/Compiler/ErrorListenerPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Handle the error error related listener.
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * @internal
+ */
+final class ErrorListenerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('fos_rest.exception_listener')) {
+            return;
+        }
+
+        if ($container->has('twig.exception_listener')) {
+            $container->getDefinition('fos_rest.exception_listener')->setDecoratedService('twig.exception_listener');
+        } elseif ($container->has('exception_listener')) {
+            $container->getDefinition('fos_rest.exception_listener')->setDecoratedService('exception_listener');
+        }
+    }
+}

--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\EventListener\ExceptionListener as LegacyExceptionListener;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -34,15 +34,20 @@ class ExceptionListener implements EventSubscriberInterface
 {
     private $exceptionListener;
     private $dispatcher;
+    private $innerExceptionListener;
 
-    public function __construct($controller, ?LoggerInterface $logger, EventDispatcherInterface $dispatcher)
+    public function __construct($controller, ?LoggerInterface $logger, $debug = false, EventDispatcherInterface $dispatcher, $innerExceptionListener = null)
     {
-        if (class_exists(ErrorListener::class)) {
-            $this->exceptionListener = new ErrorListener($controller, $logger);
-        } else {
-            $this->exceptionListener = new LegacyExceptionListener($controller, $logger);
-        }
+        $this->exceptionListener = new ErrorListener($controller, $logger, $debug);
         $this->dispatcher = $dispatcher;
+        $this->innerExceptionListener = $innerExceptionListener;
+    }
+
+    public function logKernelException(ExceptionEvent $event)
+    {
+        if ($this->innerExceptionListener) {
+            $this->innerExceptionListener->logKernelException($event);
+        }
     }
 
     public function onKernelException(ExceptionEvent $event): void
@@ -50,7 +55,11 @@ class ExceptionListener implements EventSubscriberInterface
         $request = $event->getRequest();
 
         if (!$request->attributes->get(FOSRestBundle::ZONE_ATTRIBUTE, true)) {
-            return;
+            if (null === $this->innerExceptionListener) {
+                return;
+            }
+
+            return $this->innerExceptionListener->onKernelException($event);
         }
 
         $exception = $event->getThrowable();
@@ -58,6 +67,7 @@ class ExceptionListener implements EventSubscriberInterface
         $controllerArgsListener = function ($event) use (&$controllerArgsListener, $exception) {
             /** @var ControllerArgumentsEvent $event */
             $arguments = $event->getArguments();
+
             foreach ($arguments as $k => $argument) {
                 if ($argument instanceof FlattenException || $argument instanceof LegacyFlattenException) {
                     $arguments[$k] = $exception;
@@ -66,11 +76,27 @@ class ExceptionListener implements EventSubscriberInterface
                     break;
                 }
             }
+
             $this->dispatcher->removeListener(KernelEvents::CONTROLLER_ARGUMENTS, $controllerArgsListener);
         };
-        $this->dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS, $controllerArgsListener, -100);
+
+        $this->dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS, $controllerArgsListener);
 
         $this->exceptionListener->onKernelException($event);
+    }
+
+    public function removeCspHeader(ResponseEvent $event): void
+    {
+        if ($this->innerExceptionListener instanceof ErrorListener) {
+            $this->innerExceptionListener->removeCspHeader($event);
+        }
+    }
+
+    public function onControllerArguments(ControllerArgumentsEvent $event)
+    {
+        if ($this->innerExceptionListener instanceof ErrorListener) {
+            $this->innerExceptionListener->onControllerArguments($event);
+        }
     }
 
     /**
@@ -78,8 +104,6 @@ class ExceptionListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        return array(
-            KernelEvents::EXCEPTION => array('onKernelException', -100),
-        );
+        return ErrorListener::getSubscribedEvents();
     }
 }

--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -13,15 +13,11 @@ namespace FOS\RestBundle\EventListener;
 
 use FOS\RestBundle\FOSRestBundle;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Debug\Exception\FlattenException as LegacyFlattenException;
-use Symfony\Component\ErrorHandler\Exception\FlattenException;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * ExceptionListener.
@@ -33,13 +29,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class ExceptionListener implements EventSubscriberInterface
 {
     private $exceptionListener;
-    private $dispatcher;
     private $innerExceptionListener;
 
-    public function __construct($controller, ?LoggerInterface $logger, $debug = false, EventDispatcherInterface $dispatcher, $innerExceptionListener = null)
+    public function __construct($controller, ?LoggerInterface $logger, $debug = false, $innerExceptionListener = null)
     {
         $this->exceptionListener = new ErrorListener($controller, $logger, $debug);
-        $this->dispatcher = $dispatcher;
         $this->innerExceptionListener = $innerExceptionListener;
     }
 
@@ -55,32 +49,12 @@ class ExceptionListener implements EventSubscriberInterface
         $request = $event->getRequest();
 
         if (!$request->attributes->get(FOSRestBundle::ZONE_ATTRIBUTE, true)) {
-            if (null === $this->innerExceptionListener) {
-                return;
+            if (null !== $this->innerExceptionListener) {
+                $this->innerExceptionListener->onKernelException($event);
             }
 
-            return $this->innerExceptionListener->onKernelException($event);
+            return;
         }
-
-        $exception = $event->getThrowable();
-
-        $controllerArgsListener = function ($event) use (&$controllerArgsListener, $exception) {
-            /** @var ControllerArgumentsEvent $event */
-            $arguments = $event->getArguments();
-
-            foreach ($arguments as $k => $argument) {
-                if ($argument instanceof FlattenException || $argument instanceof LegacyFlattenException) {
-                    $arguments[$k] = $exception;
-                    $event->setArguments($arguments);
-
-                    break;
-                }
-            }
-
-            $this->dispatcher->removeListener(KernelEvents::CONTROLLER_ARGUMENTS, $controllerArgsListener);
-        };
-
-        $this->dispatcher->addListener(KernelEvents::CONTROLLER_ARGUMENTS, $controllerArgsListener);
 
         $this->exceptionListener->onKernelException($event);
     }

--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -12,6 +12,7 @@
 namespace FOS\RestBundle;
 
 use FOS\RestBundle\DependencyInjection\Compiler\ConfigurationCheckPass;
+use FOS\RestBundle\DependencyInjection\Compiler\ErrorListenerPass;
 use FOS\RestBundle\DependencyInjection\Compiler\HandlerRegistryDecorationPass;
 use FOS\RestBundle\DependencyInjection\Compiler\JMSFormErrorHandlerPass;
 use FOS\RestBundle\DependencyInjection\Compiler\JMSHandlersPass;
@@ -34,6 +35,7 @@ class FOSRestBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
+        $container->addCompilerPass(new ErrorListenerPass());
         $container->addCompilerPass(new SerializerConfigurationPass());
         $container->addCompilerPass(new ConfigurationCheckPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
         $container->addCompilerPass(new FormatListenerRulesPass());

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -10,7 +10,9 @@
             <tag name="monolog.logger" channel="request" />
             <argument />
             <argument type="service" id="logger" on-invalid="null" />
+            <argument>%kernel.debug%</argument>
             <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="fos_rest.exception_listener.inner" on-invalid="null" />
         </service>
 
         <service id="fos_rest.exception.controller" class="FOS\RestBundle\Controller\ExceptionController" public="true">

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -11,7 +11,6 @@
             <argument />
             <argument type="service" id="logger" on-invalid="null" />
             <argument>%kernel.debug%</argument>
-            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_rest.exception_listener.inner" on-invalid="null" />
         </service>
 


### PR DESCRIPTION
this seems like a cleaner and also more performant approach.
there is less risk of priorities causing issues etc.

I mostly came to this as part of looking into https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1692 and realizing this is another place where we should decorate. and I needed a simpler task to get into things again :)