### PR TITLE
Responses with HTTP status 204/ 304 must not set the Content-Type header

### DIFF
--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -189,7 +189,7 @@ final class ViewHandler implements ConfigurableViewHandlerInterface
 
         $response = $this->initResponse($view, $format);
 
-        if (!$response->headers->has('Content-Type')) {
+        if (!$response->headers->has('Content-Type') && !in_array($response->getStatusCode(), [204, 304])) {
             $mimeType = $request->attributes->get('media_type');
             if (null === $mimeType) {
                 $mimeType = $request->getMimeType($format);


### PR DESCRIPTION
Hi there,

IMHO the `Content-Type` header must not be set if the `ViewHandler` is dealing with an empty `Response`.

I'm aware this might break BC but nevertheless, a Content-Type header does not really make sense in an empty response.