### PR TITLE
Allow new version of `willdurand/jsonp-callback-validator`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/http-kernel": "^4.4|^5.3|^6.0",
         "symfony/routing": "^4.4|^5.3|^6.0",
         "symfony/security-core": "^4.4|^5.3|^6.0",
-        "willdurand/jsonp-callback-validator": "^1.0",
+        "willdurand/jsonp-callback-validator": "^1.0|^2.0",
         "willdurand/negotiation": "^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
[Version 2.0](https://github.com/willdurand/JsonpCallbackValidator/releases/tag/v2.0.0) of `willdurand/jsonp-callback-validator` was tagged and released.  The actual change in the release won't be an issue here since the one place the validator is used is already making the `is_string()` check.