### PR TITLE
remove previous exception, add tests for access denied listener

### DIFF
--- a/EventListener/AccessDeniedListener.php
+++ b/EventListener/AccessDeniedListener.php
@@ -74,12 +74,12 @@ class AccessDeniedListener implements EventSubscriberInterface
         }
 
         if ($exception instanceof AccessDeniedException) {
-            $exception = new AccessDeniedHttpException('You do not have the necessary permissions', $exception);
+            $exception = new AccessDeniedHttpException('You do not have the necessary permissions');
         } elseif ($exception instanceof AuthenticationException) {
             if ($this->challenge) {
-                $exception = new UnauthorizedHttpException($this->challenge, 'You are not authenticated', $exception);
+                $exception = new UnauthorizedHttpException($this->challenge, 'You are not authenticated');
             } else {
-                $exception = new HttpException(401, 'You are not authenticated', $exception);
+                $exception = new HttpException(401, 'You are not authenticated');
             }
         }
 


### PR DESCRIPTION
This PR exprovides an alternative fix for https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1692

I tried to decorate the security component exception listener but it does not seem possible since the Firewall context has a typehint on the class (not an interface) on the exception listener (https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php#L30) but the class is also marked as `@final` (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php#L43). As such the fix is essentially a hack by not pass the previous exception to prevent the core listener from doing anything.

open questions
* [ ] instead of removing the previous exception we could also try to call `\Symfony\Component\Security\Http\Firewall\ExceptionListener::unregister()` on the given firewall instead but not sure how easy it is to find the relevant firewall
* [ ] yet another approach could be to somehow try and handle this in our ExceptionListener if https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2108 is merged. ie. use the AccessDeniedListener to set something on the request, so that we do not use the exception that was set in the core security exception listener but the one from the rest bundle AccessDeniedListener