### PR TITLE
Throw exception for false combination of twig exception controller and exception_listener configuration

### DIFF
--- a/DependencyInjection/Compiler/TwigExceptionPass.php
+++ b/DependencyInjection/Compiler/TwigExceptionPass.php
@@ -24,6 +24,14 @@ final class TwigExceptionPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        if ($container->hasDefinition('fos_rest.exception.codes_map') // is config exception.enabled true
+            && $container->hasParameter('twig.exception_listener.controller') // is twig-bundle 4.4 installed
+            && $container->getParameter('twig.exception_listener.controller') // is twig-bundle deprecated controller set
+            && !$container->hasDefinition('fos_rest.exception_listener') // is deprecated exception_listener disabled
+        ) {
+            throw new \InvalidArgumentException('You can not disable the "fos_rest.exception.exception_listener" and still have the "twig.exception_controller" enabled.');
+        }
+
         // when no custom exception controller has been set
         if ($container->hasDefinition('fos_rest.error_listener') &&
             null === $container->getDefinition('fos_rest.error_listener')->getArgument(0)

--- a/Tests/Functional/app/RequestBodyParamConverterTwigBundle/config.yml
+++ b/Tests/Functional/app/RequestBodyParamConverterTwigBundle/config.yml
@@ -11,8 +11,6 @@ framework:
 fos_rest:
     body_converter:
         enabled: true
-    exception:
-        exception_listener: false
     routing_loader: false
 
 sensio_framework_extra:


### PR DESCRIPTION
By default in symfony 4.4 the older exception controller is used so the error handler component is not used. If the exceptionListener is disabled the newer ErrorController need to be used else the mapping configuraiton and listeners don't work.

This would fix https://github.com/FriendsOfSymfony/FOSRestBundle/issues/2167#issuecomment-619902695 where on `prefer-lowest` and disabled `exception_listener` the error handler is not called and so the exception not correctly serialized