### PR TITLE
Allow RequestParam and FileParam to target class

### DIFF
--- a/Controller/Annotations/FileParam.php
+++ b/Controller/Annotations/FileParam.php
@@ -22,8 +22,7 @@ use Symfony\Component\Validator\Constraints\Image;
  *
  * @Annotation
  * @NamedArgumentConstructor
- * @Target("METHOD")
- * @Target("CLASS")
+ * @Target({"METHOD", "CLASS"})
  *
  * @author Ener-Getick <egetick@gmail.com>
  */

--- a/Controller/Annotations/FileParam.php
+++ b/Controller/Annotations/FileParam.php
@@ -23,6 +23,7 @@ use Symfony\Component\Validator\Constraints\Image;
  * @Annotation
  * @NamedArgumentConstructor
  * @Target("METHOD")
+ * @Target("CLASS")
  *
  * @author Ener-Getick <egetick@gmail.com>
  */

--- a/Controller/Annotations/FileParam.php
+++ b/Controller/Annotations/FileParam.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints\Image;
  *
  * @author Ener-Getick <egetick@gmail.com>
  */
-#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 class FileParam extends AbstractParam
 {
     /** @var bool */

--- a/Controller/Annotations/RequestParam.php
+++ b/Controller/Annotations/RequestParam.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @Annotation
  * @NamedArgumentConstructor
  * @Target("METHOD")
+ * @Target("CLASS")
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Boris Guéry    <guery.b@gmail.com>

--- a/Controller/Annotations/RequestParam.php
+++ b/Controller/Annotations/RequestParam.php
@@ -18,8 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @Annotation
  * @NamedArgumentConstructor
- * @Target("METHOD")
- * @Target("CLASS")
+ * @Target({"METHOD", "CLASS"})
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Boris Guéry    <guery.b@gmail.com>

--- a/Controller/Annotations/RequestParam.php
+++ b/Controller/Annotations/RequestParam.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Boris Guéry    <guery.b@gmail.com>
  */
-#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::IS_REPEATABLE | \Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 class RequestParam extends AbstractScalarParam
 {
     /** @var bool */


### PR DESCRIPTION
Hi,

To be consistent across the different available params and be able to place them on class, it requires to add `\Attribute::TARGET_CLASS` to the `RequestParam` and `FileParam`.

I added the annotation for compatibility too.

Hopefully this can be merged and release before #2400 as they may be incompatible.

Thanks

[edit]: Actions seems to be broken due to composer.json or lock file. Not sure how to resolve. Let me know if I can help on this too.