### PR TITLE
Deprecate the behavior of the JMSHandlerRegistry to improve performance in v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+* The JMS Handlers `JMSHandlerRegistry` and `JMSHandlerRegistryV2` behaviors are deprecated. If you depend on the inheritance of JMS handlers that they provided, a deprecation will be thrown.
+  Set the option `fos_rest.serializer.enable_jms_registry` to `false` to disable these custom registries.
+
 3.0.3
 -----
 

--- a/DependencyInjection/Compiler/HandlerRegistryDecorationPass.php
+++ b/DependencyInjection/Compiler/HandlerRegistryDecorationPass.php
@@ -28,11 +28,14 @@ use Symfony\Component\DependencyInjection\Reference;
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  *
  * @internal
+ *
+ * @deprecated since FOSRestBundle 3.1.
  */
 class HandlerRegistryDecorationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        // If handlers are disabled, this alias is not created by JMSHandlersPass
         if (!$container->has('fos_rest.serializer.jms_handler_registry')) {
             return;
         }

--- a/DependencyInjection/Compiler/JMSHandlersPass.php
+++ b/DependencyInjection/Compiler/JMSHandlersPass.php
@@ -26,9 +26,14 @@ final class JMSHandlersPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        $disableCustomRegistry = $container->hasParameter('fos_rest.serializer.disable_custom_jms_registry');
+        $container->getParameterBag()->remove('fos_rest.serializer.disable_custom_jms_registry');
+
         if ($container->has('jms_serializer.handler_registry')) {
-            // the public alias prevents the handler registry definition from being removed
-            $container->setAlias('fos_rest.serializer.jms_handler_registry', new Alias('jms_serializer.handler_registry', true));
+            if (!$disableCustomRegistry) {
+                // the public alias prevents the handler registry definition from being removed
+                $container->setAlias('fos_rest.serializer.jms_handler_registry', new Alias('jms_serializer.handler_registry', true));
+            }
 
             return;
         }

--- a/DependencyInjection/Compiler/JMSHandlersPass.php
+++ b/DependencyInjection/Compiler/JMSHandlersPass.php
@@ -26,11 +26,11 @@ final class JMSHandlersPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        $disableCustomRegistry = $container->hasParameter('fos_rest.serializer.disable_custom_jms_registry');
-        $container->getParameterBag()->remove('fos_rest.serializer.disable_custom_jms_registry');
+        $enableCustomRegistry = $container->hasParameter('fos_rest.serializer.enable_jms_registry');
+        $container->getParameterBag()->remove('fos_rest.serializer.enable_jms_registry');
 
         if ($container->has('jms_serializer.handler_registry')) {
-            if (!$disableCustomRegistry) {
+            if ($enableCustomRegistry) {
                 // the public alias prevents the handler registry definition from being removed
                 $container->setAlias('fos_rest.serializer.jms_handler_registry', new Alias('jms_serializer.handler_registry', true));
             }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -110,7 +110,7 @@ final class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->booleanNode('serialize_null')->defaultFalse()->end()
-                        ->booleanNode('disable_custom_jms_registry')->defaultFalse()->end()
+                        ->booleanNode('enable_jms_registry')->defaultTrue()->end()
                     ->end()
                 ->end()
                 ->arrayNode('zone')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -110,6 +110,7 @@ final class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->booleanNode('serialize_null')->defaultFalse()->end()
+                        ->booleanNode('disable_custom_jms_registry')->defaultFalse()->end()
                     ->end()
                 ->end()
                 ->arrayNode('zone')

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -363,8 +363,8 @@ class FOSRestExtension extends Extension
         $options['serializeNullStrategy'] = $config['serializer']['serialize_null'];
         $viewHandler->addArgument($options);
 
-        if ($config['serializer']['disable_custom_jms_registry']) {
-            $container->setParameter('fos_rest.serializer.disable_custom_jms_registry', true);
+        if ($config['serializer']['enable_jms_registry']) {
+            $container->setParameter('fos_rest.serializer.enable_jms_registry', true);
         }
     }
 

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -362,6 +362,10 @@ class FOSRestExtension extends Extension
 
         $options['serializeNullStrategy'] = $config['serializer']['serialize_null'];
         $viewHandler->addArgument($options);
+
+        if ($config['serializer']['disable_custom_jms_registry']) {
+            $container->setParameter('fos_rest.serializer.disable_custom_jms_registry', true);
+        }
     }
 
     private function loadZoneMatcherListener(array $config, XmlFileLoader $loader, ContainerBuilder $container): void

--- a/Serializer/JMSHandlerRegistry.php
+++ b/Serializer/JMSHandlerRegistry.php
@@ -59,7 +59,7 @@ class JMSHandlerRegistry implements HandlerRegistryInterface
                 return $handler;
             }
 
