### PR TITLE
POST method should not throw exception on empty payload without content-type

### DIFF
--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -111,7 +111,7 @@ class BodyListener
 
     private function isNotAnEmptyPostOrDeleteRequestWithNoSetContentType(string $method, $content, ?string $contentType): bool
     {
-        return false === (in_array($method, ['DELETE', 'POST], true) && empty($content) && empty($contentType));
+        return false === (in_array($method, ['DELETE', 'POST'], true) && empty($content) && empty($contentType));
     }
 
     private function isDecodeable(Request $request): bool

--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -76,7 +76,7 @@ class BodyListener
 
             if (null === $format || !$this->decoderProvider->supports($format)) {
                 if ($this->throwExceptionOnUnsupportedContentType
-                    && $this->isNotAnEmptyDeleteRequestWithNoSetContentType($method, $content, $contentType)
+                    && $this->isNotAnEmptyPostOrDeleteRequestWithNoSetContentType($method, $content, $contentType)
                 ) {
                     throw new UnsupportedMediaTypeHttpException("Request body format '$format' not supported");
                 }
@@ -109,9 +109,9 @@ class BodyListener
         }
     }
 
-    private function isNotAnEmptyDeleteRequestWithNoSetContentType(string $method, $content, ?string $contentType): bool
+    private function isNotAnEmptyPostOrDeleteRequestWithNoSetContentType(string $method, $content, ?string $contentType): bool
     {
-        return false === ('DELETE' === $method && empty($content) && empty($contentType));
+        return false === (in_array($method, ['DELETE', 'POST], true) && empty($content) && empty($contentType));
     }
 
     private function isDecodeable(Request $request): bool


### PR DESCRIPTION
Content-Type header field is used to specify type of data in the body request.

When request is sent with an empty payload - it should be accepted the same way as DELETE request, cause in such cases Content-Type header is not applicable.