### PR TITLE
Update psr/log to allow new versions and only require in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     },
     "require": {
         "php": "^7.2|^8.0",
-        "psr/log": "^1.0",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/event-dispatcher": "^4.4|^5.0",
@@ -42,6 +41,7 @@
         "willdurand/jsonp-callback-validator": "^1.0"
     },
     "require-dev": {
+        "psr/log": "^1.0|^2.0|^3.0",
         "sensio/framework-extra-bundle": "^5.2.3",
         "symfony/phpunit-bridge": "^5.2",
         "symfony/asset": "^4.4|^5.0",


### PR DESCRIPTION
This PR does two things:

1) Moves the `psr/log` dependency to `require-dev`, the only places in the repo that use the `Psr\Log` namespace are a docs example and the test kernel, meaning the dependency isn't actually a production dependency.

2) Allows for the new versions of the `psr/log` package to be used when able (which, probably won't be the case for a while thanks to the dependency chain, but inside this bundle, there's nothing directly blocking it).