### PR TITLE
Fix compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,6 +35,8 @@ jobs:
             symfony-require: "5.2.*"
           - php-version: 8.0
             composer-flags: "--ignore-platform-reqs --prefer-stable"
+          - php-version: 8.1
+            composer-flags: "--prefer-stable"
 
     steps:
       - name: "Checkout"

--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -125,7 +125,7 @@ class BodyListener
 
     private function isFormRequest(Request $request): bool
     {
-        $contentTypeParts = explode(';', $request->headers->get('Content-Type'));
+        $contentTypeParts = explode(';', $request->headers->get('Content-Type', ''));
 
         if (isset($contentTypeParts[0])) {
             return in_array($contentTypeParts[0], ['multipart/form-data', 'application/x-www-form-urlencoded']);

--- a/View/JsonpHandler.php
+++ b/View/JsonpHandler.php
@@ -50,7 +50,7 @@ final class JsonpHandler
         $callback = $request->query->get($this->callbackParam);
         $validator = new \JsonpCallbackValidator();
 
-        if (!$validator->validate($callback)) {
+        if (!is_string($callback) || !$validator->validate($callback)) {
             throw new BadRequestHttpException('Invalid JSONP callback value');
         }
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "doctrine/annotations": "^1.13.2",
         "psr/log": "^1.0|^2.0|^3.0",
         "sensio/framework-extra-bundle": "^5.2.3",
-        "symfony/phpunit-bridge": "^5.2",
+        "symfony/phpunit-bridge": "^5.3.10",
         "symfony/asset": "^4.4|^5.0",
         "symfony/form": "^4.4|^5.0",
         "symfony/mime": "^4.4|^5.0",


### PR DESCRIPTION
The remaining deprecation warnings in the PHP 8.1 pipeline will be fixed by the following PRs:

>   1x: PHPUnit\Runner\DefaultTestResultCache implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
>     1x in DebugClassLoader::loadClass from Symfony\Component\ErrorHandler

--> https://github.com/symfony/symfony/pull/43200 (PHPUnit 9.5 instead of PHPUnit 9.4 will be used)

>  2x: substr_count(): Passing null to parameter `#1` ($haystack) of type string is deprecated
>    1x in FormatListenerTest::testOnKernelControllerNegotiation from FOS\RestBundle\Tests\EventListener
>    1x in FormatListenerTest::testUseSpecifiedFormat from FOS\RestBundle\Tests\EventListener

--> https://github.com/symfony/symfony/pull/43357

>  1x: JMS\SerializerBundle\DependencyInjection\Compiler\ServiceMapPass implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
>    1x in DependencyInjectionTest::testSerializerRelatedServicesAreNotRemovedWhenJmsSerializerBundleIsEnabled from FOS\RestBundle\Tests\Functional

--> https://github.com/schmittjoh/JMSSerializerBundle/pull/872