### PR TITLE
FIx usage of Regex validator constructor

### DIFF
--- a/Controller/Annotations/AbstractScalarParam.php
+++ b/Controller/Annotations/AbstractScalarParam.php
@@ -42,8 +42,8 @@ abstract class AbstractScalarParam extends AbstractParam
             $constraints[] = $this->requirements;
         } elseif (is_scalar($this->requirements)) {
             $constraints[] = new Regex(
-                pattern: '#^(?:'.$this->requirements.')$#xsu',
-                message: sprintf(
+                '#^(?:'.$this->requirements.')$#xsu',
+                sprintf(
                     'Parameter \'%s\' value, does not match requirements \'%s\'',
                     $this->getName(),
                     $this->requirements
@@ -51,8 +51,8 @@ abstract class AbstractScalarParam extends AbstractParam
             );
         } elseif (is_array($this->requirements) && isset($this->requirements['rule']) && $this->requirements['error_message']) {
             $constraints[] = new Regex(
-                pattern: '#^(?:'.$this->requirements['rule'].')$#xsu',
-                message: $this->requirements['error_message'],
+                '#^(?:'.$this->requirements['rule'].')$#xsu',
+                $this->requirements['error_message'],
             );
         } elseif (is_array($this->requirements)) {
             foreach ($this->requirements as $index => $requirement) {

--- a/Controller/Annotations/AbstractScalarParam.php
+++ b/Controller/Annotations/AbstractScalarParam.php
@@ -41,19 +41,19 @@ abstract class AbstractScalarParam extends AbstractParam
         if ($this->requirements instanceof Constraint) {
             $constraints[] = $this->requirements;
         } elseif (is_scalar($this->requirements)) {
-            $constraints[] = new Regex([
-                'pattern' => '#^(?:'.$this->requirements.')$#xsu',
-                'message' => sprintf(
+            $constraints[] = new Regex(
+                pattern: '#^(?:'.$this->requirements.')$#xsu',
+                message: sprintf(
                     'Parameter \'%s\' value, does not match requirements \'%s\'',
                     $this->getName(),
                     $this->requirements
                 ),
-            ]);
+            );
         } elseif (is_array($this->requirements) && isset($this->requirements['rule']) && $this->requirements['error_message']) {
-            $constraints[] = new Regex([
-                'pattern' => '#^(?:'.$this->requirements['rule'].')$#xsu',
-                'message' => $this->requirements['error_message'],
-            ]);
+            $constraints[] = new Regex(
+                pattern: '#^(?:'.$this->requirements['rule'].')$#xsu',
+                message: $this->requirements['error_message'],
+            );
         } elseif (is_array($this->requirements)) {
             foreach ($this->requirements as $index => $requirement) {
                 if ($requirement instanceof Constraint) {


### PR DESCRIPTION
Fixes "Passing an array of options to configure the \"FOS\\RestBundle\\Validator\\Constraints\\Regex\" constraint is deprecated, use named arguments instead."

Link to issue: https://github.com/FriendsOfSymfony/FOSRestBundle/issues/2416