### PR TITLE
Trigger new event to allow updating the response based on view data at one central place

### DIFF
--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -293,6 +293,7 @@ class FOSRestExtension extends Extension
             $config['view']['empty_content'],
             $config['view']['serialize_null'],
         ]);
+        $defaultViewHandler->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')]);
     }
 
     private function loadException(array $config, XmlFileLoader $loader, ContainerBuilder $container): void

--- a/Resources/doc/2-the-view-layer.rst
+++ b/Resources/doc/2-the-view-layer.rst
@@ -198,6 +198,33 @@ data transformer. Fortunately, the FOSRestBundle comes with an
 This way, the data structure remains untouched and the person can be assigned to
 the task without any client modifications.
 
+Update the Response based on View Data
+--------------------------------------
+
+If you have the need to globally modify the response depending on the view data
+you can use the ``ViewResponseEvent``. It allows you to do some custom stuff
+at one central place and reduce repetitive work.
+
+Here's an example how to use it:
+
+.. code-block:: php
+    namespace App\EventListener;
+
+    use FOS\RestBundle\View\ViewResponseEvent;
+    use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+    #[AsEventListener]
+    class PaginationViewResponseListener
+    {
+        public function __invoke(ViewResponseEvent $event): void
+        {
+            $view = $event->getView(); // you have access to the view and the response
+            $response = $event->getResponse();
+            // ...
+        }
+    }
+
+
 Configuration
 -------------
 

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * View may be used in controllers to build up a response in a format agnostic way
@@ -52,6 +53,7 @@ final class ViewHandler implements ConfigurableViewHandlerInterface
     private $urlGenerator;
     private $serializer;
     private $requestStack;
+    private $dispatcher = null;
     private $options;
 
     private function __construct(
@@ -198,7 +200,17 @@ final class ViewHandler implements ConfigurableViewHandlerInterface
             $response->headers->set('Content-Type', $mimeType);
         }
 
+        if (null !== $this->dispatcher) {
+            $event = new ViewResponseEvent($view, $response, $request);
+            $this->dispatcher->dispatch($event);
+        }
+
         return $response;
+    }
+
+    public function setEventDispatcher(EventDispatcherInterface $dispatcher): void
+    {
+        $this->dispatcher = $dispatcher;
     }
 
     /**

--- a/View/ViewResponseEvent.php
+++ b/View/ViewResponseEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\View;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Allows to update the Response an the basis of view data.
+ */
+class ViewResponseEvent
+{
+    private $view;
+    private $response;
+    private $request;
+
+    public function __construct(View $view, Response $response, Request $request)
+    {
+        $this->view = $view;
+        $this->response = $response;
+        $this->request = $request;
+    }
+
+    public function getView(): View
+    {
+        return $this->view;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}


### PR DESCRIPTION
Currently it is not easily possible to access the response object and the view at the same time. I have the use case, that I want to return a paginated list of data (using the [KnpPaginationBundle](https://github.com/KnpLabs/KnpPaginatorBundle)) so I pass a pagination wrapper to the view layer.

The response has to contain some meta data (in fact I am using the `Link` header similar to [Githubs API](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28)), but I want to do this decoration at one central place and not in each controller. This is currently not possible. So I added a new event that is triggered in the `createResponse` method of the `ViewHandler`.

I think this addition could be useful for others, too. So I hope this gets merged.