-            @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Set the option `fos_rest.serializer.enable_jms_registry` to `false` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
         } while ($typeName = get_parent_class($typeName));
     }
 }

--- a/Serializer/JMSHandlerRegistry.php
+++ b/Serializer/JMSHandlerRegistry.php
@@ -13,7 +13,6 @@ namespace FOS\RestBundle\Serializer;
 
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
-use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 /**
  * Search in the class parents to find an adapted handler.

--- a/Serializer/JMSHandlerRegistry.php
+++ b/Serializer/JMSHandlerRegistry.php
@@ -53,18 +53,13 @@ class JMSHandlerRegistry implements HandlerRegistryInterface
      */
     public function getHandler($direction, $typeName, $format)
     {
-        $first = true;
         do {
             $handler = $this->registry->getHandler($direction, $typeName, $format);
             if (null !== $handler) {
-                if (!$first) {
-                    @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
-                }
-
                 return $handler;
             }
 
-            $first = false;
+            @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
         } while ($typeName = get_parent_class($typeName));
     }
 }

--- a/Serializer/JMSHandlerRegistry.php
+++ b/Serializer/JMSHandlerRegistry.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Serializer;
 
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 /**
  * Search in the class parents to find an adapted handler.
@@ -51,11 +52,18 @@ class JMSHandlerRegistry implements HandlerRegistryInterface
      */
     public function getHandler($direction, $typeName, $format)
     {
+        $first = true;
         do {
             $handler = $this->registry->getHandler($direction, $typeName, $format);
             if (null !== $handler) {
+                if (!$first && FlattenException::class !== $typeName) {
+                    @trigger_error(sprintf('The behavior of %s is deprecated since FOSRestBundle 2.8. In version 3.0, it will only force JMS Serializer to use the %s handler when possible. You should not rely on it for the parent type "%s".', __CLASS__, FlattenException::class, $typeName), E_USER_DEPRECATED);
+                }
+
                 return $handler;
             }
+
+            $first = false;
         } while ($typeName = get_parent_class($typeName));
     }
 }

--- a/Serializer/JMSHandlerRegistry.php
+++ b/Serializer/JMSHandlerRegistry.php
@@ -21,6 +21,8 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
  * @author Ener-Getick <egetick@gmail.com>
  *
  * @internal do not depend on this class directly
