### PR TITLE
Bump willdurand/negotiation to ^3.0 to allow PHP 8.0

### DIFF
--- a/Negotiation/FormatNegotiator.php
+++ b/Negotiation/FormatNegotiator.php
@@ -40,7 +40,7 @@ class FormatNegotiator extends BaseNegotiator
         $this->map[] = [$requestMatcher, $options];
     }
 
-    public function getBest($header, array $priorities = [])
+    public function getBest($header, array $priorities = [], $strict = false)
     {
         $request = $this->getRequest();
         $header = $header ?: $request->headers->get('Accept');
@@ -82,7 +82,7 @@ class FormatNegotiator extends BaseNegotiator
                     empty($priorities) ? $options['priorities'] : $priorities
                 );
 
-                $mimeType = parent::getBest($header, $mimeTypes);
+                $mimeType = parent::getBest($header, $mimeTypes, $strict);
 
                 if (null !== $mimeType) {
                     return $mimeType;

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "symfony/routing": "^3.4|^4.3",
         "symfony/security-core": "^3.4|^4.3",
         "doctrine/inflector": "^1.0",
-        "willdurand/negotiation": "^2.0|^3.0",
+        "willdurand/negotiation": "^3.0",
         "willdurand/jsonp-callback-validator": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "symfony/routing": "^3.4|^4.3",
         "symfony/security-core": "^3.4|^4.3",
         "doctrine/inflector": "^1.0",
-        "willdurand/negotiation": "^2.0",
+        "willdurand/negotiation": "^2.0|^3.0",
         "willdurand/jsonp-callback-validator": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
As explained in: https://github.com/willdurand/Negotiation/releases/tag/3.0.0 `FOSRESTBundle` blocks update and allow to use in PHP 8.

```
composer depends willdurand/negotiation
friendsofsymfony/rest-bundle  3.0.3  requires  willdurand/negotiation (^2.0)
```

There is no side effects (I think) because main change was in internal class from `Match` (which is a reserved keyword) to `AcceptMatch` 