### PR TITLE
Fix compatibility of Route annotations with symfony >= 5.3

### DIFF
--- a/Controller/Annotations/Copy.php
+++ b/Controller/Annotations/Copy.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * COPY Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>

--- a/Controller/Annotations/Delete.php
+++ b/Controller/Annotations/Delete.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * DELETE Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Delete extends Route

--- a/Controller/Annotations/Get.php
+++ b/Controller/Annotations/Get.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * GET Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Get extends Route

--- a/Controller/Annotations/Head.php
+++ b/Controller/Annotations/Head.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * HEAD Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Head extends Route

--- a/Controller/Annotations/Link.php
+++ b/Controller/Annotations/Link.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * LINK Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Link extends Route

--- a/Controller/Annotations/Lock.php
+++ b/Controller/Annotations/Lock.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * LOCK Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>

--- a/Controller/Annotations/Mkcol.php
+++ b/Controller/Annotations/Mkcol.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * MKCOL Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>

--- a/Controller/Annotations/Move.php
+++ b/Controller/Annotations/Move.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * MOVE Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>

--- a/Controller/Annotations/Options.php
+++ b/Controller/Annotations/Options.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * OPTIONS Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Options extends Route

--- a/Controller/Annotations/Patch.php
+++ b/Controller/Annotations/Patch.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * PATCH Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Patch extends Route

--- a/Controller/Annotations/Post.php
+++ b/Controller/Annotations/Post.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * POST Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Post extends Route

--- a/Controller/Annotations/PropFind.php
+++ b/Controller/Annotations/PropFind.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * PROPFIND Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>

--- a/Controller/Annotations/PropPatch.php
+++ b/Controller/Annotations/PropPatch.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * PROPPATCH Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>

--- a/Controller/Annotations/Put.php
+++ b/Controller/Annotations/Put.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * PUT Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Put extends Route

--- a/Controller/Annotations/Route.php
+++ b/Controller/Annotations/Route.php
@@ -17,12 +17,93 @@ use Symfony\Component\Routing\Annotation\Route as BaseRoute;
  * Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"CLASS", "METHOD"})
  */
 class Route extends BaseRoute
 {
-    public function __construct(array $data)
-    {
-        parent::__construct($data);
+    public function __construct(
+        $data = [],
+        $path = null,
+        string $name = null,
+        array $requirements = [],
+        array $options = [],
+        array $defaults = [],
+        string $host = null,
+        $methods = [],
+        $schemes = [],
+        string $condition = null,
+        int $priority = null,
+        string $locale = null,
+        string $format = null,
+        bool $utf8 = null,
+        bool $stateless = null,
+        string $env = null
+    ) {
+        // BC layer for symfony < 5.2
+        // Before symfony/routing 5.2 the constructor only had one parameter
+        $method = new \ReflectionMethod(BaseRoute::class, '__construct');
+        if (1 === $method->getNumberOfParameters()) {
+            if (\is_string($data)) {
+                $path = $data;
+                $data = [];
+            } elseif (!\is_array($data)) {
+                throw new \TypeError(sprintf('"%s": Argument $data is expected to be a string or array, got "%s".', __METHOD__, get_debug_type($data)));
+            }
+
+            $data['path'] = $path;
+            $data['name'] = $name;
+            $data['requirements'] = $requirements;
+            $data['options'] = $options;
+            $data['defaults'] = $defaults;
+            $data['host'] = $host;
+            $data['methods'] = $methods;
+            $data['schemes'] = $schemes;
+            $data['condition'] = $condition;
+
+            parent::__construct($data);
+        } else {
+            // BC layer for symfony < 6.0
+            // The constructor parameter $data has been removed since symfony 6.0
+            if ('data' === $method->getParameters()[0]->getName()) {
+                parent::__construct(
+                    $data,
+                    $path,
+                    $name,
+                    $requirements,
+                    $options,
+                    $defaults,
+                    $host,
+                    $methods,
+                    $schemes,
+                    $condition,
+                    $priority,
+                    $locale,
+                    $format,
+                    $utf8,
+                    $stateless,
+                    $env,
+                );
+            } else {
+                parent::__construct(
+                    $path,
+                    $name,
+                    $requirements,
+                    $options,
+                    $defaults,
+                    $host,
+                    $methods,
+                    $schemes,
+                    $condition,
+                    $priority,
+                    $locale,
+                    $format,
+                    $utf8,
+                    $stateless,
+                    $env,
+                );
+            }
+        }
 
         if (!$this->getMethods()) {
             $this->setMethods((array) $this->getMethod());

--- a/Controller/Annotations/Unlink.php
+++ b/Controller/Annotations/Unlink.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * UNLINK Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
 class Unlink extends Route

--- a/Controller/Annotations/Unlock.php
+++ b/Controller/Annotations/Unlock.php
@@ -15,6 +15,7 @@ namespace FOS\RestBundle\Controller\Annotations;
  * UNLOCK Route annotation class.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  *
  * @author Maximilian Bosch <maximilian.bosch.27@gmail.com>

--- a/Tests/Controller/Annotations/RouteTest.php
+++ b/Tests/Controller/Annotations/RouteTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace FOS\RestBundle\Tests\Controller\Annotations;
+
+use FOS\RestBundle\Controller\Annotations\Route;
+use PHPUnit\Framework\TestCase;
+
+class RouteTest extends TestCase
+{
+    public function testCanInstantiate()
+    {
+        $path = '/path';
+        $name = 'route_name';
+        $requirements = ['locale' => 'en'];
+        $options = ['compiler_class' => 'RouteCompiler'];
+        $defaults = ['_controller' => 'MyBlogBundle:Blog:index'];
+        $host = '{locale}.example.com';
+        $methods = ['GET', 'POST'];
+        $schemes = ['https'];
+        $condition = 'context.getMethod() == "GET"';
+
+        $route = new Route(
+            $path,
+            null,
+            $name,
+            $requirements,
+            $options,
+            $defaults,
+            $host,
+            $methods,
+            $schemes,
+            $condition
+        );
+
+        $this->assertEquals($path, $route->getPath());
+        $this->assertEquals($name, $route->getName());
+        $this->assertEquals($requirements, $route->getRequirements());
+        $this->assertEquals($options, $route->getOptions());
+        $this->assertEquals($defaults, $route->getDefaults());
+        $this->assertEquals($host, $route->getHost());
+        $this->assertEquals($methods, $route->getMethods());
+        $this->assertEquals($schemes, $route->getSchemes());
+        $this->assertEquals($condition, $route->getCondition());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
         "symfony/validator": "Add support for validation capabilities in the ParamFetcher, requires ^2.7|^3.0"
     },
     "conflict": {
+        "doctrine/annotations": "<1.12",
         "doctrine/inflector": "1.4.0",
         "sensio/framework-extra-bundle": "<5.2.3",
         "symfony/error-handler": "<4.4.1",


### PR DESCRIPTION
Constructing Route annotations using named arguments was added in symfony 5.2 (https://github.com/symfony/symfony/pull/40266)

Closes https://github.com/FriendsOfSymfony/FOSRestBundle/issues/2311