+ *
+ * @deprecated since FOSRestBundle 3.1, use the option `fos_rest.serializer.disable_jms_handlers` to avoid relying on it.
  */
 class JMSHandlerRegistry implements HandlerRegistryInterface
 {
@@ -56,8 +58,8 @@ class JMSHandlerRegistry implements HandlerRegistryInterface
         do {
             $handler = $this->registry->getHandler($direction, $typeName, $format);
             if (null !== $handler) {
-                if (!$first && FlattenException::class !== $typeName) {
-                    @trigger_error(sprintf('The behavior of %s is deprecated since FOSRestBundle 2.8. In version 3.0, it will only force JMS Serializer to use the %s handler when possible. You should not rely on it for the parent type "%s".', __CLASS__, FlattenException::class, $typeName), E_USER_DEPRECATED);
+                if (!$first) {
+                    @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
                 }
 
                 return $handler;

--- a/Serializer/JMSHandlerRegistryV2.php
+++ b/Serializer/JMSHandlerRegistryV2.php
@@ -13,7 +13,6 @@ namespace FOS\RestBundle\Serializer;
 
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
-use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 /**
  * Search in the class parents to find an adapted handler.

--- a/Serializer/JMSHandlerRegistryV2.php
+++ b/Serializer/JMSHandlerRegistryV2.php
@@ -53,18 +53,13 @@ final class JMSHandlerRegistryV2 implements HandlerRegistryInterface
      */
     public function getHandler(int $direction, string $typeName, string $format)
     {
-        $first = true;
         do {
             $handler = $this->registry->getHandler($direction, $typeName, $format);
             if (null !== $handler) {
-                if (!$first) {
-                    @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
-                }
-
                 return $handler;
             }
 
-            $first = false;
+            @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
         } while ($typeName = get_parent_class($typeName));
     }
 }

--- a/Serializer/JMSHandlerRegistryV2.php
+++ b/Serializer/JMSHandlerRegistryV2.php
@@ -13,6 +13,7 @@ namespace FOS\RestBundle\Serializer;
 
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\Handler\HandlerRegistryInterface;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 /**
  * Search in the class parents to find an adapted handler.
@@ -51,11 +52,18 @@ final class JMSHandlerRegistryV2 implements HandlerRegistryInterface
      */
     public function getHandler(int $direction, string $typeName, string $format)
     {
+        $first = true;
         do {
             $handler = $this->registry->getHandler($direction, $typeName, $format);
             if (null !== $handler) {
+                if (!$first && FlattenException::class !== $typeName) {
+                    @trigger_error(sprintf('The behavior of %s is deprecated since FOSRestBundle 2.8. In version 3.0, it will only force JMS Serializer to use the %s handler when possible. You should not rely on it for the parent type "%s".', __CLASS__, FlattenException::class, $typeName), E_USER_DEPRECATED);
+                }
+
                 return $handler;
             }
+
+            $first = false;
         } while ($typeName = get_parent_class($typeName));
     }
 }

--- a/Serializer/JMSHandlerRegistryV2.php
+++ b/Serializer/JMSHandlerRegistryV2.php
@@ -59,7 +59,7 @@ final class JMSHandlerRegistryV2 implements HandlerRegistryInterface
                 return $handler;
             }
 
-            @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Set the option `fos_rest.serializer.enable_jms_registry` to `false` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
         } while ($typeName = get_parent_class($typeName));
     }
 }

--- a/Serializer/JMSHandlerRegistryV2.php
+++ b/Serializer/JMSHandlerRegistryV2.php
@@ -21,6 +21,8 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
  * @author Ener-Getick <egetick@gmail.com>
  *
  * @internal do not depend on this class directly
