### PR TITLE
Fix usage of null as an array offset which is deprecated in PHP 8.5

### DIFF
--- a/EventListener/AllowedMethodsListener.php
+++ b/EventListener/AllowedMethodsListener.php
@@ -41,10 +41,14 @@ class AllowedMethodsListener
 
         $allowedMethods = $this->loader->getAllowedMethods();
 
-        if (isset($allowedMethods[$event->getRequest()->attributes->get('_route')])) {
+        $route = $event->getRequest()->attributes->get('_route');
+        if (null === $route) {
+            $route = '';
+        }
+        if (isset($allowedMethods[$route])) {
             $event->getResponse()
                 ->headers
-                ->set('Allow', implode(', ', $allowedMethods[$event->getRequest()->attributes->get('_route')]));
+                ->set('Allow', implode(', ', $allowedMethods[$route]));
         }
     }
 }


### PR DESCRIPTION
> Using [null](https://www.php.net/manual/en/reserved.constants.php#constant.null) as an array offset or when calling [array_key_exists()](https://www.php.net/manual/en/function.array-key-exists.php) is now deprecated. Instead an empty string should be used.

https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset