### PR TITLE
Add fos rest info in the symfony serialization context

### DIFF
--- a/Serializer/Normalizer/FlattenExceptionNormalizer.php
+++ b/Serializer/Normalizer/FlattenExceptionNormalizer.php
@@ -11,17 +11,18 @@
 
 namespace FOS\RestBundle\Serializer\Normalizer;
 
+use FOS\RestBundle\Serializer\Serializer;
 use FOS\RestBundle\Util\ExceptionValueMap;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  *
  * @internal
  */
-final class FlattenExceptionNormalizer implements NormalizerInterface
+final class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
 {
     private $statusCodeMap;
     private $messagesMap;
@@ -73,8 +74,8 @@ final class FlattenExceptionNormalizer implements NormalizerInterface
         }
     }
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = [])
     {
-        return $data instanceof FlattenException;
+        return $data instanceof FlattenException && ($context[Serializer::FOS_BUNDLE_SERIALIZATION_CONTEXT] ?? false);
     }
 }

--- a/Serializer/Serializer.php
+++ b/Serializer/Serializer.php
@@ -18,6 +18,8 @@ use FOS\RestBundle\Context\Context;
  */
 interface Serializer
 {
+    public const FOS_BUNDLE_SERIALIZATION_CONTEXT = 'fos_bundle_serialization';
+
     /**
      * @return string
      */

--- a/Serializer/SymfonySerializerAdapter.php
+++ b/Serializer/SymfonySerializerAdapter.php
@@ -58,6 +58,11 @@ final class SymfonySerializerAdapter implements Serializer
         if (null !== $context->getGroups()) {
             $newContext['groups'] = $context->getGroups();
         }
+
+        if (false === $context->hasAttribute(Serializer::FOS_BUNDLE_SERIALIZATION_CONTEXT)) {
+            $newContext[Serializer::FOS_BUNDLE_SERIALIZATION_CONTEXT] = true;
+        }
+
         $newContext['version'] = $context->getVersion();
         $newContext['enable_max_depth'] = $context->isMaxDepthEnabled();
         $newContext['skip_null_values'] = !$context->getSerializeNull();

--- a/Tests/Functional/app/FlattenExceptionNormalizerLegacyFormat/config.yml
+++ b/Tests/Functional/app/FlattenExceptionNormalizerLegacyFormat/config.yml
@@ -11,3 +11,4 @@ fos_rest:
         codes:
             'InvalidArgumentException': 400
         flatten_exception_format: 'legacy'
+        serializer_error_renderer: true

--- a/Tests/Functional/app/FlattenExceptionNormalizerLegacyFormatDebug/config.yml
+++ b/Tests/Functional/app/FlattenExceptionNormalizerLegacyFormatDebug/config.yml
@@ -10,3 +10,4 @@ fos_rest:
     exception:
         debug: true
         flatten_exception_format: 'legacy'
+        serializer_error_renderer: true

--- a/Tests/Functional/app/FlattenExceptionNormalizerRfc7807Format/config.yml
+++ b/Tests/Functional/app/FlattenExceptionNormalizerRfc7807Format/config.yml
@@ -11,3 +11,4 @@ fos_rest:
         codes:
             'InvalidArgumentException': 400
         flatten_exception_format: 'rfc7807'
+        serializer_error_renderer: true

--- a/Tests/Serializer/SymfonySerializerAdapterTest.php
+++ b/Tests/Serializer/SymfonySerializerAdapterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Serializer;
+
+use FOS\RestBundle\Context\Context;
+use FOS\RestBundle\Serializer\SymfonySerializerAdapter;
+use FOS\RestBundle\Serializer\Serializer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class SymfonySerializerAdapterTest extends TestCase
+{
+    private $serializer;
+    private $adapter;
+
+    protected function setUp(): void
+    {
+        $this->serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
+
+        $this->adapter = new SymfonySerializerAdapter($this->serializer);
+    }
+
+    public function testHasFosRestContextAttributeByDefault()
+    {
+        $context = new Context();
+        $this->serializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturnCallback(function ($data, $format, $context) {
+                self::assertSame(1, $data);
+                self::assertSame('json', $format);
+                self::assertSame(true, $context[Serializer::FOS_BUNDLE_SERIALIZATION_CONTEXT]);
+
+                return 'abc';
+            });
+
+        $this->adapter->serialize(1, 'json', $context);
+    }
+
+    public function testCanOverrideContextAttribute()
+    {
+        $context = new Context();
+        $context->setAttribute(Serializer::FOS_BUNDLE_SERIALIZATION_CONTEXT, false);
+        $this->serializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturnCallback(function ($data, $format, $context) {
+                self::assertSame(1, $data);
+                self::assertSame('json', $format);
+                self::assertSame(false, $context[Serializer::FOS_BUNDLE_SERIALIZATION_CONTEXT]);
+
+                return 'abc';
+            });
+
+        $this->adapter->serialize(1, 'json', $context);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/2292

using same approach as in https://github.com/symfony/messenger/blob/1cc72a00521c69219ba79b7b04757d5e7fface66/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php#L98

