### PR TITLE
Fix MimeTypeListenerTest for latest symfony versions

### DIFF
--- a/Tests/EventListener/MimeTypeListenerTest.php
+++ b/Tests/EventListener/MimeTypeListenerTest.php
@@ -55,6 +55,8 @@ class MimeTypeListenerTest extends TestCase
         $listener = new MimeTypeListener(['soap' => ['application/soap+xml']]);
 
         $request = new Request();
+        $mimeType = $request->getMimeType('soap');
+
         $request->attributes->set(FOSRestBundle::ZONE_ATTRIBUTE, false);
         $event = $this->getMockBuilder(RequestEvent::class)
             ->disableOriginalConstructor()->getMock();
@@ -68,7 +70,7 @@ class MimeTypeListenerTest extends TestCase
 
         $listener->onKernelRequest($event);
 
-        $this->assertNull($request->getMimeType('soap'));
+        $this->assertSame($mimeType, $request->getMimeType('soap'));
     }
 
     public function testOnKernelRequestWithZone()


### PR DESCRIPTION
Symfony 7.4 added mime type mapping for soap (see https://github.com/symfony/symfony/pull/61267).

This PR makes the MimeTypeListenerTest more robust by not expecting `null` explicitly but to check that the mime type was not changed.