### PR TITLE
fix: Sensio extra bundle TemplateListener invocation before view response listener and serialization

### DIFF
--- a/EventListener/ViewResponseListener.php
+++ b/EventListener/ViewResponseListener.php
@@ -170,7 +170,7 @@ class ViewResponseListener implements EventSubscriberInterface
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',
-            KernelEvents::VIEW => ['onKernelView', -128],
+            KernelEvents::VIEW => ['onKernelView', 30],
         ];
     }
 

--- a/Tests/Functional/Bundle/TestBundle/Controller/ArticleController.php
+++ b/Tests/Functional/Bundle/TestBundle/Controller/ArticleController.php
@@ -32,14 +32,26 @@ class ArticleController extends AbstractFOSRestController
     }
 
     /**
-     * @Get("/articles.{_format}", name="get_article", defaults={"_format": "html"})
+     * @Get("/articles.{_format}", name="get_articles", defaults={"_format": "html"})
      *
      * @View()
      */
-    #[Get(path: '/articles.{_format}', name: 'get_article', defaults: ['_format' => 'html'])]
+    #[Get(path: '/articles.{_format}', name: 'get_articles', defaults: ['_format' => 'html'])]
     #[View]
     public function cgetAction()
     {
         return $this->view();
+    }
+
+    /**
+     * @Get("/articles/{id}.{_format}", name="get_article", defaults={"_format": "html"})
+     *
+     * @View()
+     */
+    #[Get(path: '/articles/{id}.{_format}', name: 'get_article', defaults: ['_format' => 'html'])]
+    #[View]
+    public function cgetSingleAction(int $id)
+    {
+        return ['id' => $id];
     }
 }

--- a/Tests/Functional/ViewResponseListenerTest.php
+++ b/Tests/Functional/ViewResponseListenerTest.php
@@ -35,4 +35,12 @@ class ViewResponseListenerTest extends WebTestCase
         $this->assertSame('http://localhost/hello/Post%201', $client->getResponse()->headers->get('location'));
         $this->assertStringNotContainsString('fooo', $client->getResponse()->getContent());
     }
+
+    public function testControllerReturnsView()
+    {
+        $client = $this->createClient(['test_case' => 'ViewResponseListener']);
+        $client->request('GET', '/articles.json');
+
+        $this->assertTrue($client->getResponse()->isSuccessful());
+    }
 }

--- a/Tests/Functional/app/ViewResponseListener/bundles.php
+++ b/Tests/Functional/app/ViewResponseListener/bundles.php
@@ -11,6 +11,7 @@
 
 $bundles = [
     new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new \Symfony\Bundle\TwigBundle\TwigBundle(),
     new \FOS\RestBundle\FOSRestBundle(),
     new \FOS\RestBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
         xsi:noNamespaceSchemaLocation=".phpunit/phpunit.xsd"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=104&amp;max[indirect]=243"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=120&amp;max[indirect]=243"/>
         <env name="SYMFONY_PHPUNIT_VERSION" value="9.6"/>
         <ini name="error_reporting" value="-1"/>
         <server name="SHELL_VERBOSITY" value="-1"/>


### PR DESCRIPTION
Hi,

As discussed in #2400 and pointed in #2409 (thanks for the bundles.php, not sure I would have found it without a lot of struggles :sweat_smile: ) here is the fix and test.

I relied on the existing redirect test as this existing one and the one you provided trigger the same error. A test idea which could cover more cases (and may be more common) would be that the controller returns an object to be serialized but it would require to add symfony serializer or jms into the loaded bundles and provide the necessary configuration I think.

Let me know if I really should add the new test you provide or a modified one which could return an `\stdClass` which should be serialized via the view response listener.

Thanks @mbabker 