### PR TITLE
Add phpunit result cache file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 composer.lock
 composer.phar
 .php-cs-fixer.cache
+/.phpunit.result.cache


### PR DESCRIPTION
As PHPUnit installation and configuration is specific to this library and not to the contributor, this file should be added to the `.gitignore`