### PR TITLE
Provide the formats as parameter to be reusable in other bundles

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -330,6 +330,8 @@ class FOSRestExtension extends Extension
             }
         }
 
+        $container->getDefinition('fos_rest.view_formats_provider')->replaceArgument(0, $formats);
+
         if ($config['routing_loader']['enabled']) {
             $container->getDefinition('fos_rest.routing.loader.yaml_collection')->replaceArgument(3, $formats);
             $container->getDefinition('fos_rest.routing.loader.xml_collection')->replaceArgument(3, $formats);

--- a/Resources/config/view.xml
+++ b/Resources/config/view.xml
@@ -16,5 +16,8 @@
             <argument /> <!-- JSONP callback parameter -->
         </service>
 
+        <service id="fos_rest.view_formats_provider" class="FOS\RestBundle\View\FormatsProvider">
+            <argument /> <!-- formats -->
+        </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/FOSRestExtensionTest.php
+++ b/Tests/DependencyInjection/FOSRestExtensionTest.php
@@ -793,6 +793,15 @@ class FOSRestExtensionTest extends TestCase
             ],
             $this->defaultFormat
         );
+
+        $viewFormatsProviderDefinitionName = 'fos_rest.view_formats_provider';
+        $this->assertValidFormatsProvider(
+            $this->container->getDefinition($viewFormatsProviderDefinitionName),
+            [
+                'xml' => false,
+                'html' => true,
+            ]
+        );
     }
 
     public function testLoadOkMessagesClass()
@@ -982,6 +991,18 @@ class FOSRestExtensionTest extends TestCase
         $this->assertEquals($formats, $arguments[3]);
         $this->assertSame($defaultFormat, $arguments[4]);
         $this->assertArrayHasKey('routing.loader', $loader->getTags());
+    }
+
+    /**
+     * Assert that format provider definition described properly.
+     *
+     * @param Definition $loader  loader definition
+     * @param string[]   $formats supported view formats
+     */
+    private function assertValidFormatsProvider(Definition $provider, array $formats)
+    {
+        $arguments = $provider->getArguments();
+        $this->assertEquals($formats, $arguments[0]);
     }
 
     private function assertAlias($value, $key)

--- a/Tests/Functional/app/config/default.php
+++ b/Tests/Functional/app/config/default.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\HttpKernel\Kernel;
 
 $container->loadFromExtension('fos_rest', [

--- a/Tests/View/FormatsProviderTest.php
+++ b/Tests/View/FormatsProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\View;
+
+use FOS\RestBundle\View\FormatsProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * FormatsProvider test.
+ *
+ * @author Alexander Schranz <alexander@sulu.io>
+ */
+class FormatsProviderTest extends TestCase
+{
+    public function testGetFormats()
+    {
+        $formatsProvider = new FormatsProvider([
+            'xml' => true,
+            'json' => true,
+        ]);
+
+        $this->assertEquals(
+            [
+                'xml' => true,
+                'json' => true,
+            ],
+            $formatsProvider->getFormats()
+        );
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+if (!file_exists($file = __DIR__.'/../vendor/autoload.php')) {
+    throw new \RuntimeException('Install the dependencies to run the test suite.');
+}
+
+$loader = require $file;
+AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+AnnotationReader::addGlobalIgnoredName('required');

--- a/View/FormatsProvider.php
+++ b/View/FormatsProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\View;
+
+/**
+ * Provides the available view formats.
+ *
+ * @author Alexander Schranz <alexander@sulu.io>
+ */
+class FormatsProvider implements FormatsProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $formats;
+
+    /**
+     * @param array $formats
+     */
+    public function __construct(array $formats = [])
+    {
+        $this->formats = $formats;
+    }
+
+    public function getFormats(): array
+    {
+        return $this->formats;
+    }
+}

--- a/View/FormatsProviderInterface.php
+++ b/View/FormatsProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\View;
+
+interface FormatsProviderInterface
+{
+    /**
+     * @return array $formats
+     */
+    public function getFormats(): array;
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<phpunit bootstrap="./Tests/bootstrap.php" colors="true">
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="SHELL_VERBOSITY" value="-1" />


### PR DESCRIPTION
For creating the FOSRestRoutingBundle I need a way to access the formats of the FOSRestBundle.