### PR TITLE
Fix deprecation in SF 6.1

### DIFF
--- a/Serializer/Normalizer/FlattenExceptionNormalizer.php
+++ b/Serializer/Normalizer/FlattenExceptionNormalizer.php
@@ -15,14 +15,14 @@ use FOS\RestBundle\Serializer\Serializer;
 use FOS\RestBundle\Util\ExceptionValueMap;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  *
  * @internal
  */
-final class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
+final class FlattenExceptionNormalizer implements NormalizerInterface
 {
     private $statusCodeMap;
     private $messagesMap;

--- a/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/Serializer/Normalizer/FormErrorNormalizer.php
@@ -38,7 +38,7 @@ class FormErrorNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null): bool
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof FormInterface && $data->isSubmitted() && !$data->isValid();
     }


### PR DESCRIPTION
Fix the following deprecation:

The "FOS\RestBundle\Serializer\Normalizer\FormErrorNormalizer::supportsNormalization()" method will require a new "array $context" argument in the next major version of its interface "Symfony\Component\Serializer\Normalizer\NormalizerInterface", not defining it is deprecated.

The "FOS\RestBundle\Serializer\Normalizer\FlattenExceptionNormalizer" class implements "Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface" that is deprecated since symfony/serializer 6.1, use NormalizerInterface instead.
