### PR TITLE
Fix deprecations from symfony/validator

### DIFF
--- a/Controller/Annotations/AbstractScalarParam.php
+++ b/Controller/Annotations/AbstractScalarParam.php
@@ -41,19 +41,19 @@ abstract class AbstractScalarParam extends AbstractParam
         if ($this->requirements instanceof Constraint) {
             $constraints[] = $this->requirements;
         } elseif (is_scalar($this->requirements)) {
-            $constraints[] = new Regex([
-                'pattern' => '#^(?:'.$this->requirements.')$#xsu',
-                'message' => sprintf(
+            $constraints[] = new Regex(
+                '#^(?:'.$this->requirements.')$#xsu',
+                sprintf(
                     'Parameter \'%s\' value, does not match requirements \'%s\'',
                     $this->getName(),
                     $this->requirements
                 ),
-            ]);
+            );
         } elseif (is_array($this->requirements) && isset($this->requirements['rule']) && $this->requirements['error_message']) {
-            $constraints[] = new Regex([
-                'pattern' => '#^(?:'.$this->requirements['rule'].')$#xsu',
-                'message' => $this->requirements['error_message'],
-            ]);
+            $constraints[] = new Regex(
+                '#^(?:'.$this->requirements['rule'].')$#xsu',
+                $this->requirements['error_message'],
+            );
         } elseif (is_array($this->requirements)) {
             foreach ($this->requirements as $index => $requirement) {
                 if ($requirement instanceof Constraint) {
@@ -75,9 +75,12 @@ abstract class AbstractScalarParam extends AbstractParam
         // If the user wants to map the value, apply all constraints to every
         // value of the map
         if ($this->map) {
-            $constraints = [
-                new All(['constraints' => $constraints]),
-            ];
+            if ([] !== $constraints) {
+                $constraints = [
+                    new All($constraints),
+                ];
+            }
+
             if (false === $this->nullable) {
                 $constraints[] = new NotNull();
             }

--- a/Controller/Annotations/FileParam.php
+++ b/Controller/Annotations/FileParam.php
@@ -79,15 +79,19 @@ class FileParam extends AbstractParam
 
         $options = is_array($this->requirements) ? $this->requirements : [];
         if ($this->image) {
-            $constraints[] = new Image($options);
+            $constraint = new Image();
         } else {
-            $constraints[] = new File($options);
+            $constraint = new File();
         }
+        foreach ($options as $name => $value) {
+            $constraint->$name = $value;
+        }
+        $constraints[] = $constraint;
 
         // If the user wants to map the value
         if ($this->map) {
             $constraints = [
-                new All(['constraints' => $constraints]),
+                new All($constraints),
             ];
         }
 

--- a/Tests/Controller/Annotations/AbstractScalarParamTest.php
+++ b/Tests/Controller/Annotations/AbstractScalarParamTest.php
@@ -133,8 +133,6 @@ class AbstractScalarParamTest extends TestCase
     {
         $this->param->nullable = true;
         $this->param->map = true;
-        $this->assertEquals([new All([
-            'constraints' => [],
-        ])], $this->param->getConstraints());
+        $this->assertEquals([], $this->param->getConstraints());
     }
 }

--- a/Tests/Controller/Annotations/FileParamTest.php
+++ b/Tests/Controller/Annotations/FileParamTest.php
@@ -75,19 +75,19 @@ class FileParamTest extends TestCase
     public function testFileRequirements()
     {
         $this->param->nullable = true;
-        $this->param->requirements = $requirements = ['mimeTypes' => 'application/json'];
+        $this->param->requirements = ['mimeTypes' => 'application/json'];
         $this->assertEquals([
-            new File($requirements),
+            new File(null, null, null, 'application/json'),
         ], $this->param->getConstraints());
     }
 
     public function testImageRequirements()
     {
         $this->param->image = true;
-        $this->param->requirements = $requirements = ['mimeTypes' => 'image/gif'];
+        $this->param->requirements = ['mimeTypes' => ['image/*']];
         $this->assertEquals([
             new NotNull(),
-            new Image($requirements),
+            new Image(null, null, null, ['image/*']),
         ], $this->param->getConstraints());
     }
 
@@ -95,20 +95,20 @@ class FileParamTest extends TestCase
     {
         $this->param->image = true;
         $this->param->map = true;
-        $this->param->requirements = $requirements = ['mimeTypes' => 'image/gif'];
+        $this->param->requirements = ['mimeTypes' => ['image/*']];
         $this->assertEquals([new All([
             new NotNull(),
-            new Image($requirements),
+            new Image(null, null, null, ['image/*']),
         ])], $this->param->getConstraints());
     }
 
     public function testFileConstraintsWhenParamIsAnArray()
     {
         $this->param->map = true;
-        $this->param->requirements = $requirements = ['mimeTypes' => 'application/pdf'];
+        $this->param->requirements = ['mimeTypes' => 'application/pdf'];
         $this->assertEquals([new All([
             new NotNull(),
-            new File($requirements),
+            new File(null, null, null, 'application/pdf'),
         ])], $this->param->getConstraints());
     }
 }


### PR DESCRIPTION
This PR fixes deprecations introduced in symfony/validator 7.3 (https://github.com/symfony/symfony/pull/54744). Some of them are fixed in #2417 too, but I thought it would be clearer to include them in this PR as well.

Failing tests for PHP 8.3 and 8.4 are not related to the modifications, they also occur on the 3.x-branch.

Fixes #2416