### PR TITLE
Add compatibility with symfony/framework-bundle 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
         "sensio/framework-extra-bundle": "<5.2.3",
         "symfony/error-handler": "<4.4.1",
         "jms/serializer-bundle": "<2.4.3|3.0.0",
-        "jms/serializer": "<1.13.0"
+        "jms/serializer": "<1.13.0",
+        "symfony/routing": ">6"
     },
     "minimum-stability":  "dev",
     "extra": {


### PR DESCRIPTION
This PR follow #2332
Tests are currently failling with `symfony/routing` v6.
In order to be compatible with Symfony framework bundle in version 5.4 without delay, we have to add a conflict rule to avoid the installation of this version, the time to add/ensure a compatibility.
