### PR TITLE
Fix deprecation warning when using symfony/http-foundation:8.1

### DIFF
--- a/EventListener/BodyListener.php
+++ b/EventListener/BodyListener.php
@@ -15,8 +15,6 @@ use FOS\RestBundle\Decoder\DecoderProviderInterface;
 use FOS\RestBundle\FOSRestBundle;
 use FOS\RestBundle\Normalizer\ArrayNormalizerInterface;
 use FOS\RestBundle\Normalizer\Exception\NormalizationException;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -89,11 +87,7 @@ class BodyListener
                 $decoder = $this->decoderProvider->getDecoder($format);
                 $data = $decoder->decode($content);
                 if (is_array($data)) {
-                    if (class_exists(InputBag::class)) {
-                        $request->request = new InputBag($data);
-                    } else {
-                        $request->request = new ParameterBag($data);
-                    }
+                    $request->request->replace($data);
 
                     $normalizeRequest = true;
                 } else {
@@ -111,11 +105,7 @@ class BodyListener
                 throw new BadRequestHttpException($e->getMessage());
             }
 
-            if (class_exists(InputBag::class)) {
-                $request->request = new InputBag($data);
-            } else {
-                $request->request = new ParameterBag($data);
-            }
+            $request->request->replace($data);
         }
     }
 

--- a/Tests/Controller/Annotations/FileParamTest.php
+++ b/Tests/Controller/Annotations/FileParamTest.php
@@ -14,7 +14,6 @@ namespace FOS\RestBundle\Tests\Controller\Annotations;
 use FOS\RestBundle\Controller\Annotations\AbstractParam;
 use FOS\RestBundle\Controller\Annotations\FileParam;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\FileBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\All;
@@ -50,16 +49,12 @@ class FileParamTest extends TestCase
             ->method('getKey')
             ->willReturn('foo');
 
-        $request = $this->getMockBuilder(Request::class)->getMock();
-        $parameterBag = $this->getMockBuilder(FileBag::class)->getMock();
-        $parameterBag
-            ->expects($this->once())
-            ->method('get')
-            ->with('foo', 'bar')
-            ->willReturn('foobar');
-        $request->files = $parameterBag;
+        $request = $this->getMockBuilder(Request::class)
+            ->onlyMethods([])
+            ->setConstructorArgs([[], [], [], [], ['foo' => ['foobar']]])
+            ->getMock();
 
-        $this->assertEquals('foobar', $this->param->getValue($request, 'bar'));
+        $this->assertEquals(['foobar'], $this->param->getValue($request, 'bar'));
     }
 
     public function testComplexRequirements()

--- a/Tests/Controller/Annotations/QueryParamTest.php
+++ b/Tests/Controller/Annotations/QueryParamTest.php
@@ -14,8 +14,6 @@ namespace FOS\RestBundle\Tests\Controller\Annotations;
 use FOS\RestBundle\Controller\Annotations\AbstractScalarParam;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -47,16 +45,10 @@ class QueryParamTest extends TestCase
             ->method('getKey')
             ->willReturn('foo');
 
-        $request = $this->getMockBuilder(Request::class)->getMock();
-
-        if (class_exists(InputBag::class)) {
-            $bag = new InputBag();
-        } else {
-            $bag = new ParameterBag();
-        }
-
-        $bag->set('foo', 'foobar');
-        $request->query = $bag;
+        $request = $this->getMockBuilder(Request::class)
+            ->onlyMethods([])
+            ->setConstructorArgs([['foo' => 'foobar']])
+            ->getMock();
 
         $this->assertEquals('foobar', $this->param->getValue($request, 'bar'));
     }

--- a/Tests/Controller/Annotations/RequestParamTest.php
+++ b/Tests/Controller/Annotations/RequestParamTest.php
@@ -14,8 +14,6 @@ namespace FOS\RestBundle\Tests\Controller\Annotations;
 use FOS\RestBundle\Controller\Annotations\AbstractScalarParam;
 use FOS\RestBundle\Controller\Annotations\RequestParam;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -47,16 +45,10 @@ class RequestParamTest extends TestCase
             ->method('getKey')
             ->willReturn('foo');
 
-        $request = $this->getMockBuilder(Request::class)->getMock();
-
-        if (class_exists(InputBag::class)) {
-            $bag = new InputBag();
-        } else {
-            $bag = new ParameterBag();
-        }
-
-        $bag->set('foo', 'foobar');
-        $request->request = $bag;
+        $request = $this->getMockBuilder(Request::class)
+            ->onlyMethods([])
+            ->setConstructorArgs([[], ['foo' => 'foobar']])
+            ->getMock();
 
         $this->assertEquals('foobar', $this->param->getValue($request, 'bar'));
     }

--- a/Tests/EventListener/BodyListenerTest.php
+++ b/Tests/EventListener/BodyListenerTest.php
@@ -21,7 +21,6 @@ use FOS\RestBundle\Normalizer\ArrayNormalizerInterface;
 use FOS\RestBundle\Normalizer\Exception\NormalizationException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -64,7 +63,7 @@ class BodyListenerTest extends TestCase
         $request->setMethod($method);
 
         if ($contentType) {
-            $request->headers = new HeaderBag(['Content-Type' => $contentType]);
+            $request->headers->replace(['Content-Type' => $contentType]);
         }
 
         $event = $this->getMockBuilder(RequestEvent::class)


### PR DESCRIPTION
This PR fixes the following deprecations warnings when using this library with Symfony 8.1:

>   Since symfony/http-foundation 8.1: Directly setting property "request" of "Symfony\Component\HttpFoundation\Request" is deprecated; pass the POST data as a constructor argument or call "initialize()" instead.
> Since symfony/http-foundation 8.1: Directly setting property "files" of "Mock_Request_8e3a88e1" is deprecated; pass files as a constructor argument or call "initialize()" instead.
> Since symfony/http-foundation 8.1: Directly setting property "query" of "Mock_Request_8e3a88e1" is deprecated; pass
> Since symfony/http-foundation 8.1: Directly setting property "request" of "Mock_Request_8e3a88e1" is deprecated; pass the POST data as a constructor argument or call "initialize()" instead.

From https://github.com/symfony/symfony/blob/8.1/UPGRADE-8.1.md#httpfoundation:

> Deprecate setting public properties of `Request` and `Response` objects directly; use setters or constructor arguments instead