### PR TITLE
Remove requirement to symfony/debug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "php": "^7.2",
         "psr/log": "^1.0",
         "symfony/config": "^4.4|^5.0",
-        "symfony/debug": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/event-dispatcher": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4.1|^5.0",


### PR DESCRIPTION
In the 3.0 there seems no longer a need to require `Symfony\Component\Debug`. 