+ *
+ * @deprecated since FOSRestBundle 3.1, use the option `fos_rest.serializer.disable_custom_jms_registry` to avoid relying on it.
  */
 final class JMSHandlerRegistryV2 implements HandlerRegistryInterface
 {
@@ -56,8 +58,8 @@ final class JMSHandlerRegistryV2 implements HandlerRegistryInterface
         do {
             $handler = $this->registry->getHandler($direction, $typeName, $format);
             if (null !== $handler) {
-                if (!$first && FlattenException::class !== $typeName) {
-                    @trigger_error(sprintf('The behavior of %s is deprecated since FOSRestBundle 2.8. In version 3.0, it will only force JMS Serializer to use the %s handler when possible. You should not rely on it for the parent type "%s".', __CLASS__, FlattenException::class, $typeName), E_USER_DEPRECATED);
+                if (!$first) {
+                    @trigger_error(sprintf('Relying on the custom registry %s to inherit the JMS handler of type `%s` is deprecated since FOSRestBundle 3.1. It will be removed in version 4.0. Use the option `fos_rest.serializer.disable_custom_jms_registry` to disable it.', __CLASS__, $typeName), E_USER_DEPRECATED);
                 }
 
                 return $handler;

--- a/Tests/Functional/SerializerErrorTest.php
+++ b/Tests/Functional/SerializerErrorTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\RestBundle\Tests\Functional;
 
+use JMS\Serializer\Handler\HandlerRegistry;
 use Symfony\Component\ErrorHandler\ErrorRenderer\SerializerErrorRenderer;
 
 /**
@@ -29,6 +30,7 @@ class SerializerErrorTest extends WebTestCase
         self::deleteTmpDir('FlattenExceptionNormalizerRfc7807Format');
         self::deleteTmpDir('FormErrorHandler');
         self::deleteTmpDir('FormErrorNormalizer');
+        self::deleteTmpDir('DisableJMSHandlers');
         parent::tearDownAfterClass();
     }
 
@@ -272,5 +274,22 @@ XML;
             ['FormErrorNormalizer', $expectedSerializerContent],
             ['FormErrorHandler', $expectedJMSContent],
         ];
+    }
+
+    public function testJMSHandlers()
+    {
+        // Test case importing the JMS Serializer bundle
+        self::bootKernel(['test_case' => 'FormErrorHandler', 'debug' => false]);
+
+        $this->assertTrue(self::$container->has('fos_rest.serializer.jms_handler_registry'));
+        $this->assertNotInstanceOf(HandlerRegistry::class, self::$container->get('jms_serializer.handler_registry'));
+    }
+
+    public function testDisabledJMSRegistry()
+    {
+        self::bootKernel(['test_case' => 'DisableJMSHandlers', 'debug' => false]);
+
+        $this->assertFalse(self::$container->has('fos_rest.serializer.jms_handler_registry'));
+        $this->assertInstanceOf(HandlerRegistry::class, self::$container->get('jms_serializer.handler_registry'));
     }
 }

--- a/Tests/Functional/app/DisableJMSHandlers/bundles.php
+++ b/Tests/Functional/app/DisableJMSHandlers/bundles.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \FOS\RestBundle\FOSRestBundle(),
+    new \JMS\SerializerBundle\JMSSerializerBundle(),
+    new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
+];

--- a/Tests/Functional/app/DisableJMSHandlers/config.yml
+++ b/Tests/Functional/app/DisableJMSHandlers/config.yml
@@ -4,4 +4,4 @@ imports:
 
 fos_rest:
     serializer:
-        disable_custom_jms_registry: true
+        enable_jms_registry: false

--- a/Tests/Functional/app/DisableJMSHandlers/config.yml
+++ b/Tests/Functional/app/DisableJMSHandlers/config.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: ../config/exception_listener.yml }
+
+fos_rest:
+    serializer:
+        disable_custom_jms_registry: true

--- a/UPGRADING-3.0.md
+++ b/UPGRADING-3.0.md
@@ -156,6 +156,3 @@ Upgrading From 2.x To 3.0
    * `FOS\RestBundle\View\JsonpHandler`
    * `FOS\RestBundle\View\View`
    * `FOS\RestBundle\View\ViewHandler`
-
- * The JMS Handlers `JMSHandlerRegistry` and `JMSHandlerRegistryV2` behaviors have changed.
-   They no longer force JMS Serializer to check for parent handlers arbitrary. They only force heredity when having `FlattenException` as parent.

--- a/UPGRADING-3.0.md
+++ b/UPGRADING-3.0.md
@@ -156,3 +156,6 @@ Upgrading From 2.x To 3.0
    * `FOS\RestBundle\View\JsonpHandler`
    * `FOS\RestBundle\View\View`
    * `FOS\RestBundle\View\ViewHandler`
+
+ * The JMS Handlers `JMSHandlerRegistry` and `JMSHandlerRegistryV2` behaviors have changed.
+   They no longer force JMS Serializer to check for parent handlers arbitrary. They only force heredity when having `FlattenException` as parent.


### PR DESCRIPTION
Sorry I am quite late at submitting changes for v3...

I think it wasn't a good idea to introduce such an handler in the first place (sorry for that) and I think it should be reworked to do just what we want it to: inherit the FlattenException handler.

As @goetas noted (a while ago now) in https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1899#discussion_r233769559, it has terrible performance issues and I think v3 would be a great opportunity to fix it.

I hope it's still ok for you but if not, well I missed the boat :)