### PR TITLE
Enable usage of the bundle without Twig

### DIFF
--- a/DependencyInjection/Compiler/ConfigurationCheckPass.php
+++ b/DependencyInjection/Compiler/ConfigurationCheckPass.php
@@ -13,7 +13,6 @@ namespace FOS\RestBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener;
 use Sensio\Bundle\FrameworkExtraBundle\EventListener\ParamConverterListener;
 
 /**
@@ -29,12 +28,6 @@ final class ConfigurationCheckPass implements CompilerPassInterface
     {
         if ($container->has('fos_rest.converter.request_body') && !($container->has('sensio_framework_extra.converter.listener') || $container->has(ParamConverterListener::class))) {
             throw new \RuntimeException('You need to enable the parameter converter listeners in SensioFrameworkExtraBundle when using the FOSRestBundle RequestBodyParamConverter');
-        }
-
-        if ($container->has('fos_rest.view_response_listener') && isset($container->getParameter('kernel.bundles')['SensioFrameworkExtraBundle'])) {
-            if (!($container->has('sensio_framework_extra.view.listener') || $container->has(TemplateListener::class))) {
-                throw new \RuntimeException('You must enable the SensioFrameworkExtraBundle view annotations to use the ViewResponseListener. Did you forget to install and enable the TwigBundle?');
-            }
         }
     }
 }

--- a/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ConfigurationCheckPassTest.php
@@ -34,18 +34,4 @@ class ConfigurationCheckPassTest extends TestCase
         $compiler = new ConfigurationCheckPass();
         $compiler->process($container);
     }
-
-    public function testExceptionWhenViewAnnotationsAreNotEnabled()
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('SensioFrameworkExtraBundle view annotations');
-
-        $container = new ContainerBuilder();
-
-        $container->register('fos_rest.view_response_listener');
-        $container->setParameter('kernel.bundles', ['SensioFrameworkExtraBundle' => '']);
-
-        $compiler = new ConfigurationCheckPass();
-        $compiler->process($container);
-    }
 }

--- a/Tests/Functional/app/RouteAttributes/bundles.php
+++ b/Tests/Functional/app/RouteAttributes/bundles.php
@@ -14,5 +14,4 @@ return [
     new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
     new \FOS\RestBundle\FOSRestBundle(),
     new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
-    new \Symfony\Bundle\TwigBundle\TwigBundle(),
 ];

--- a/Tests/Functional/app/RouteAttributes/config.yml
+++ b/Tests/Functional/app/RouteAttributes/config.yml
@@ -16,7 +16,3 @@ fos_rest:
     format_listener:
         rules:
             - { path: ^/, priorities: [ json, xml ], fallback_format: ~, prefer_extension: true }
-
-twig:
-    exception_controller: ~
-    strict_variables: '%kernel.debug%'

--- a/Tests/Functional/app/Version/bundles.php
+++ b/Tests/Functional/app/Version/bundles.php
@@ -11,7 +11,6 @@
 
 return [
     new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-    new \Symfony\Bundle\TwigBundle\TwigBundle(),
     new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
     new \FOS\RestBundle\FOSRestBundle(),
     new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),

--- a/Tests/Functional/app/Version/config.yml
+++ b/Tests/Functional/app/Version/config.yml
@@ -31,7 +31,3 @@ fos_rest:
             - custom_header
             - media_type
             - query
-
-twig:
-    exception_controller: ~
-    strict_variables: '%kernel.debug%'

--- a/Tests/Functional/app/ViewResponseListener/bundles.php
+++ b/Tests/Functional/app/ViewResponseListener/bundles.php
@@ -14,5 +14,4 @@ return [
     new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
     new \FOS\RestBundle\FOSRestBundle(),
     new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
-    new \Symfony\Bundle\TwigBundle\TwigBundle(),
 ];

--- a/Tests/Functional/app/ViewResponseListener/config.yml
+++ b/Tests/Functional/app/ViewResponseListener/config.yml
@@ -16,7 +16,3 @@ fos_rest:
     format_listener:
         rules:
             - { path: ^/, priorities: [ json, xml ], fallback_format: ~, prefer_extension: true }
-
-twig:
-    exception_controller: ~
-    strict_variables: '%kernel.debug%'


### PR DESCRIPTION
As I made a fork, and following https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1812#issuecomment-893277145, I open this PR which will evolve according to the feedbacks