### PR TITLE
WIP: Allow installation with Symfony 7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,10 +20,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: 7.2
+          - php-version: 7.4
             composer-flags: "--prefer-lowest "
             can-fail: false
-          - php-version: 7.3
+          - php-version: 7.4
             composer-flags: ""
             can-fail: false
           - php-version: 7.4
@@ -49,7 +49,14 @@ jobs:
             symfony-require: "6.3.*"
           - php-version: 8.2
             composer-flags: ""
+            can-fail: false
+            symfony-require: "6.4.*"
+          - php-version: 8.2
+            composer-flags: ""
             can-fail: true # we don't want to fail the build if we are incompatible with the next (unstable) Symfony version
+
+    env:
+      COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: "Checkout"
@@ -82,7 +89,6 @@ jobs:
         env:
           SYMFONY_REQUIRE: "${{ matrix.symfony-require }}"
         run: |
-          composer remove friendsofphp/php-cs-fixer --dev --no-update
           composer update --no-interaction --no-progress ${{ matrix.composer-flags }}
 
       - name: "Run PHPUnit"

--- a/composer.json
+++ b/composer.json
@@ -28,43 +28,47 @@
             "Tests/"
         ]
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:mbabker/JMSSerializerBundle.git"
+        }
+    ],
     "require": {
-        "php": "^7.2|^8.0",
-        "symfony/config": "^5.4|^6.0",
-        "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/event-dispatcher": "^5.4|^6.0",
-        "symfony/framework-bundle": "^4.4.1|^5.0|^6.0",
-        "symfony/http-foundation": "^5.4|^6.0",
-        "symfony/http-kernel": "^5.4|^6.0",
-        "symfony/routing": "^5.4|^6.0",
-        "symfony/security-core": "^5.4|^6.0",
+        "php": "^7.4|^8.0",
+        "symfony/config": "^5.4|^6.0|^7.0",
+        "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+        "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^4.4.1|^5.0|^6.0|^7.0",
+        "symfony/http-foundation": "^5.4|^6.0|^7.0",
+        "symfony/http-kernel": "^5.4|^6.0|^7.0",
+        "symfony/routing": "^5.4|^6.0|^7.0",
+        "symfony/security-core": "^5.4|^6.0|^7.0",
         "willdurand/jsonp-callback-validator": "^1.0|^2.0",
         "willdurand/negotiation": "^2.0|^3.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13.2|^2.0 ",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "php-cs-fixer/shim": "^3.0",
+        "jms/serializer-bundle": "dev-symfony-7 as 5.99",
         "jms/serializer": "^1.13|^2.0|^3.0",
-        "jms/serializer-bundle": "^2.4.3|^3.0.1|^4.0|^5.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "sensio/framework-extra-bundle": "^6.1",
-        "symfony/phpunit-bridge": "^5.4|^6.0",
-        "symfony/asset": "^5.4|^6.0",
-        "symfony/browser-kit": "^5.4|^6.0",
-        "symfony/css-selector": "^5.4|^6.0",
-        "symfony/expression-language": "^5.4|^6.0",
-        "symfony/form": "^5.4|^6.0",
-        "symfony/mime": "^5.4|^6.0",
-        "symfony/security-bundle": "^5.4|^6.0",
-        "symfony/serializer": "^5.4|^6.0",
-        "symfony/twig-bundle": "^5.4|^6.0",
-        "symfony/validator": "^5.4|^6.0",
-        "symfony/web-profiler-bundle": "^5.4|^6.0",
-        "symfony/yaml": "^5.4|^6.0"
+        "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
+        "symfony/asset": "^5.4|^6.0|^7.0",
+        "symfony/browser-kit": "^5.4|^6.0|^7.0",
+        "symfony/css-selector": "^5.4|^6.0|^7.0",
+        "symfony/expression-language": "^5.4|^6.0|^7.0",
+        "symfony/form": "^5.4|^6.0|^7.0",
+        "symfony/mime": "^5.4|^6.0|^7.0",
+        "symfony/security-bundle": "^5.4|^6.0|^7.0",
+        "symfony/serializer": "^5.4|^6.0|^7.0",
+        "symfony/twig-bundle": "^5.4|^6.0|^7.0",
+        "symfony/validator": "^5.4|^6.0|^7.0",
+        "symfony/web-profiler-bundle": "^5.4|^6.0|^7.0",
+        "symfony/yaml": "^5.4|^6.0|^7.0"
     },
     "suggest": {
-        "sensio/framework-extra-bundle": "Add support for the request body converter and the view response listener, requires ^3.0",
         "jms/serializer-bundle": "Add support for advanced serialization capabilities, recommended, requires ^2.0|^3.0",
         "symfony/serializer": "Add support for basic serialization capabilities and xml decoding, requires ^2.7|^3.0",
         "symfony/validator": "Add support for validation capabilities in the ParamFetcher, requires ^2.7|^3.0"


### PR DESCRIPTION
I want to use this as a discussion point how we can keep this bundle compatibilty with the latest Symfony Version. The hardest part mostly will be the deprecation of the [Symfony FrameworkExtraBundle](https://github.com/sensiolabs/SensioFrameworkExtraBundle).

Some background from our side we @sulu use highly the FOSRestBundle and even still use [RestRoutingBundle](https://github.com/handcraftedinthealps/RestRoutingBundle). We are not using any FrameworkExtraBundle so one solution from our side is also skip the ExtraBundle related features when the ExtraBundle is not installed.

# Requires

 - [ ] https://github.com/schmittjoh/JMSSerializerBundle/pull/937 (@mbabker  Symfony 7 PR for JMS Serializer)

# TODO

 - [ ] Fix compatibility
 - [ ] Decide which min Version for PHP (7.4 would currently be required by the php-cs-fixer shim)
 - [ ] Decide what todo with the [Symfony FrameworkExtraBundle](https://github.com/sensiolabs/SensioFrameworkExtraBundle) requirement / features build ontop of it?
    - [ ] ParameterConverter -> ArgumentResolver?
    - [ ] BodyListener -> normal RequestListener?
