### PR TITLE
Fix requests without content type

### DIFF
--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -81,11 +81,16 @@ class RequestBodyParamConverter implements ParamConverterInterface
         }
         $this->configureContext($context = new Context(), $arrayContext);
 
+        $format = $request->getContentType();
+        if (null === $format) {
+            return $this->throwException(new UnsupportedMediaTypeHttpException(), $configuration);
+        }
+
         try {
             $object = $this->serializer->deserialize(
                 $request->getContent(),
                 $configuration->getClass(),
-                $request->getContentType(),
+                $format,
                 $context
             );
         } catch (UnsupportedFormatException $e) {

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -273,6 +273,15 @@ class RequestBodyParamConverterTest extends TestCase
         $this->assertFalse($converter->supports($this->createConfiguration(null, 'post')));
     }
 
+    public function testNoContentTypeCausesUnsupportedMediaTypeException()
+    {
+        $converter = new RequestBodyParamConverter($this->serializer);
+        $request = $this->createRequest();
+        $request->headers->remove('CONTENT_TYPE');
+        $this->expectException(UnsupportedMediaTypeHttpException::class);
+        $this->launchExecution($converter, $request);
+    }
+
     protected function launchExecution($converter, $request = null, $configuration = null)
     {
         if (null === $request) {


### PR DESCRIPTION
```
Argument 3 passed to FOS\RestBundle\Serializer\JMSSerializerAdapter::deserialize() must be of the type string, null given
```