### PR TITLE
Remove accidentally added return type from ExceptionHandler

### DIFF
--- a/Serializer/Normalizer/ExceptionHandler.php
+++ b/Serializer/Normalizer/ExceptionHandler.php
@@ -132,7 +132,7 @@ class ExceptionHandler extends AbstractExceptionNormalizer implements Subscribin
         }
     }
 
-    protected function convertToArray(\Exception $exception, Context $context): array
+    protected function convertToArray(\Exception $exception, Context $context)
     {
         return $this->convertThrowableToArray($exception, $context);
     }


### PR DESCRIPTION
In #2126 this was accidently added to a protected function which could be overwritten.