### PR TITLE
Fixed SF 6.3 deprecations for Normalizers

### DIFF
--- a/Serializer/Normalizer/FlattenExceptionNormalizer.php
+++ b/Serializer/Normalizer/FlattenExceptionNormalizer.php
@@ -74,6 +74,13 @@ final class FlattenExceptionNormalizer implements NormalizerInterface
         }
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            FlattenException::class => false,
+        ];
+    }
+
     public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         if (!($data instanceof FlattenException)) {

--- a/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/Serializer/Normalizer/FormErrorNormalizer.php
@@ -35,6 +35,13 @@ class FormErrorNormalizer implements NormalizerInterface
         ];
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            FormInterface::class => false,
+        ];
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Classes that implement the `Symfony\Component\Serializer\NormalizerInterface` will require the getSupportedTypes method for Symfony >= 7.0 (see [here](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php)).

Currently Symfony's phpunit-bridge reports deprecation messages.

I have added the required function for the FlattenExceptionNormalizer and the FormErrorNormalizer.