### PR TITLE
Declare nullable parameter types explicitly

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,7 @@ return (new PhpCsFixer\Config())
     ->setRules([
         'psr_autoloading' => true,
         'header_comment' => ['header' => $header],
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/Context/Context.php
+++ b/Context/Context.php
@@ -111,7 +111,7 @@ final class Context
      *
      * @param string[]|null $groups
      */
-    public function setGroups(array $groups = null): self
+    public function setGroups(?array $groups = null): self
     {
         $this->groups = $groups;
 

--- a/Controller/Annotations/Route.php
+++ b/Controller/Annotations/Route.php
@@ -56,20 +56,20 @@ class Route extends CompatRoute
     public function __construct(
         $data = [],
         $path = null,
-        string $name = null,
+        ?string $name = null,
         array $requirements = [],
         array $options = [],
         array $defaults = [],
-        string $host = null,
+        ?string $host = null,
         $methods = [],
         $schemes = [],
-        string $condition = null,
-        int $priority = null,
-        string $locale = null,
-        string $format = null,
-        bool $utf8 = null,
-        bool $stateless = null,
-        string $env = null
+        ?string $condition = null,
+        ?int $priority = null,
+        ?string $locale = null,
+        ?string $format = null,
+        ?bool $utf8 = null,
+        ?bool $stateless = null,
+        ?string $env = null
     ) {
         // Use Reflection to get the constructor from the parent class two levels up (accounting for our compat definition)
         $method = (new \ReflectionClass($this))->getParentClass()->getParentClass()->getMethod('__construct');

--- a/DependencyInjection/FOSRestExtension.php
+++ b/DependencyInjection/FOSRestExtension.php
@@ -393,7 +393,7 @@ class FOSRestExtension extends ConfigurableExtension
         }
     }
 
-    private function createZoneRequestMatcher(ContainerBuilder $container, ?string $path = null, ?string $host = null, array $methods = [], array $ips = null): Reference
+    private function createZoneRequestMatcher(ContainerBuilder $container, ?string $path = null, ?string $host = null, array $methods = [], ?array $ips = null): Reference
     {
         if ($methods) {
             $methods = array_map('strtoupper', (array) $methods);

--- a/ErrorRenderer/SerializerErrorRenderer.php
+++ b/ErrorRenderer/SerializerErrorRenderer.php
@@ -34,7 +34,7 @@ final class SerializerErrorRenderer implements ErrorRendererInterface
      * @param string|callable(FlattenException) $format
      * @param string|bool                       $debug
      */
-    public function __construct(Serializer $serializer, $format, ErrorRendererInterface $fallbackErrorRenderer = null, $debug = false)
+    public function __construct(Serializer $serializer, $format, ?ErrorRendererInterface $fallbackErrorRenderer = null, $debug = false)
     {
         if (!is_string($format) && !is_callable($format)) {
             throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be a string or a callable, "%s" given.', __METHOD__, \is_object($format) ? \get_class($format) : \gettype($format)));

--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -40,7 +40,7 @@ class BodyListener
     public function __construct(
         DecoderProviderInterface $decoderProvider,
         bool $throwExceptionOnUnsupportedContentType = false,
-        ArrayNormalizerInterface $arrayNormalizer = null,
+        ?ArrayNormalizerInterface $arrayNormalizer = null,
         bool $normalizeForms = false
     ) {
         $this->decoderProvider = $decoderProvider;

--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -41,7 +41,7 @@ final class RequestBodyParamConverter implements ParamConverterInterface
         Serializer $serializer,
         ?array $groups = null,
         ?string $version = null,
-        ValidatorInterface $validator = null,
+        ?ValidatorInterface $validator = null,
         ?string $validationErrorsArgument = null
     ) {
         $this->serializer = $serializer;

--- a/Resources/doc/examples/RssHandler.php
+++ b/Resources/doc/examples/RssHandler.php
@@ -48,7 +48,7 @@ class RssHandler
 {
     private $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }

--- a/Resources/doc/examples/RssHandler.php
+++ b/Resources/doc/examples/RssHandler.php
@@ -100,8 +100,8 @@ class RssHandler
             $entry->setLink($document['url']);
             $entry->addAuthor([
                 'name' => $document['author'],
-                //'email' => '',
-                //'uri'   => '',
+                // 'email' => '',
+                // 'uri'   => '',
             ]);
 
             $entry->setDateModified($document['dateUpdated']->getTimestamp());

--- a/Serializer/JMSSerializerAdapter.php
+++ b/Serializer/JMSSerializerAdapter.php
@@ -42,8 +42,8 @@ final class JMSSerializerAdapter implements Serializer
 
     public function __construct(
         SerializerInterface $serializer,
-        SerializationContextFactoryInterface $serializationContextFactory = null,
-        DeserializationContextFactoryInterface $deserializationContextFactory = null
+        ?SerializationContextFactoryInterface $serializationContextFactory = null,
+        ?DeserializationContextFactoryInterface $deserializationContextFactory = null
     ) {
         $this->serializer = $serializer;
         $this->serializationContextFactory = $serializationContextFactory;

--- a/Serializer/Normalizer/FormErrorHandler.php
+++ b/Serializer/Normalizer/FormErrorHandler.php
@@ -39,7 +39,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
         return JMSFormErrorHandler::getSubscribingMethods();
     }
 
-    public function serializeFormToXml(XmlSerializationVisitor $visitor, Form $form, array $type, Context $context = null)
+    public function serializeFormToXml(XmlSerializationVisitor $visitor, Form $form, array $type, ?Context $context = null)
     {
         if ($context) {
             if ($context->hasAttribute('status_code')) {
@@ -72,7 +72,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
         return $this->formErrorHandler->serializeFormToXml($visitor, $form, $type);
     }
 
-    public function serializeFormToJson(JsonSerializationVisitor $visitor, Form $form, array $type, Context $context = null)
+    public function serializeFormToJson(JsonSerializationVisitor $visitor, Form $form, array $type, ?Context $context = null)
     {
         $isRoot = !interface_exists(SerializationVisitorInterface::class) && null === $visitor->getRoot();
         $result = $this->adaptFormArray($this->formErrorHandler->serializeFormToJson($visitor, $form, $type), $context);
@@ -84,7 +84,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
         return $result;
     }
 
-    public function serializeFormToYml(YamlSerializationVisitor $visitor, Form $form, array $type, Context $context = null)
+    public function serializeFormToYml(YamlSerializationVisitor $visitor, Form $form, array $type, ?Context $context = null)
     {
         $isRoot = null === $visitor->getRoot();
         $result = $this->adaptFormArray($this->formErrorHandler->serializeFormToYml($visitor, $form, $type), $context);
@@ -101,7 +101,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
         return call_user_func_array([$this->formErrorHandler, $name], $arguments);
     }
 
-    private function adaptFormArray(\ArrayObject $serializedForm, Context $context = null)
+    private function adaptFormArray(\ArrayObject $serializedForm, ?Context $context = null)
     {
         $statusCode = $this->getStatusCode($context);
         if (null !== $statusCode) {
@@ -115,7 +115,7 @@ class FormErrorHandler implements SubscribingHandlerInterface
         return $serializedForm;
     }
 
-    private function getStatusCode(Context $context = null)
+    private function getStatusCode(?Context $context = null)
     {
         if (null === $context) {
             return;

--- a/Tests/Functional/Bundle/TestBundle/Security/ApiTokenGuardAuthenticator.php
+++ b/Tests/Functional/Bundle/TestBundle/Security/ApiTokenGuardAuthenticator.php
@@ -73,7 +73,7 @@ class ApiTokenGuardAuthenticator extends AbstractGuardAuthenticator
     /**
      * Called when authentication is needed, but it's not sent.
      */
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         $data = ['message' => 'Authentication Required'];
 

--- a/View/ViewHandler.php
+++ b/View/ViewHandler.php
@@ -58,7 +58,7 @@ final class ViewHandler implements ConfigurableViewHandlerInterface
         UrlGeneratorInterface $urlGenerator,
         Serializer $serializer,
         RequestStack $requestStack,
-        array $formats = null,
+        ?array $formats = null,
         int $failedValidationCode = Response::HTTP_BAD_REQUEST,
         int $emptyContentCode = Response::HTTP_NO_CONTENT,
         bool $serializeNull = false,
@@ -83,7 +83,7 @@ final class ViewHandler implements ConfigurableViewHandlerInterface
         UrlGeneratorInterface $urlGenerator,
         Serializer $serializer,
         RequestStack $requestStack,
-        array $formats = null,
+        ?array $formats = null,
         int $failedValidationCode = Response::HTTP_BAD_REQUEST,
         int $emptyContentCode = Response::HTTP_NO_CONTENT,
         bool $serializeNull = false,
@@ -137,7 +137,7 @@ final class ViewHandler implements ConfigurableViewHandlerInterface
      *
      * @throws UnsupportedMediaTypeHttpException
      */
-    public function handle(View $view, Request $request = null): Response
+    public function handle(View $view, ?Request $request = null): Response
     {
         if (null === $request) {
             $request = $this->requestStack->getCurrentRequest();

--- a/View/ViewHandlerInterface.php
+++ b/View/ViewHandlerInterface.php
@@ -41,7 +41,7 @@ interface ViewHandlerInterface
      *
      * @return Response
      */
-    public function handle(View $view, Request $request = null);
+    public function handle(View $view, ?Request $request = null);
 
     /**
      * @return Response


### PR DESCRIPTION
Implicitly nullable parameter types will be deprecated in PHP 8.4: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types