### PR TITLE
Fix incorrect PHPDoc return type for ParamFetcher::getParams()

### DIFF
--- a/Request/ParamFetcher.php
+++ b/Request/ParamFetcher.php
@@ -70,7 +70,7 @@ final class ParamFetcher implements ParamFetcherInterface
     }
 
     /**
-     * @return ParamInterface[]
+     * @return array<string, ParamInterface>
      */
     public function getParams(): array
     {


### PR DESCRIPTION
getParams() returns an associative array keyed by parameter name.
The current PHPDoc `@return ParamInterface[]` implies a numeric array/list of values.
This updates the annotation to `array<string, ParamInterface>`.