### PR TITLE
Bugfix: Fix PHP 8.5 deprecation

### DIFF
--- a/EventListener/AllowedMethodsListener.php
+++ b/EventListener/AllowedMethodsListener.php
@@ -41,10 +41,14 @@ class AllowedMethodsListener
 
         $allowedMethods = $this->loader->getAllowedMethods();
 
-        if (isset($allowedMethods[$event->getRequest()->attributes->get('_route')])) {
+        if (null === $route = $event->getRequest()->attributes->get('_route')) {
+            return;
+        }
+
+        if (isset($allowedMethods[$route])) {
             $event->getResponse()
                 ->headers
-                ->set('Allow', implode(', ', $allowedMethods[$event->getRequest()->attributes->get('_route')]));
+                ->set('Allow', implode(', ', $allowedMethods[$route]));
         }
     }
 }


### PR DESCRIPTION
This PR fixes PHP 8.5 deprecation `Using null as an array offset is deprecated, use an empty string instead`