### PR TITLE
Fix backward compatibility layer for rest route annotations

### DIFF
--- a/Controller/Annotations/Route.php
+++ b/Controller/Annotations/Route.php
@@ -44,14 +44,15 @@ class Route extends BaseRoute
         // BC layer for symfony < 5.2
         // Before symfony/routing 5.2 the constructor only had one parameter
         $method = new \ReflectionMethod(BaseRoute::class, '__construct');
-        if (1 === $method->getNumberOfParameters()) {
-            if (\is_string($data)) {
-                $path = $data;
-                $data = [];
-            } elseif (!\is_array($data)) {
-                throw new \TypeError(sprintf('"%s": Argument $data is expected to be a string or array, got "%s".', __METHOD__, get_debug_type($data)));
-            }
 
+        if (\is_string($data)) {
+            $path = $data;
+            $data = [];
+        } elseif (!\is_array($data)) {
+            throw new \TypeError(sprintf('"%s": Argument $data is expected to be a string or array, got "%s".', __METHOD__, get_debug_type($data)));
+        }
+
+        if (1 === $method->getNumberOfParameters()) {
             $data['path'] = $path;
             $data['name'] = $name;
             $data['requirements'] = $requirements;


### PR DESCRIPTION
I'm currently updating: https://github.com/handcraftedinthealps/RestRoutingBundle/pull/18 and did stumble over an issue. That the path here: https://github.com/handcraftedinthealps/RestRoutingBundle/blob/745e0a70c854b55c2b1ff04dc72763b39734fd1a/Tests/Fixtures/Controller/AnnotatedUsersController.php#L170 was not used when using Symfony 6.