### PR TITLE
Support intersection types in param fetcher listener

### DIFF
--- a/EventListener/ParamFetcherListener.php
+++ b/EventListener/ParamFetcherListener.php
@@ -86,14 +86,16 @@ class ParamFetcherListener
     {
         $type = $controllerParam->getType();
         foreach ($type instanceof \ReflectionUnionType ? $type->getTypes() : [$type] as $type) {
-            if (null === $type || $type->isBuiltin() || !$type instanceof \ReflectionNamedType) {
-                continue;
-            }
+            foreach ($type instanceof \ReflectionIntersectionType ? $type->getTypes() : [$type] as $type) {
+                if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+                    continue;
+                }
 
-            $class = new \ReflectionClass($type->getName());
+                $class = new \ReflectionClass($type->getName());
 
-            if ($class->implementsInterface(ParamFetcherInterface::class)) {
-                return true;
+                if ($class->implementsInterface(ParamFetcherInterface::class)) {
+                    return true;
+                }
             }
         }
 

--- a/Tests/EventListener/ParamFetcherListenerTest.php
+++ b/Tests/EventListener/ParamFetcherListenerTest.php
@@ -17,6 +17,8 @@ use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Request\ParamFetcher;
 use FOS\RestBundle\Request\ParamReaderInterface;
 use FOS\RestBundle\Tests\Fixtures\Controller\ParamFetcherController;
+use FOS\RestBundle\Tests\Fixtures\Controller\ParamFetcherDnfTypeController;
+use FOS\RestBundle\Tests\Fixtures\Controller\ParamFetcherIntersectionTypeController;
 use FOS\RestBundle\Tests\Fixtures\Controller\ParamFetcherUnionTypeController;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -141,6 +143,14 @@ class ParamFetcherListenerTest extends TestCase
             $paramFetcher[] = ['byUnionTypeAction', 'pfu'];
         }
 
+        if (\PHP_VERSION_ID >= 80100) {
+            $paramFetcher[] = ['byIntersectionTypeAction', 'pfi'];
+        }
+
+        if (\PHP_VERSION_ID >= 80200) {
+            $paramFetcher[] = ['byDnfTypeAction', 'pfd'];
+        }
+
         return $paramFetcher;
     }
 
@@ -148,7 +158,15 @@ class ParamFetcherListenerTest extends TestCase
     {
         $this->requestStack->push($request);
 
-        $controller = \PHP_VERSION_ID < 80000 ? new ParamFetcherController() : new ParamFetcherUnionTypeController();
+        if (\PHP_VERSION_ID >= 80200) {
+            $controller = new ParamFetcherDnfTypeController();
+        } elseif (\PHP_VERSION_ID >= 80100) {
+            $controller = new ParamFetcherIntersectionTypeController();
+        } elseif (\PHP_VERSION_ID >= 80000) {
+            $controller = new ParamFetcherUnionTypeController();
+        } else {
+            $controller = new ParamFetcherController();
+        }
         $callable = $actionMethod ? [$controller, $actionMethod] : $controller;
         $kernel = $this->createMock(HttpKernelInterface::class);
 

--- a/Tests/Fixtures/Controller/ParamFetcherDnfTypeController.php
+++ b/Tests/Fixtures/Controller/ParamFetcherDnfTypeController.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Request\ParamFetcherInterface;
+
+/**
+ * Fixture for testing whether the ParamFetcher can be injected into
+ * a disjunctive normal form type-hinted controller method.
+ */
+class ParamFetcherDnfTypeController extends ParamFetcherIntersectionTypeController
+{
+    /**
+     * Make sure the ParamFetcher can be injected according to the DNF typehint.
+     */
+    public function byDnfTypeAction((ParamFetcherInterface&ParamFetcherIntersectionTypeMarkerInterface)|null $pfd)
+    {
+    }
+}

--- a/Tests/Fixtures/Controller/ParamFetcherIntersectionTypeController.php
+++ b/Tests/Fixtures/Controller/ParamFetcherIntersectionTypeController.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+use FOS\RestBundle\Request\ParamFetcherInterface;
+
+/**
+ * Fixture for testing whether the ParamFetcher can be injected into
+ * an intersection type-hinted controller method.
+ */
+class ParamFetcherIntersectionTypeController extends ParamFetcherUnionTypeController
+{
+    /**
+     * Make sure the ParamFetcher can be injected according to the intersection typehint.
+     */
+    public function byIntersectionTypeAction(ParamFetcherInterface&ParamFetcherIntersectionTypeMarkerInterface $pfi)
+    {
+    }
+}

--- a/Tests/Fixtures/Controller/ParamFetcherIntersectionTypeMarkerInterface.php
+++ b/Tests/Fixtures/Controller/ParamFetcherIntersectionTypeMarkerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\RestBundle\Tests\Fixtures\Controller;
+
+interface ParamFetcherIntersectionTypeMarkerInterface
+{
+}


### PR DESCRIPTION
Currently, the listener does not handle intersection types and fails when encountering one:

> Error: Call to undefined method ReflectionIntersectionType::isBuiltin()

This PR adds support for both intersection and DNF types.
