### PR TITLE
Allow to specify Throwable as exception class

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -561,7 +561,7 @@ final class Configuration implements ConfigurationInterface
 
     private function testExceptionExists(string $throwable)
     {
-        if (!is_subclass_of($throwable, \Throwable::class)) {
+        if (!is_a($throwable, \Throwable::class, true)) {
             throw new InvalidConfigurationException(sprintf('FOSRestBundle exception mapper: Could not load class "%s" or the class does not extend from "%s". Most probably this is a configuration problem.', $throwable, \Throwable::class));
         }
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -48,6 +48,7 @@ class ConfigurationTest extends TestCase
         $expectedConfig = [
             \RuntimeException::class => 500,
             \TypeError::class => 500,
+            \Throwable::class => 500,
         ];
 
         $config = $this->processor->processConfiguration(


### PR DESCRIPTION
Currently we can't use Throwable in exception.codes because check method uses `is_subclass_of`.
This PR fixes this issue.