### PR TITLE
decorate the exception_listener - simplification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 branches:
   only:
     - master
+    - decorate-error-listener
     - /^\d+\.(\d+|x)$/
 
 matrix:

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -55,14 +55,13 @@ class ExceptionController
      * Converts an Exception to a Response.
      *
      * @param Request                   $request
-     * @param \Exception|\Throwable     $exception
      * @param DebugLoggerInterface|null $logger
      *
      * @throws \InvalidArgumentException
      *
      * @return Response
      */
-    public function showAction(Request $request, $exception, DebugLoggerInterface $logger = null)
+    public function showAction(Request $request, \Throwable $exception, DebugLoggerInterface $logger = null)
     {
         $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
 

--- a/Resources/config/exception_listener.xml
+++ b/Resources/config/exception_listener.xml
@@ -11,7 +11,6 @@
             <argument />
             <argument type="service" id="logger" on-invalid="null" />
             <argument>%kernel.debug%</argument>
-            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_rest.exception_listener.inner" on-invalid="null" />
         </service>
 


### PR DESCRIPTION
Part of https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2108

 * Typehinting `\Throwable` in the exception controller allows us to get rid of the argument controller logic, which is done by the ErrorListener if necessary