### PR TITLE
make sure tests fail without access denied listener

### DIFF
--- a/Tests/Functional/AccessDeniedListenerTest.php
+++ b/Tests/Functional/AccessDeniedListenerTest.php
@@ -19,6 +19,10 @@ class AccessDeniedListenerTest extends WebTestCase
 
     public static function setUpBeforeClass()
     {
+        if (!interface_exists(ErrorRendererInterface::class)) {
+            self::markTestSkipped();
+        }
+
         parent::setUpBeforeClass();
         static::$client = static::createClient(['test_case' => 'AccessDeniedListener']);
     }
@@ -29,65 +33,39 @@ class AccessDeniedListenerTest extends WebTestCase
         parent::tearDownAfterClass();
     }
 
-    protected function setUp()
+    public function testNoCredentialsGives403()
     {
-        if (!interface_exists(ErrorRendererInterface::class)) {
-            $this->markTestSkipped();
-        }
+        static::$client->request('POST', '/api/login', [], [], ['CONTENT_TYPE' => 'application/json']);
+        $response = static::$client->getResponse();
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 
-    public function testBundleListenerHandlesExceptionsInRestZonesWithoutLogin()
+    public function testWrongLoginGives401()
     {
-        static::$client->request('GET', '/api/comments');
+        static::$client->request('POST', '/api/login', [], [], ['HTTP_X-FOO' => 'BAR', 'CONTENT_TYPE' => 'application/json']);
+        $response = static::$client->getResponse();
 
-        $this->assertEquals(401, static::$client->getResponse()->getStatusCode());
-        $this->assertEquals('application/json', static::$client->getResponse()->headers->get('Content-Type'));
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 
-    public function testBundleListenerHandlesExceptionsInRestZonesWithLogin()
+    public function testSuccessfulLogin()
     {
-        $credentials = [
-            'PHP_AUTH_USER' => 'restapi',
-            'PHP_AUTH_PW' => 'secretpw',
-        ];
+        static::$client->request('POST', '/api/login', [], [], ['HTTP_X-FOO' => 'FOOBAR', 'CONTENT_TYPE' => 'application/json']);
+        $response = static::$client->getResponse();
 
-        static::$client->request('GET', '/api/comments', [], [], $credentials);
-
-        $this->assertEquals(200, static::$client->getResponse()->getStatusCode());
-        $this->assertEquals('application/json', static::$client->getResponse()->headers->get('Content-Type'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 
-    public function testBundleListenerHandlesExceptionsInRestZonesWrongLogin()
+    public function testAccessDeniedExceptionGives403()
     {
-        $credentials = [
-            'PHP_AUTH_USER' => 'admin',
-            'PHP_AUTH_PW' => 'secretpw',
-        ];
+        static::$client->request('GET', '/api/comments', [], [], ['CONTENT_TYPE' => 'application/json']);
+        $response = static::$client->getResponse();
 
-        static::$client->request('GET', '/api/comments', [], [], $credentials);
-
-        $this->assertEquals(403, static::$client->getResponse()->getStatusCode());
-        $this->assertEquals('application/json', static::$client->getResponse()->headers->get('Content-Type'));
-    }
-
-    public function testBundleListenerHandlesExceptionsInRestZonesWithIncorrectLogin()
-    {
-        $credentials = [
-            'PHP_AUTH_USER' => 'restapi',
-            'PHP_AUTH_PW' => 'foobar',
-        ];
-
-        static::$client->request('GET', '/api/comments', [], [], $credentials);
-
-        $this->assertEquals(401, static::$client->getResponse()->getStatusCode());
-        $this->assertEquals('application/json', static::$client->getResponse()->headers->get('Content-Type'));
-    }
-
-    public function testSymfonyListenerHandlesExceptionsOutsideRestZones()
-    {
-        static::$client->request('GET', '/admin/comments');
-
-        $this->assertEquals(302, static::$client->getResponse()->getStatusCode());
-        $this->assertEquals('text/html; charset=UTF-8', static::$client->getResponse()->headers->get('Content-Type'));
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 }

--- a/Tests/Functional/Bundle/TestBundle/Controller/Api/CommentController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/Api/CommentController.php
@@ -15,6 +15,11 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class CommentController
 {
+    public function loginAction()
+    {
+        return new JsonResponse('login');
+    }
+
     public function getCommentAction($id)
     {
         return new JsonResponse(array('id' => (int) $id));

--- a/Tests/Functional/Bundle/TestBundle/Entity/User.php
+++ b/Tests/Functional/Bundle/TestBundle/Entity/User.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Entity;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    const ROLE_DEFAULT = 'ROLE_USER';
+
+    public $username;
+    public $roles = [];
+
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+
+        $roles[] = static::ROLE_DEFAULT;
+
+        return array_unique($roles);
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function getPassword(): string
+    {
+        return '';
+    }
+
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+}

--- a/Tests/Functional/Bundle/TestBundle/Security/ApiTokenAuthenticator.php
+++ b/Tests/Functional/Bundle/TestBundle/Security/ApiTokenAuthenticator.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Security;
+
+use FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class ApiTokenAuthenticator extends AbstractGuardAuthenticator
+{
+    protected $headerName = 'x-foo';
+    protected $tokenValue = 'FOOBAR';
+
+    /**
+     * Called on every request. Return whatever credentials you want,
+     * or null to stop authentication.
+     */
+    public function getCredentials(Request $request): ?string
+    {
+        if (!$request->headers->has($this->headerName)) {
+            return null;
+        }
+
+        return $request->headers->get($this->headerName);
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider): ?UserInterface
+    {
+        if (!$credentials || $credentials !== $this->tokenValue) {
+            return null;
+        }
+
+        $user = new User();
+        $user->username = 'foo';
+        $user->roles[] = 'ROLE_API';
+
+        return $user;
+    }
+
+    public function checkCredentials($credentials, UserInterface $user): bool
+    {
+        return true;
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        throw new AuthenticationException('Token not valid');
+    }
+
+    /**
+     * Called when authentication is needed, but it's not sent.
+     */
+    public function start(Request $request, AuthenticationException $authException = null): Response
+    {
+        $data = ['message' => 'Authentication Required'];
+
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function supportsRememberMe(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Does the authenticator support the given Request?
+     *
+     * If this returns false, the authenticator will be skipped.
+     */
+    public function supports(Request $request): bool
+    {
+        if (!$request->headers->has($this->headerName)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Tests/Functional/app/AccessDeniedListener/config.yml
+++ b/Tests/Functional/app/AccessDeniedListener/config.yml
@@ -17,3 +17,7 @@ fos_rest:
     body_listener: false
     zone:
         - { path: ^/api/* }
+
+services:
+    api_token_authenticator:
+        class:  FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Security\ApiTokenAuthenticator

--- a/Tests/Functional/app/AccessDeniedListener/routing.yml
+++ b/Tests/Functional/app/AccessDeniedListener/routing.yml
@@ -4,8 +4,8 @@ api:
         _controller: FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller\Api\CommentController::getComments
         _format: json
 
-admin:
-    path:     /admin/comments
+api_login:
+    path:     /api/login
     defaults:
-        _controller: FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller\CommentController::getComments
-        _format: html
+        _controller: FOS\RestBundle\Tests\Functional\Bundle\TestBundle\Controller\Api\CommentController::loginAction
+        _format: json

--- a/Tests/Functional/app/AccessDeniedListener/security.php
+++ b/Tests/Functional/app/AccessDeniedListener/security.php
@@ -21,30 +21,22 @@ $container->loadFromExtension('security', [
     'encoders' => ['Symfony\Component\Security\Core\User\User' => 'plaintext'],
     'providers' => [
         'in_memory' => [
-            'memory' => [
-                'users' => [
-                    'restapi' => ['password' => 'secretpw', 'roles' => ['ROLE_API']],
-                    'admin' => ['password' => 'secretpw', 'roles' => ['ROLE_ADMIN']],
-                ],
-            ],
+            'memory' => [],
         ],
     ],
     'firewalls' => [
-        'api' => array_merge($defaultFirewall, [
-            'pattern' => '^/api',
-            'stateless' => true,
-            'http_basic' => ['realm' => 'Demo REST API'],
-            'json_login' => [
-                'check_path' => '/api/login',
-            ],
-        ]),
         'default' => array_merge($defaultFirewall, [
-            'anonymous' => null,
-            'form_login' => null,
+            'provider' => 'in_memory',
+            'anonymous' => 'lazy',
+            'stateless' => true,
+            'guard' => [
+                'authenticators' => [
+                    'api_token_authenticator',
+                ],
+            ],
         ]),
     ],
     'access_control' => [
-        ['path' => '^/admin', 'roles' => 'ROLE_ADMIN'],
         ['path' => '^/api', 'roles' => 'ROLE_API'],
     ],
 ]);


### PR DESCRIPTION
core already seems to do all the right things when using basic auth and/or json_login. so at least for 3.0, imho we should just remove the AccessDeniedListener and tell people to use `json_login` or adapt whatever custom solution they have.

however when using a custom guard authenticator it does not work properly out of the box unless one enables the the AccessDeniedListener and only with the removed `$exception` propagation done in https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2109

that being said an alternative and likely cleaner approach in place of the AccessDeniedListener would be to offer a default implementation for a failure handler. so maybe for 3.0 this is what should be done? ie. drop AccessDeniedListener and add a failure handler? then we avoid even going into the exception handling process and directly return the appropriate response.

and unrelated issue I noticed is if I enable the `exception_listener` in the tests (ie. set `true` here https://github.com/FriendsOfSymfony/FOSRestBundle/blob/fix-access-denied-tests/Tests/Functional/app/AccessDeniedListener/config.yml#L14), then the explode with a circular dependency in the `AbstractNormalizer`:
```
Symfony\Component\Serializer\Exception\CircularReferenceException: A circular reference has been detected when serializing the object of class "Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException" (configured limit: 1).

/FOSRestBundle/vendor/symfony/serializer/Normalizer/AbstractNormalizer.php:330
...
```