### PR TITLE
Update route requirements docblock

### DIFF
--- a/Controller/Annotations/Route.php
+++ b/Controller/Annotations/Route.php
@@ -45,11 +45,11 @@ if (class_exists(BaseAttributeRoute::class)) {
 class Route extends CompatRoute
 {
     /**
-     * @param array|string      $data
-     * @param array|string|null $path
-     * @param string[]          $requirements
-     * @param string[]|string   $methods
-     * @param string[]|string   $schemes
+     * @param array|string              $data
+     * @param array|string|null         $path
+     * @param array<string|\Stringable> $requirements
+     * @param string[]|string           $methods
+     * @param string[]|string           $schemes
      *
      * @throws \TypeError if the $data argument is an unsupported type
      */


### PR DESCRIPTION
Fixes Phpstan error when using backed enums on route requirements.

It currently fails with `Parameter $requirements of attribute class FOS\RestBundle\Controller\Annotations\Post constructor expects array<string>, array<string, Symfony\Component\Routing\Requirement\EnumRequirement> given.`